### PR TITLE
feat(kafka): add built-in transformers to enforce constraints on topics

### DIFF
--- a/jikkou-api/src/main/java/io/streamthoughts/jikkou/JikkouMetadataAnnotations.java
+++ b/jikkou-api/src/main/java/io/streamthoughts/jikkou/JikkouMetadataAnnotations.java
@@ -25,6 +25,7 @@ public final class JikkouMetadataAnnotations {
     public static String JIKKOU_IO_ITEMS_COUNT = "jikkou.io/items-count";
     public static final String JIKKOU_IO_IGNORE = "jikkou.io/ignore";
     public static final String JIKKOU_IO_DELETE = "jikkou.io/delete";
+    public static final String JIKKOU_IO_TRANSFORM_PREFIX = "transform.jikkou.io";
 
     private JikkouMetadataAnnotations() {
     }

--- a/jikkou-api/src/main/java/io/streamthoughts/jikkou/api/model/HasMetadata.java
+++ b/jikkou-api/src/main/java/io/streamthoughts/jikkou/api/model/HasMetadata.java
@@ -109,13 +109,43 @@ public interface HasMetadata extends Resource {
         return Optional.ofNullable(getMetadata());
     }
 
+    /**
+     * Static helper method get a single metadata annotation from the given resource.
+     *
+     * @param resource      the resource.
+     * @param annotationKey the key of the annotation
+     * @return the optional value for the annotation.
+     */
     static Optional<Object> getMetadataAnnotation(@NotNull HasMetadata resource,
-                                                  @NotNull String annotation) {
+                                                  @NotNull String annotationKey) {
         return resource.optionalMetadata()
                 .stream()
-                .map(meta -> meta.getAnnotation(annotation))
+                .map(meta -> meta.getAnnotation(annotationKey))
                 .flatMap(Optional::stream)
                 .findFirst();
+    }
+
+
+    /**
+     * Static helper method to add a single metadata annotation to the given resource.
+     *
+     * @param resource        the resource
+     * @param annotationKey   the key of the annotation to add.
+     * @param annotationValue the value of the annotation to add.
+     * @return a new {@link HasMetadata}.
+     */
+    @NotNull
+    @SuppressWarnings("unchecked")
+    static <T extends HasMetadata> T addMetadataAnnotation(@NotNull T resource,
+                                                           @NotNull String annotationKey,
+                                                           @NotNull Object annotationValue) {
+        ObjectMeta objectMeta = resource.optionalMetadata()
+                .map(ObjectMeta::toBuilder)
+                .or(() -> Optional.of(ObjectMeta.builder()))
+                .map(builder -> builder.withAnnotation(annotationKey, annotationValue))
+                .map(ObjectMeta.ObjectMetaBuilder::build)
+                .get();
+        return (T) resource.withMetadata(objectMeta);
     }
 
     static <T extends HasMetadata> List<T> sortByName(final List<T> resources) {

--- a/jikkou-api/src/main/java/io/streamthoughts/jikkou/api/transform/ResourceTransformation.java
+++ b/jikkou-api/src/main/java/io/streamthoughts/jikkou/api/transform/ResourceTransformation.java
@@ -31,7 +31,7 @@ import org.jetbrains.annotations.NotNull;
  * This interface is used to transform a resource.
  */
 @Evolving
-@ExtensionType("ResourceTransformation")
+@ExtensionType("Transformation")
 public interface ResourceTransformation<T extends HasMetadata> extends ResourceInterceptor {
 
     /**

--- a/jikkou-api/src/main/java/io/streamthoughts/jikkou/api/validation/ResourceValidation.java
+++ b/jikkou-api/src/main/java/io/streamthoughts/jikkou/api/validation/ResourceValidation.java
@@ -37,7 +37,7 @@ import org.jetbrains.annotations.NotNull;
  * @param <T> type of resources accepted by the validation.
  */
 @Evolving
-@ExtensionType("ResourceValidation")
+@ExtensionType("Validation")
 public interface ResourceValidation<T extends HasMetadata> extends ResourceInterceptor {
 
     /**

--- a/jikkou-api/src/test/java/io/streamthoughts/jikkou/api/transform/ResourceTransformationChainTest.java
+++ b/jikkou-api/src/test/java/io/streamthoughts/jikkou/api/transform/ResourceTransformationChainTest.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2023 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.streamthoughts.jikkou.api.transform;
 
 import io.streamthoughts.jikkou.api.TestResource;
@@ -5,14 +23,13 @@ import io.streamthoughts.jikkou.api.model.GenericResourceListObject;
 import io.streamthoughts.jikkou.api.model.HasItems;
 import io.streamthoughts.jikkou.api.model.HasMetadata;
 import io.streamthoughts.jikkou.api.model.ResourceType;
-import org.jetbrains.annotations.NotNull;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 class ResourceTransformationChainTest {
 

--- a/jikkou-extension-kafka/src/main/java/io/streamthoughts/jikkou/kafka/KafkaExtensionProvider.java
+++ b/jikkou-extension-kafka/src/main/java/io/streamthoughts/jikkou/kafka/KafkaExtensionProvider.java
@@ -28,8 +28,14 @@ import io.streamthoughts.jikkou.kafka.control.AdminClientKafkaQuotaController;
 import io.streamthoughts.jikkou.kafka.control.AdminClientKafkaTopicCollector;
 import io.streamthoughts.jikkou.kafka.control.AdminClientKafkaTopicController;
 import io.streamthoughts.jikkou.kafka.health.KafkaBrokerHealthIndicator;
-import io.streamthoughts.jikkou.kafka.transformations.PrincipalAuthorizationTransformation;
-import io.streamthoughts.jikkou.kafka.transformations.TopicConfigMapsTransformation;
+import io.streamthoughts.jikkou.kafka.transformations.KafkaPrincipalAuthorizationTransformation;
+import io.streamthoughts.jikkou.kafka.transformations.KafkaTopicConfigMapsTransformation;
+import io.streamthoughts.jikkou.kafka.transformations.KafkaTopicMaxNumPartitionsTransformation;
+import io.streamthoughts.jikkou.kafka.transformations.KafkaTopicMaxReplicasTransformation;
+import io.streamthoughts.jikkou.kafka.transformations.KafkaTopicMaxRetentionMsTransformation;
+import io.streamthoughts.jikkou.kafka.transformations.KafkaTopicMinInSyncReplicasTransformation;
+import io.streamthoughts.jikkou.kafka.transformations.KafkaTopicMinReplicasTransformation;
+import io.streamthoughts.jikkou.kafka.transformations.KafkaTopicMinRetentionMsTransformation;
 import io.streamthoughts.jikkou.kafka.validations.ClientQuotaValidation;
 import io.streamthoughts.jikkou.kafka.validations.NoDuplicatePrincipalAllowedValidation;
 import io.streamthoughts.jikkou.kafka.validations.NoDuplicatePrincipalRoleValidation;
@@ -70,8 +76,14 @@ public class KafkaExtensionProvider implements ExtensionProvider {
         factory.register(AdminClientKafkaAclCollector.class);
 
         // transformations
-        factory.register(TopicConfigMapsTransformation.class);
-        factory.register(PrincipalAuthorizationTransformation.class);
+        factory.register(KafkaTopicConfigMapsTransformation.class);
+        factory.register(KafkaPrincipalAuthorizationTransformation.class);
+        factory.register(KafkaTopicMaxRetentionMsTransformation.class);
+        factory.register(KafkaTopicMaxReplicasTransformation.class);
+        factory.register(KafkaTopicMaxNumPartitionsTransformation.class);
+        factory.register(KafkaTopicMinRetentionMsTransformation.class);
+        factory.register(KafkaTopicMinReplicasTransformation.class);
+        factory.register(KafkaTopicMinInSyncReplicasTransformation.class);
 
         // validations
         factory.register(ClientQuotaValidation.class);

--- a/jikkou-extension-kafka/src/main/java/io/streamthoughts/jikkou/kafka/transformations/KafkaPrincipalAuthorizationTransformation.java
+++ b/jikkou-extension-kafka/src/main/java/io/streamthoughts/jikkou/kafka/transformations/KafkaPrincipalAuthorizationTransformation.java
@@ -37,13 +37,14 @@ import org.jetbrains.annotations.NotNull;
  */
 @SupportedResource(type = V1KafkaPrincipalAuthorization.class)
 @ExtensionEnabled
-public class PrincipalAuthorizationTransformation implements ResourceTransformation<V1KafkaPrincipalAuthorization> {
+public class KafkaPrincipalAuthorizationTransformation implements ResourceTransformation<V1KafkaPrincipalAuthorization> {
 
     /**
      * {@inheritDoc
      */
     @Override
-    public @NotNull Optional<V1KafkaPrincipalAuthorization> transform(@NotNull V1KafkaPrincipalAuthorization toTransform, @NotNull HasItems items) {
+    public @NotNull Optional<V1KafkaPrincipalAuthorization> transform(@NotNull V1KafkaPrincipalAuthorization toTransform,
+                                                                      @NotNull HasItems items) {
         Set<String> roles = toTransform.getSpec().getRoles();
         if (roles == null || roles.isEmpty()) {
             return Optional.of(toTransform);

--- a/jikkou-extension-kafka/src/main/java/io/streamthoughts/jikkou/kafka/transformations/KafkaTopicConfigMapsTransformation.java
+++ b/jikkou-extension-kafka/src/main/java/io/streamthoughts/jikkou/kafka/transformations/KafkaTopicConfigMapsTransformation.java
@@ -18,10 +18,11 @@
  */
 package io.streamthoughts.jikkou.kafka.transformations;
 
-import io.streamthoughts.jikkou.api.annotations.SupportedResource;
+import io.streamthoughts.jikkou.api.annotations.Priority;
 import io.streamthoughts.jikkou.api.error.InvalidResourceException;
 import io.streamthoughts.jikkou.api.model.Configs;
 import io.streamthoughts.jikkou.api.model.HasItems;
+import io.streamthoughts.jikkou.api.model.HasPriority;
 import io.streamthoughts.jikkou.api.models.ConfigMap;
 import io.streamthoughts.jikkou.api.models.ConfigMapList;
 import io.streamthoughts.jikkou.api.transform.ResourceTransformation;
@@ -34,12 +35,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Transformation to apply all config-maps to topic objects.
+ * This transformation is used to apply all config-maps to topic objects.
+ *
+ * @see ConfigMap
  */
-@SupportedResource(type = V1KafkaTopic.class)
-public class TopicConfigMapsTransformation implements ResourceTransformation<V1KafkaTopic> {
+@Priority(HasPriority.LOWEST_PRECEDENCE)
+public class KafkaTopicConfigMapsTransformation implements ResourceTransformation<V1KafkaTopic> {
 
-    private static final Logger LOG = LoggerFactory.getLogger(TopicConfigMapsTransformation.class);
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaTopicConfigMapsTransformation.class);
 
     /**
      * {@inheritDoc

--- a/jikkou-extension-kafka/src/main/java/io/streamthoughts/jikkou/kafka/transformations/KafkaTopicMaxNumPartitionsTransformation.java
+++ b/jikkou-extension-kafka/src/main/java/io/streamthoughts/jikkou/kafka/transformations/KafkaTopicMaxNumPartitionsTransformation.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2023 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.jikkou.kafka.transformations;
+
+import static io.streamthoughts.jikkou.JikkouMetadataAnnotations.JIKKOU_IO_TRANSFORM_PREFIX;
+
+import io.streamthoughts.jikkou.api.annotations.ExtensionEnabled;
+import io.streamthoughts.jikkou.api.annotations.Priority;
+import io.streamthoughts.jikkou.api.annotations.SupportedResource;
+import io.streamthoughts.jikkou.api.config.ConfigProperty;
+import io.streamthoughts.jikkou.api.config.Configuration;
+import io.streamthoughts.jikkou.api.error.ConfigException;
+import io.streamthoughts.jikkou.api.model.HasItems;
+import io.streamthoughts.jikkou.api.model.HasMetadata;
+import io.streamthoughts.jikkou.api.model.HasPriority;
+import io.streamthoughts.jikkou.api.transform.ResourceTransformation;
+import io.streamthoughts.jikkou.kafka.models.V1KafkaTopic;
+import io.streamthoughts.jikkou.kafka.models.V1KafkaTopicSpec;
+import java.util.Optional;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * This transformation can be used to enforce a maximum number of partitions for a kafka topic.
+ */
+@Priority(HasPriority.HIGHEST_PRECEDENCE)
+@SupportedResource(type = V1KafkaTopic.class)
+@ExtensionEnabled(value = false)
+public class KafkaTopicMaxNumPartitionsTransformation implements ResourceTransformation<V1KafkaTopic> {
+
+    public static final String JIKKOU_IO_KAFKA_MAX_NUM_PARTITION = JIKKOU_IO_TRANSFORM_PREFIX + "/kafka-max-num-partition";
+
+    public static final ConfigProperty<Integer> MAX_NUM_PARTITIONS_CONFIG = ConfigProperty
+            .ofInt("maxNumPartitions");
+
+    private Integer maxNumPartitions;
+
+    /**
+     * {@inheritDoc}
+     **/
+    @Override
+    public void configure(@NotNull Configuration config) throws ConfigException {
+        maxNumPartitions = MAX_NUM_PARTITIONS_CONFIG.getOptional(config)
+                .orElseThrow(() -> new ConfigException(
+                        String.format("The '%s' configuration property is required for transformation class: %s",
+                                MAX_NUM_PARTITIONS_CONFIG.key(),
+                                KafkaTopicMaxNumPartitionsTransformation.class.getName()
+                        )
+                ));
+    }
+
+    /**
+     * {@inheritDoc}
+     **/
+    @Override
+    public @NotNull Optional<V1KafkaTopic> transform(@NotNull V1KafkaTopic resource,
+                                                     @NotNull HasItems resources) {
+        V1KafkaTopicSpec spec = resource.getSpec();
+        Integer partitions = spec.getPartitions();
+        if (partitions != null && partitions > maxNumPartitions) {
+            V1KafkaTopicSpec newSpec = spec.withPartitions(maxNumPartitions);
+            resource = HasMetadata.addMetadataAnnotation(resource, JIKKOU_IO_KAFKA_MAX_NUM_PARTITION, maxNumPartitions);
+            return Optional.of(resource.withSpec(newSpec));
+        }
+        return Optional.of(resource);
+    }
+}

--- a/jikkou-extension-kafka/src/main/java/io/streamthoughts/jikkou/kafka/transformations/KafkaTopicMaxReplicasTransformation.java
+++ b/jikkou-extension-kafka/src/main/java/io/streamthoughts/jikkou/kafka/transformations/KafkaTopicMaxReplicasTransformation.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2023 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.jikkou.kafka.transformations;
+
+import static io.streamthoughts.jikkou.JikkouMetadataAnnotations.JIKKOU_IO_TRANSFORM_PREFIX;
+
+import io.streamthoughts.jikkou.api.annotations.ExtensionEnabled;
+import io.streamthoughts.jikkou.api.annotations.Priority;
+import io.streamthoughts.jikkou.api.annotations.SupportedResource;
+import io.streamthoughts.jikkou.api.config.ConfigProperty;
+import io.streamthoughts.jikkou.api.config.Configuration;
+import io.streamthoughts.jikkou.api.error.ConfigException;
+import io.streamthoughts.jikkou.api.model.HasItems;
+import io.streamthoughts.jikkou.api.model.HasMetadata;
+import io.streamthoughts.jikkou.api.model.HasPriority;
+import io.streamthoughts.jikkou.api.transform.ResourceTransformation;
+import io.streamthoughts.jikkou.kafka.models.V1KafkaTopic;
+import io.streamthoughts.jikkou.kafka.models.V1KafkaTopicSpec;
+import java.util.Optional;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * This transformation can be used to enforce a minimum number of replicas for a kafka topic.
+ */
+@Priority(HasPriority.HIGHEST_PRECEDENCE)
+@SupportedResource(type = V1KafkaTopic.class)
+@ExtensionEnabled(value = false)
+public class KafkaTopicMaxReplicasTransformation implements ResourceTransformation<V1KafkaTopic> {
+
+    public static final String JIKKOU_IO_KAFKA_MAX_REPLICAS = JIKKOU_IO_TRANSFORM_PREFIX +  "/kafka-max-replicas";
+
+    public static final ConfigProperty<Integer> MAX_REPLICATION_FACTOR_CONFIG = ConfigProperty
+            .ofInt("maxReplicationFactor");
+
+    private short maxReplicationFactor;
+
+    /**
+     * {@inheritDoc}
+     **/
+    @Override
+    public void configure(@NotNull Configuration config) throws ConfigException {
+        maxReplicationFactor = MAX_REPLICATION_FACTOR_CONFIG.getOptional(config)
+                .orElseThrow(() -> new ConfigException(
+                        String.format("The '%s' configuration property is required for transformation class: %s",
+                                MAX_REPLICATION_FACTOR_CONFIG.key(),
+                                KafkaTopicMaxReplicasTransformation.class.getName()
+                        )
+                )).shortValue();
+    }
+
+    /**
+     * {@inheritDoc}
+     **/
+    @Override
+    public @NotNull Optional<V1KafkaTopic> transform(@NotNull V1KafkaTopic resource,
+                                                     @NotNull HasItems resources) {
+        V1KafkaTopicSpec spec = resource.getSpec();
+        Short replicas = spec.getReplicas();
+        if (isGreaterThanMaxReplicas(replicas)) {
+            resource = HasMetadata.addMetadataAnnotation(resource,
+                    JIKKOU_IO_KAFKA_MAX_REPLICAS,
+                    maxReplicationFactor
+            );
+            V1KafkaTopicSpec newSpec = spec.withReplicas(maxReplicationFactor);
+            return Optional.of(resource.withSpec(newSpec));
+        }
+        return Optional.of(resource);
+    }
+
+    private boolean isGreaterThanMaxReplicas(Short replicas) {
+        return replicas != null && replicas > maxReplicationFactor;
+    }
+}

--- a/jikkou-extension-kafka/src/main/java/io/streamthoughts/jikkou/kafka/transformations/KafkaTopicMaxRetentionMsTransformation.java
+++ b/jikkou-extension-kafka/src/main/java/io/streamthoughts/jikkou/kafka/transformations/KafkaTopicMaxRetentionMsTransformation.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2023 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.jikkou.kafka.transformations;
+
+import static io.streamthoughts.jikkou.JikkouMetadataAnnotations.JIKKOU_IO_TRANSFORM_PREFIX;
+
+import io.streamthoughts.jikkou.api.annotations.ExtensionEnabled;
+import io.streamthoughts.jikkou.api.annotations.Priority;
+import io.streamthoughts.jikkou.api.annotations.SupportedResource;
+import io.streamthoughts.jikkou.api.config.ConfigProperty;
+import io.streamthoughts.jikkou.api.config.Configuration;
+import io.streamthoughts.jikkou.api.error.ConfigException;
+import io.streamthoughts.jikkou.api.model.ConfigValue;
+import io.streamthoughts.jikkou.api.model.Configs;
+import io.streamthoughts.jikkou.api.model.HasItems;
+import io.streamthoughts.jikkou.api.model.HasMetadata;
+import io.streamthoughts.jikkou.api.model.HasPriority;
+import io.streamthoughts.jikkou.api.transform.ResourceTransformation;
+import io.streamthoughts.jikkou.kafka.models.V1KafkaTopic;
+import io.streamthoughts.jikkou.kafka.models.V1KafkaTopicSpec;
+import java.util.Optional;
+import java.util.function.Predicate;
+import org.apache.kafka.common.config.TopicConfig;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * This transformation can be used to enforce a maximum number of replicas for a kafka topic.
+ */
+@Priority(HasPriority.HIGHEST_PRECEDENCE)
+@SupportedResource(type = V1KafkaTopic.class)
+@ExtensionEnabled(value = false)
+public class KafkaTopicMaxRetentionMsTransformation implements ResourceTransformation<V1KafkaTopic> {
+
+    public static final String JIKKOU_IO_KAFKA_MAX_RETENTION_MS = JIKKOU_IO_TRANSFORM_PREFIX + "/kafka-max-retention-ms";
+
+    public static final ConfigProperty<Long> MAX_RETENTIONS_MS_CONFIG = ConfigProperty
+            .ofLong("maxRetentionMs");
+
+    private Long maxRetentionMs;
+
+    /**
+     * {@inheritDoc}
+     **/
+    @Override
+    public void configure(@NotNull Configuration config) throws ConfigException {
+        maxRetentionMs = MAX_RETENTIONS_MS_CONFIG.getOptional(config)
+                .orElseThrow(() -> new ConfigException(
+                        String.format("The '%s' configuration property is required for transformation class: %s",
+                                MAX_RETENTIONS_MS_CONFIG.key(),
+                                KafkaTopicMaxRetentionMsTransformation.class.getName()
+                        )
+                ));
+    }
+
+    /**
+     * {@inheritDoc}
+     **/
+    @Override
+    public @NotNull Optional<V1KafkaTopic> transform(@NotNull V1KafkaTopic resource,
+                                                     @NotNull HasItems resources) {
+        Optional<Long> retentionMs = getCurrentRetentionMs(resource);
+        if (retentionMs.isEmpty() || retentionMs.get() > maxRetentionMs) {
+            return enforceConstraint(resource);
+        }
+        return Optional.of(resource);
+    }
+
+    private Optional<Long> getCurrentRetentionMs(V1KafkaTopic resource) {
+        V1KafkaTopicSpec spec = resource.getSpec();
+        return Optional.ofNullable(spec.getConfigs())
+                .filter(Predicate.not(Configs::isEmpty))
+                .flatMap(it -> Optional.ofNullable(it.get(TopicConfig.RETENTION_MS_CONFIG)))
+                .flatMap(it -> Optional.ofNullable(it.value()))
+                .map(it -> Long.parseLong(it.toString()));
+    }
+
+
+    @NotNull
+    private Optional<V1KafkaTopic> enforceConstraint(@NotNull V1KafkaTopic resource) {
+        V1KafkaTopicSpec spec = resource.getSpec();
+        Configs configs = Optional.ofNullable(spec.getConfigs()).orElse(Configs.empty());
+        configs.add(new ConfigValue(TopicConfig.RETENTION_MS_CONFIG, maxRetentionMs));
+        resource = HasMetadata.addMetadataAnnotation(resource,
+                JIKKOU_IO_KAFKA_MAX_RETENTION_MS,
+                maxRetentionMs
+        );
+        return Optional.of(resource.withSpec(spec.withConfigs(configs)));
+    }
+}

--- a/jikkou-extension-kafka/src/main/java/io/streamthoughts/jikkou/kafka/transformations/KafkaTopicMinInSyncReplicasTransformation.java
+++ b/jikkou-extension-kafka/src/main/java/io/streamthoughts/jikkou/kafka/transformations/KafkaTopicMinInSyncReplicasTransformation.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2023 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.jikkou.kafka.transformations;
+
+import static io.streamthoughts.jikkou.JikkouMetadataAnnotations.JIKKOU_IO_TRANSFORM_PREFIX;
+
+import io.streamthoughts.jikkou.api.annotations.ExtensionEnabled;
+import io.streamthoughts.jikkou.api.annotations.Priority;
+import io.streamthoughts.jikkou.api.annotations.SupportedResource;
+import io.streamthoughts.jikkou.api.config.ConfigProperty;
+import io.streamthoughts.jikkou.api.config.Configuration;
+import io.streamthoughts.jikkou.api.error.ConfigException;
+import io.streamthoughts.jikkou.api.model.ConfigValue;
+import io.streamthoughts.jikkou.api.model.Configs;
+import io.streamthoughts.jikkou.api.model.HasItems;
+import io.streamthoughts.jikkou.api.model.HasMetadata;
+import io.streamthoughts.jikkou.api.model.HasPriority;
+import io.streamthoughts.jikkou.api.transform.ResourceTransformation;
+import io.streamthoughts.jikkou.kafka.models.V1KafkaTopic;
+import io.streamthoughts.jikkou.kafka.models.V1KafkaTopicSpec;
+import java.util.Optional;
+import java.util.function.Predicate;
+import org.apache.kafka.common.config.TopicConfig;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * This transformation can be used to enforce a {@code min.insync.replicas} for a kafka topic.
+ */
+@Priority(HasPriority.HIGHEST_PRECEDENCE)
+@SupportedResource(type = V1KafkaTopic.class)
+@ExtensionEnabled(value = false)
+public class KafkaTopicMinInSyncReplicasTransformation implements ResourceTransformation<V1KafkaTopic> {
+
+    public static final String JIKKOU_IO_KAFKA_MIN_INSYNC_REPLICAS = JIKKOU_IO_TRANSFORM_PREFIX + "/kafka-min-sync-replicas";
+
+    public static final ConfigProperty<Integer> MIN_INSYNC_REPLICAS_CONFIG = ConfigProperty
+            .ofInt("minInSyncReplicas");
+
+    private int minInSyncReplicas;
+
+    /**
+     * {@inheritDoc}
+     **/
+    @Override
+    public void configure(@NotNull Configuration config) throws ConfigException {
+        minInSyncReplicas = MIN_INSYNC_REPLICAS_CONFIG.getOptional(config)
+                .orElseThrow(() -> new ConfigException(
+                        String.format("The '%s' configuration property is required for transformation class: %s",
+                                MIN_INSYNC_REPLICAS_CONFIG.key(),
+                                KafkaTopicMinInSyncReplicasTransformation.class.getName()
+                        )
+                ));
+    }
+
+    /**
+     * {@inheritDoc}
+     **/
+    @Override
+    public @NotNull Optional<V1KafkaTopic> transform(@NotNull V1KafkaTopic resource,
+                                                     @NotNull HasItems resources) {
+        Optional<Integer> inSyncReplicas = getCurrentMinInSyncReplicas(resource);
+        if (inSyncReplicas.isEmpty() || inSyncReplicas.get() < minInSyncReplicas) {
+            return enforceConstraint(resource);
+        }
+        return Optional.of(resource);
+    }
+
+    private Optional<Integer> getCurrentMinInSyncReplicas(V1KafkaTopic resource) {
+        V1KafkaTopicSpec spec = resource.getSpec();
+        return Optional.ofNullable(spec.getConfigs())
+                .filter(Predicate.not(Configs::isEmpty))
+                .flatMap(it -> Optional.ofNullable(it.get(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG)))
+                .flatMap(it -> Optional.ofNullable(it.value()))
+                .map(it -> Integer.parseInt(it.toString()));
+    }
+
+    @NotNull
+    private Optional<V1KafkaTopic> enforceConstraint(@NotNull V1KafkaTopic resource) {
+        V1KafkaTopicSpec spec = resource.getSpec();
+        Configs configs = Optional.ofNullable(spec.getConfigs()).orElse(Configs.empty());
+        configs.add(new ConfigValue(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, this.minInSyncReplicas));
+        resource = HasMetadata.addMetadataAnnotation(resource,
+                JIKKOU_IO_KAFKA_MIN_INSYNC_REPLICAS,
+                this.minInSyncReplicas
+        );
+        return Optional.of(resource.withSpec(spec.withConfigs(configs)));
+    }
+}

--- a/jikkou-extension-kafka/src/main/java/io/streamthoughts/jikkou/kafka/transformations/KafkaTopicMinReplicasTransformation.java
+++ b/jikkou-extension-kafka/src/main/java/io/streamthoughts/jikkou/kafka/transformations/KafkaTopicMinReplicasTransformation.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2023 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.jikkou.kafka.transformations;
+
+import static io.streamthoughts.jikkou.JikkouMetadataAnnotations.JIKKOU_IO_TRANSFORM_PREFIX;
+import static io.streamthoughts.jikkou.kafka.internals.KafkaTopics.NO_REPLICATION_FACTOR;
+
+import io.streamthoughts.jikkou.api.annotations.ExtensionEnabled;
+import io.streamthoughts.jikkou.api.annotations.Priority;
+import io.streamthoughts.jikkou.api.annotations.SupportedResource;
+import io.streamthoughts.jikkou.api.config.ConfigProperty;
+import io.streamthoughts.jikkou.api.config.Configuration;
+import io.streamthoughts.jikkou.api.error.ConfigException;
+import io.streamthoughts.jikkou.api.model.HasItems;
+import io.streamthoughts.jikkou.api.model.HasMetadata;
+import io.streamthoughts.jikkou.api.model.HasPriority;
+import io.streamthoughts.jikkou.api.transform.ResourceTransformation;
+import io.streamthoughts.jikkou.kafka.models.V1KafkaTopic;
+import io.streamthoughts.jikkou.kafka.models.V1KafkaTopicSpec;
+import java.util.Optional;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * This transformation can be used to enforce a minimum number of replicas for a kafka topic.
+ */
+@Priority(HasPriority.HIGHEST_PRECEDENCE)
+@SupportedResource(type = V1KafkaTopic.class)
+@ExtensionEnabled(value = false)
+public class KafkaTopicMinReplicasTransformation implements ResourceTransformation<V1KafkaTopic> {
+
+    public static final String JIKKOU_IO_KAFKA_MIN_REPLICAS = JIKKOU_IO_TRANSFORM_PREFIX + "/kafka-min-replicas";
+
+    public static final ConfigProperty<Integer> MIN_REPLICATION_FACTOR_CONFIG = ConfigProperty
+            .ofInt("minReplicationFactor");
+
+    private short minReplicationFactor;
+
+    /**
+     * {@inheritDoc}
+     **/
+    @Override
+    public void configure(@NotNull Configuration config) throws ConfigException {
+        minReplicationFactor = MIN_REPLICATION_FACTOR_CONFIG.getOptional(config)
+                .orElseThrow(() -> new ConfigException(
+                        String.format("The '%s' configuration property is required for transformation class: %s",
+                                MIN_REPLICATION_FACTOR_CONFIG.key(),
+                                KafkaTopicMinReplicasTransformation.class.getName()
+                        )
+                )).shortValue();
+    }
+
+    /**
+     * {@inheritDoc}
+     **/
+    @Override
+    public @NotNull Optional<V1KafkaTopic> transform(@NotNull V1KafkaTopic resource,
+                                                     @NotNull HasItems resources) {
+        V1KafkaTopicSpec spec = resource.getSpec();
+        Short replicas = spec.getReplicas();
+        if (isLessThanMinReplicas(replicas)) {
+            V1KafkaTopicSpec newSpec = spec.withReplicas(minReplicationFactor);
+            resource = HasMetadata.addMetadataAnnotation(resource,
+                    JIKKOU_IO_KAFKA_MIN_REPLICAS,
+                    minReplicationFactor
+            );
+            return Optional.of(resource.withSpec(newSpec));
+        }
+        return Optional.of(resource);
+    }
+
+    private boolean isLessThanMinReplicas(@Nullable Short replicas) {
+        return replicas != null && !replicas.equals(NO_REPLICATION_FACTOR) && replicas < minReplicationFactor;
+    }
+}

--- a/jikkou-extension-kafka/src/main/java/io/streamthoughts/jikkou/kafka/transformations/KafkaTopicMinRetentionMsTransformation.java
+++ b/jikkou-extension-kafka/src/main/java/io/streamthoughts/jikkou/kafka/transformations/KafkaTopicMinRetentionMsTransformation.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2023 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.jikkou.kafka.transformations;
+
+import static io.streamthoughts.jikkou.JikkouMetadataAnnotations.JIKKOU_IO_TRANSFORM_PREFIX;
+
+import io.streamthoughts.jikkou.api.annotations.ExtensionEnabled;
+import io.streamthoughts.jikkou.api.annotations.Priority;
+import io.streamthoughts.jikkou.api.annotations.SupportedResource;
+import io.streamthoughts.jikkou.api.config.ConfigProperty;
+import io.streamthoughts.jikkou.api.config.Configuration;
+import io.streamthoughts.jikkou.api.error.ConfigException;
+import io.streamthoughts.jikkou.api.model.ConfigValue;
+import io.streamthoughts.jikkou.api.model.Configs;
+import io.streamthoughts.jikkou.api.model.HasItems;
+import io.streamthoughts.jikkou.api.model.HasMetadata;
+import io.streamthoughts.jikkou.api.model.HasPriority;
+import io.streamthoughts.jikkou.api.transform.ResourceTransformation;
+import io.streamthoughts.jikkou.kafka.models.V1KafkaTopic;
+import io.streamthoughts.jikkou.kafka.models.V1KafkaTopicSpec;
+import java.util.Optional;
+import java.util.function.Predicate;
+import org.apache.kafka.common.config.TopicConfig;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * This transformation can be used to enforce a minimum number of replicas for a kafka topic.
+ */
+@Priority(HasPriority.HIGHEST_PRECEDENCE)
+@SupportedResource(type = V1KafkaTopic.class)
+@ExtensionEnabled(value = false)
+public class KafkaTopicMinRetentionMsTransformation implements ResourceTransformation<V1KafkaTopic> {
+
+    public static final String JIKKOU_IO_KAFKA_MIN_RETENTION_MS = JIKKOU_IO_TRANSFORM_PREFIX + "/kafka-min-retention-ms";
+
+    public static final ConfigProperty<Long> MIN_RETENTIONS_MS_CONFIG = ConfigProperty
+            .ofLong("minRetentionMs");
+
+    private Long minRetentionMs;
+
+    /**
+     * {@inheritDoc}
+     **/
+    @Override
+    public void configure(@NotNull Configuration config) throws ConfigException {
+        minRetentionMs = MIN_RETENTIONS_MS_CONFIG.getOptional(config)
+                .orElseThrow(() -> new ConfigException(
+                        String.format("The '%s' configuration property is required for transformation class: %s",
+                                MIN_RETENTIONS_MS_CONFIG.key(),
+                                KafkaTopicMinRetentionMsTransformation.class.getName()
+                        )
+                ));
+    }
+
+    /**
+     * {@inheritDoc}
+     **/
+    @Override
+    public @NotNull Optional<V1KafkaTopic> transform(@NotNull V1KafkaTopic resource,
+                                                     @NotNull HasItems resources) {
+        Optional<Long> retentionMs = getCurrentRetentionMs(resource);
+        if (retentionMs.isEmpty() || retentionMs.get() < minRetentionMs) {
+            return enforceConstraint(resource);
+        }
+        return Optional.of(resource);
+    }
+
+    private Optional<Long> getCurrentRetentionMs(V1KafkaTopic resource) {
+        V1KafkaTopicSpec spec = resource.getSpec();
+        return Optional.ofNullable(spec.getConfigs())
+                .filter(Predicate.not(Configs::isEmpty))
+                .flatMap(it -> Optional.ofNullable(it.get(TopicConfig.RETENTION_MS_CONFIG)))
+                .flatMap(it -> Optional.ofNullable(it.value()))
+                .map(it -> Long.parseLong(it.toString()));
+    }
+
+    @NotNull
+    private Optional<V1KafkaTopic> enforceConstraint(@NotNull V1KafkaTopic resource) {
+        V1KafkaTopicSpec spec = resource.getSpec();
+        Configs configs = Optional.ofNullable(spec.getConfigs()).orElse(Configs.empty());
+        configs.add(new ConfigValue(TopicConfig.RETENTION_MS_CONFIG, minRetentionMs));
+        resource = HasMetadata.addMetadataAnnotation(resource,
+                JIKKOU_IO_KAFKA_MIN_RETENTION_MS,
+                minRetentionMs
+        );
+        return Optional.of(resource.withSpec(spec.withConfigs(configs)));
+    }
+}

--- a/jikkou-extension-kafka/src/main/java/io/streamthoughts/jikkou/kafka/validations/TopicMinNumPartitionsValidation.java
+++ b/jikkou-extension-kafka/src/main/java/io/streamthoughts/jikkou/kafka/validations/TopicMinNumPartitionsValidation.java
@@ -31,7 +31,6 @@ import org.jetbrains.annotations.NotNull;
 @ExtensionEnabled(value = false)
 public class TopicMinNumPartitionsValidation extends TopicValidation {
 
-
     public static final ConfigProperty<Integer> VALIDATION_TOPIC_MIN_NUM_PARTITIONS_CONFIG = ConfigProperty
             .ofInt("topic-min-num-partitions");
 

--- a/jikkou-extension-kafka/src/test/java/io/streamthoughts/jikkou/kafka/transformations/KafkaKafkaTopicConfigMapsTransformationTest.java
+++ b/jikkou-extension-kafka/src/test/java/io/streamthoughts/jikkou/kafka/transformations/KafkaKafkaTopicConfigMapsTransformationTest.java
@@ -29,7 +29,7 @@ import java.util.Set;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-class ApplyConfigMapsTransformationTest {
+class KafkaKafkaTopicConfigMapsTransformationTest {
 
     static final String TEST_CONFIG_MAP_NAME = "configMap";
     static final String TEST_TOPIC = "topic";
@@ -64,7 +64,7 @@ class ApplyConfigMapsTransformationTest {
                 .build();
 
         // When
-        var result = (V1KafkaTopic) new TopicConfigMapsTransformation()
+        var result = (V1KafkaTopic) new KafkaTopicConfigMapsTransformation()
                 .transform(resource, new GenericResourceListObject(List.of(TEST_CONFIG_MAP)))
                 .get();
 
@@ -93,7 +93,7 @@ class ApplyConfigMapsTransformationTest {
                 .build();
 
         // When
-        var result = (V1KafkaTopic) new TopicConfigMapsTransformation()
+        var result = (V1KafkaTopic) new KafkaTopicConfigMapsTransformation()
                 .transform(resource, new GenericResourceListObject(List.of(TEST_CONFIG_MAP)))
                 .get();
 
@@ -124,7 +124,7 @@ class ApplyConfigMapsTransformationTest {
                 .build();
 
         // When
-        var result = (V1KafkaTopic) new TopicConfigMapsTransformation()
+        var result = (V1KafkaTopic) new KafkaTopicConfigMapsTransformation()
                 .transform(resource, new GenericResourceListObject(List.of(TEST_CONFIG_MAP)))
                 .get();
 

--- a/jikkou-extension-kafka/src/test/java/io/streamthoughts/jikkou/kafka/transformations/KafkaTopicMaxNumPartitionsTransformationTest.java
+++ b/jikkou-extension-kafka/src/test/java/io/streamthoughts/jikkou/kafka/transformations/KafkaTopicMaxNumPartitionsTransformationTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2023 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.jikkou.kafka.transformations;
+
+import static io.streamthoughts.jikkou.kafka.transformations.KafkaTopicMaxNumPartitionsTransformation.MAX_NUM_PARTITIONS_CONFIG;
+
+import io.streamthoughts.jikkou.api.model.GenericResourceListObject;
+import io.streamthoughts.jikkou.kafka.models.V1KafkaTopic;
+import io.streamthoughts.jikkou.kafka.models.V1KafkaTopicSpec;
+import java.util.Collections;
+import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class KafkaTopicMaxNumPartitionsTransformationTest {
+
+    @Test
+    void shouldEnforceConstraintForInvalidValue() {
+        // Given
+        KafkaTopicMaxNumPartitionsTransformation transformation = new KafkaTopicMaxNumPartitionsTransformation();
+        transformation.configure(MAX_NUM_PARTITIONS_CONFIG.asConfiguration(10));
+        V1KafkaTopic resource = V1KafkaTopic.builder()
+                .withSpec(V1KafkaTopicSpec
+                        .builder()
+                        .withPartitions(100)
+                        .build())
+                .build();
+        // When
+        Optional<V1KafkaTopic> result = transformation
+                .transform(resource, GenericResourceListObject.of(Collections.emptyList()));
+
+        // Then
+        Assertions.assertNotNull(result);
+        Assertions.assertTrue(result.isPresent());
+
+        V1KafkaTopic transformed = result.get();
+        Assertions.assertEquals(10, transformed.getSpec().getPartitions());
+    }
+
+    @Test
+    void shouldNotEnforceConstraintForValidValue() {
+        // Given
+        KafkaTopicMaxNumPartitionsTransformation transformation = new KafkaTopicMaxNumPartitionsTransformation();
+        transformation.configure(MAX_NUM_PARTITIONS_CONFIG.asConfiguration(10));
+        V1KafkaTopic resource = V1KafkaTopic.builder()
+                .withSpec(V1KafkaTopicSpec
+                        .builder()
+                        .withPartitions(4)
+                        .build())
+                .build();
+        // When
+        Optional<V1KafkaTopic> result = transformation
+                .transform(resource, GenericResourceListObject.of(Collections.emptyList()));
+
+        // Then
+        Assertions.assertNotNull(result);
+        Assertions.assertTrue(result.isPresent());
+
+        V1KafkaTopic transformed = result.get();
+        Assertions.assertEquals(4, transformed.getSpec().getPartitions());
+    }
+}

--- a/jikkou-extension-kafka/src/test/java/io/streamthoughts/jikkou/kafka/transformations/KafkaTopicMaxReplicasTransformationTest.java
+++ b/jikkou-extension-kafka/src/test/java/io/streamthoughts/jikkou/kafka/transformations/KafkaTopicMaxReplicasTransformationTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2023 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.jikkou.kafka.transformations;
+
+import io.streamthoughts.jikkou.api.model.GenericResourceListObject;
+import io.streamthoughts.jikkou.kafka.models.V1KafkaTopic;
+import io.streamthoughts.jikkou.kafka.models.V1KafkaTopicSpec;
+import java.util.Collections;
+import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class KafkaTopicMaxReplicasTransformationTest {
+
+    @Test
+    void shouldEnforceConstraintForInvalidValue() {
+        // Given
+        KafkaTopicMaxReplicasTransformation transformation = new KafkaTopicMaxReplicasTransformation();
+        transformation.configure(KafkaTopicMaxReplicasTransformation.MAX_REPLICATION_FACTOR_CONFIG.asConfiguration(3));
+        V1KafkaTopic resource = V1KafkaTopic.builder()
+                .withSpec(V1KafkaTopicSpec
+                        .builder()
+                        .withReplicas((short)6)
+                        .build())
+                .build();
+        // When
+        Optional<V1KafkaTopic> result = transformation
+                .transform(resource, GenericResourceListObject.of(Collections.emptyList()));
+
+        // Then
+        Assertions.assertNotNull(result);
+        Assertions.assertTrue(result.isPresent());
+
+        V1KafkaTopic transformed = result.get();
+        Assertions.assertEquals((short)3, transformed.getSpec().getReplicas());
+    }
+
+    @Test
+    void shouldNotEnforceConstraintForValidValue() {
+        // Given
+        KafkaTopicMaxReplicasTransformation transformation = new KafkaTopicMaxReplicasTransformation();
+        transformation.configure(KafkaTopicMaxReplicasTransformation.MAX_REPLICATION_FACTOR_CONFIG.asConfiguration(3));
+        V1KafkaTopic resource = V1KafkaTopic.builder()
+                .withSpec(V1KafkaTopicSpec
+                        .builder()
+                        .withReplicas((short)2)
+                        .build())
+                .build();
+        // When
+        Optional<V1KafkaTopic> result = transformation
+                .transform(resource, GenericResourceListObject.of(Collections.emptyList()));
+
+        // Then
+        Assertions.assertNotNull(result);
+        Assertions.assertTrue(result.isPresent());
+
+        V1KafkaTopic transformed = result.get();
+        Assertions.assertEquals((short)2, transformed.getSpec().getReplicas());
+    }
+
+}

--- a/jikkou-extension-kafka/src/test/java/io/streamthoughts/jikkou/kafka/transformations/KafkaTopicMaxRetentionMsTransformationTest.java
+++ b/jikkou-extension-kafka/src/test/java/io/streamthoughts/jikkou/kafka/transformations/KafkaTopicMaxRetentionMsTransformationTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2023 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.jikkou.kafka.transformations;
+
+import io.streamthoughts.jikkou.api.model.Configs;
+import io.streamthoughts.jikkou.api.model.GenericResourceListObject;
+import io.streamthoughts.jikkou.kafka.models.V1KafkaTopic;
+import io.streamthoughts.jikkou.kafka.models.V1KafkaTopicSpec;
+import java.util.Collections;
+import java.util.Optional;
+import org.apache.kafka.common.config.TopicConfig;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class KafkaTopicMaxRetentionMsTransformationTest {
+
+    public static final long MAX_VALUE = 1000;
+
+    @Test
+    void shouldEnforceConstraintForInvalidValue() {
+        // Given
+        KafkaTopicMaxRetentionMsTransformation transformation = new KafkaTopicMaxRetentionMsTransformation();
+        transformation.configure(KafkaTopicMaxRetentionMsTransformation.MAX_RETENTIONS_MS_CONFIG.asConfiguration(MAX_VALUE));
+        V1KafkaTopic resource = V1KafkaTopic.builder()
+                .withSpec(V1KafkaTopicSpec
+                        .builder()
+                        .withConfigs(Configs.of(TopicConfig.RETENTION_MS_CONFIG, 5000L))
+                        .build())
+                .build();
+        // When
+        Optional<V1KafkaTopic> result = transformation
+                .transform(resource, GenericResourceListObject.of(Collections.emptyList()));
+
+        // Then
+        Assertions.assertNotNull(result);
+        Assertions.assertTrue(result.isPresent());
+
+        V1KafkaTopic transformed = result.get();
+        Assertions.assertEquals(
+                MAX_VALUE,
+                transformed.getSpec().getConfigs().get(TopicConfig.RETENTION_MS_CONFIG).value()
+        );
+    }
+
+    @Test
+    void shouldEnforceConstraintForMissingValue() {
+        // Given
+        KafkaTopicMaxRetentionMsTransformation transformation = new KafkaTopicMaxRetentionMsTransformation();
+        transformation.configure(KafkaTopicMaxRetentionMsTransformation.MAX_RETENTIONS_MS_CONFIG.asConfiguration(MAX_VALUE));
+        V1KafkaTopic resource = V1KafkaTopic.builder()
+                .withSpec(V1KafkaTopicSpec
+                        .builder()
+                        .build())
+                .build();
+        // When
+        Optional<V1KafkaTopic> result = transformation
+                .transform(resource, GenericResourceListObject.of(Collections.emptyList()));
+
+        // Then
+        Assertions.assertNotNull(result);
+        Assertions.assertTrue(result.isPresent());
+
+        V1KafkaTopic transformed = result.get();
+        Assertions.assertEquals(
+                MAX_VALUE,
+                transformed.getSpec().getConfigs().get(TopicConfig.RETENTION_MS_CONFIG).value()
+        );
+    }
+
+    @Test
+    void shouldNotEnforceConstraintForValidValue() {
+        // Given
+        KafkaTopicMaxRetentionMsTransformation transformation = new KafkaTopicMaxRetentionMsTransformation();
+        transformation.configure(KafkaTopicMaxRetentionMsTransformation.MAX_RETENTIONS_MS_CONFIG.asConfiguration(MAX_VALUE));
+        V1KafkaTopic resource = V1KafkaTopic.builder()
+                .withSpec(V1KafkaTopicSpec
+                        .builder()
+                        .withConfigs(Configs.of(TopicConfig.RETENTION_MS_CONFIG, -1L))
+                        .build())
+                .build();
+        // When
+        Optional<V1KafkaTopic> result = transformation
+                .transform(resource, GenericResourceListObject.of(Collections.emptyList()));
+
+        // Then
+        Assertions.assertNotNull(result);
+        Assertions.assertTrue(result.isPresent());
+
+        V1KafkaTopic transformed = result.get();
+        Assertions.assertEquals(
+                -1L,
+                transformed.getSpec().getConfigs().get(TopicConfig.RETENTION_MS_CONFIG).value()
+        );
+    }
+}

--- a/jikkou-extension-kafka/src/test/java/io/streamthoughts/jikkou/kafka/transformations/KafkaTopicMinInSyncReplicasTransformationTest.java
+++ b/jikkou-extension-kafka/src/test/java/io/streamthoughts/jikkou/kafka/transformations/KafkaTopicMinInSyncReplicasTransformationTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2023 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.jikkou.kafka.transformations;
+
+import io.streamthoughts.jikkou.api.config.Configuration;
+import io.streamthoughts.jikkou.api.model.Configs;
+import io.streamthoughts.jikkou.api.model.GenericResourceListObject;
+import io.streamthoughts.jikkou.kafka.models.V1KafkaTopic;
+import io.streamthoughts.jikkou.kafka.models.V1KafkaTopicSpec;
+import java.util.Collections;
+import java.util.Optional;
+import org.apache.kafka.common.config.TopicConfig;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class KafkaTopicMinInSyncReplicasTransformationTest {
+
+    static Configuration CONFIGURATION = KafkaTopicMinInSyncReplicasTransformation.MIN_INSYNC_REPLICAS_CONFIG
+            .asConfiguration(2);
+
+    @Test
+    void shouldEnforceConstraintForInvalidValue() {
+        // Given
+        KafkaTopicMinInSyncReplicasTransformation transformation = new KafkaTopicMinInSyncReplicasTransformation();
+        transformation.configure(CONFIGURATION);
+
+        V1KafkaTopic resource = V1KafkaTopic.builder()
+                .withSpec(V1KafkaTopicSpec
+                        .builder()
+                        .withConfigs(Configs.of(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, 1))
+                        .build())
+                .build();
+        // When
+        Optional<V1KafkaTopic> result = transformation
+                .transform(resource, GenericResourceListObject.of(Collections.emptyList()));
+
+        // Then
+        Assertions.assertNotNull(result);
+        Assertions.assertTrue(result.isPresent());
+
+        V1KafkaTopic transformed = result.get();
+        Assertions.assertEquals(
+                2,
+                transformed.getSpec().getConfigs().get(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG).value()
+        );
+    }
+
+    @Test
+    void shouldEnforceConstraintForMissingValue() {
+        // Given
+        KafkaTopicMinInSyncReplicasTransformation transformation = new KafkaTopicMinInSyncReplicasTransformation();
+        transformation.configure(CONFIGURATION);
+
+        V1KafkaTopic resource = V1KafkaTopic.builder()
+                .withSpec(V1KafkaTopicSpec
+                        .builder()
+                        .build())
+                .build();
+        // When
+        Optional<V1KafkaTopic> result = transformation
+                .transform(resource, GenericResourceListObject.of(Collections.emptyList()));
+
+        // Then
+        Assertions.assertNotNull(result);
+        Assertions.assertTrue(result.isPresent());
+
+        V1KafkaTopic transformed = result.get();
+        Assertions.assertEquals(
+                2,
+                transformed.getSpec().getConfigs().get(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG).value()
+        );
+    }
+
+    @Test
+    void shouldNotEnforceConstraintForValidResource() {
+        // Given
+        KafkaTopicMinInSyncReplicasTransformation transformation = new KafkaTopicMinInSyncReplicasTransformation();
+        transformation.configure(CONFIGURATION);
+
+        V1KafkaTopic resource = V1KafkaTopic.builder()
+                .withSpec(V1KafkaTopicSpec
+                        .builder()
+                        .withConfigs(Configs.of(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, 3))
+                        .build())
+                .build();
+        // When
+        Optional<V1KafkaTopic> result = transformation
+                .transform(resource, GenericResourceListObject.of(Collections.emptyList()));
+
+        // Then
+        Assertions.assertNotNull(result);
+        Assertions.assertTrue(result.isPresent());
+
+        V1KafkaTopic transformed = result.get();
+         Assertions.assertEquals(
+                3,
+                transformed.getSpec().getConfigs().get(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG).value()
+        );
+    }
+}

--- a/jikkou-extension-kafka/src/test/java/io/streamthoughts/jikkou/kafka/transformations/KafkaTopicMinReplicasTransformationTest.java
+++ b/jikkou-extension-kafka/src/test/java/io/streamthoughts/jikkou/kafka/transformations/KafkaTopicMinReplicasTransformationTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2023 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.jikkou.kafka.transformations;
+
+import io.streamthoughts.jikkou.api.model.GenericResourceListObject;
+import io.streamthoughts.jikkou.kafka.models.V1KafkaTopic;
+import io.streamthoughts.jikkou.kafka.models.V1KafkaTopicSpec;
+import java.util.Collections;
+import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class KafkaTopicMinReplicasTransformationTest {
+
+    @Test
+    void shouldNotEnforceConstraintForValidValue() {
+        // Given
+        KafkaTopicMinReplicasTransformation transformation = new KafkaTopicMinReplicasTransformation();
+        transformation.configure(KafkaTopicMinReplicasTransformation.MIN_REPLICATION_FACTOR_CONFIG.asConfiguration(3));
+        V1KafkaTopic resource = V1KafkaTopic.builder()
+                .withSpec(V1KafkaTopicSpec
+                        .builder()
+                        .withReplicas((short) 6)
+                        .build())
+                .build();
+        // When
+        Optional<V1KafkaTopic> result = transformation
+                .transform(resource, GenericResourceListObject.of(Collections.emptyList()));
+
+        // Then
+        Assertions.assertNotNull(result);
+        Assertions.assertTrue(result.isPresent());
+
+        V1KafkaTopic transformed = result.get();
+        Assertions.assertEquals((short) 6, transformed.getSpec().getReplicas());
+    }
+
+    @Test
+    void shouldEnforceConstraintForInvalidValue() {
+        // Given
+        KafkaTopicMinReplicasTransformation transformation = new KafkaTopicMinReplicasTransformation();
+        transformation.configure(KafkaTopicMinReplicasTransformation.MIN_REPLICATION_FACTOR_CONFIG.asConfiguration(3));
+        V1KafkaTopic resource = V1KafkaTopic.builder()
+                .withSpec(V1KafkaTopicSpec
+                        .builder()
+                        .withReplicas((short) 1)
+                        .build())
+                .build();
+        // When
+        Optional<V1KafkaTopic> result = transformation
+                .transform(resource, GenericResourceListObject.of(Collections.emptyList()));
+
+        // Then
+        Assertions.assertNotNull(result);
+        Assertions.assertTrue(result.isPresent());
+
+        V1KafkaTopic transformed = result.get();
+        Assertions.assertEquals((short) 3, transformed.getSpec().getReplicas());
+    }
+
+}

--- a/jikkou-extension-kafka/src/test/java/io/streamthoughts/jikkou/kafka/transformations/KafkaTopicMinRetentionMsTransformationTest.java
+++ b/jikkou-extension-kafka/src/test/java/io/streamthoughts/jikkou/kafka/transformations/KafkaTopicMinRetentionMsTransformationTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2023 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.jikkou.kafka.transformations;
+
+import io.streamthoughts.jikkou.api.model.Configs;
+import io.streamthoughts.jikkou.api.model.GenericResourceListObject;
+import io.streamthoughts.jikkou.kafka.models.V1KafkaTopic;
+import io.streamthoughts.jikkou.kafka.models.V1KafkaTopicSpec;
+import java.util.Collections;
+import java.util.Optional;
+import org.apache.kafka.common.config.TopicConfig;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class KafkaTopicMinRetentionMsTransformationTest {
+
+    public static final long MIN_VALUE = 1000L;
+
+    @Test
+    void shouldEnforceConstraintForInvalidValue() {
+        // Given
+        KafkaTopicMinRetentionMsTransformation transformation = new KafkaTopicMinRetentionMsTransformation();
+        transformation.configure(KafkaTopicMinRetentionMsTransformation.MIN_RETENTIONS_MS_CONFIG.asConfiguration(MIN_VALUE));
+        V1KafkaTopic resource = V1KafkaTopic.builder()
+                .withSpec(V1KafkaTopicSpec
+                        .builder()
+                        .withConfigs(Configs.of(TopicConfig.RETENTION_MS_CONFIG, -1L))
+                        .build())
+                .build();
+        // When
+        Optional<V1KafkaTopic> result = transformation
+                .transform(resource, GenericResourceListObject.of(Collections.emptyList()));
+
+        // Then
+        Assertions.assertNotNull(result);
+        Assertions.assertTrue(result.isPresent());
+
+        V1KafkaTopic transformed = result.get();
+        Assertions.assertEquals(
+                MIN_VALUE,
+                transformed.getSpec().getConfigs().get(TopicConfig.RETENTION_MS_CONFIG).value()
+        );
+    }
+
+    @Test
+    void shouldEnforceConstraintForMissingValue() {
+        // Given
+        KafkaTopicMinRetentionMsTransformation transformation = new KafkaTopicMinRetentionMsTransformation();
+        transformation.configure(KafkaTopicMinRetentionMsTransformation.MIN_RETENTIONS_MS_CONFIG.asConfiguration(MIN_VALUE));
+        V1KafkaTopic resource = V1KafkaTopic.builder()
+                .withSpec(V1KafkaTopicSpec
+                        .builder()
+                        .build())
+                .build();
+        // When
+        Optional<V1KafkaTopic> result = transformation
+                .transform(resource, GenericResourceListObject.of(Collections.emptyList()));
+
+        // Then
+        Assertions.assertNotNull(result);
+        Assertions.assertTrue(result.isPresent());
+
+        V1KafkaTopic transformed = result.get();
+        Assertions.assertEquals(
+                MIN_VALUE,
+                transformed.getSpec().getConfigs().get(TopicConfig.RETENTION_MS_CONFIG).value()
+        );
+    }
+
+    @Test
+    void shouldNotEnforceConstraintForValidValue() {
+        // Given
+        KafkaTopicMinRetentionMsTransformation transformation = new KafkaTopicMinRetentionMsTransformation();
+        transformation.configure(KafkaTopicMinRetentionMsTransformation.MIN_RETENTIONS_MS_CONFIG.asConfiguration(MIN_VALUE));
+        V1KafkaTopic resource = V1KafkaTopic.builder()
+                .withSpec(V1KafkaTopicSpec
+                        .builder()
+                        .withConfigs(Configs.of(TopicConfig.RETENTION_MS_CONFIG, 5000L))
+                        .build())
+                .build();
+        // When
+        Optional<V1KafkaTopic> result = transformation
+                .transform(resource, GenericResourceListObject.of(Collections.emptyList()));
+
+        // Then
+        Assertions.assertNotNull(result);
+        Assertions.assertTrue(result.isPresent());
+
+        V1KafkaTopic transformed = result.get();
+        Assertions.assertEquals(
+            5000L,
+            transformed.getSpec().getConfigs().get(TopicConfig.RETENTION_MS_CONFIG).value()
+        );
+    }
+}


### PR DESCRIPTION
This commits adds the following built-in transformation:
* KafkaTopicMaxNumPartitionsTransformation
* KafkaTopicMaxReplicasTransformation
* KafkaTopicMaxRetentionMsTransformation
* KafkaTopicMinReplicasTransformation
* KafkaTopicMinInSyncReplicasTransformation
* KafkaTopicMinRetentionMsTransformation

Resolves: #184