### PR TITLE
feat(core): add annotation to bypass validation

### DIFF
--- a/jikkou-api/src/main/java/io/streamthoughts/jikkou/JikkouMetadataAnnotations.java
+++ b/jikkou-api/src/main/java/io/streamthoughts/jikkou/JikkouMetadataAnnotations.java
@@ -19,28 +19,37 @@
 package io.streamthoughts.jikkou;
 
 import io.streamthoughts.jikkou.api.model.HasMetadata;
+import org.jetbrains.annotations.NotNull;
 
 public final class JikkouMetadataAnnotations {
 
     public static String JIKKOU_IO_ITEMS_COUNT = "jikkou.io/items-count";
     public static final String JIKKOU_IO_IGNORE = "jikkou.io/ignore";
     public static final String JIKKOU_IO_DELETE = "jikkou.io/delete";
+    public static final String JIKKOU_BYPASS_VALIDATIONS = "jikkou.io/bypass-validations";
     public static final String JIKKOU_IO_TRANSFORM_PREFIX = "transform.jikkou.io";
 
     private JikkouMetadataAnnotations() {
     }
 
+    public static boolean isAnnotatedWithByPassValidation(final HasMetadata resource) {
+        return isAnnotatedWith(resource, JikkouMetadataAnnotations.JIKKOU_BYPASS_VALIDATIONS);
+    }
+
     public static boolean isAnnotatedWithIgnore(final HasMetadata resource) {
-        return HasMetadata.getMetadataAnnotation(resource, JikkouMetadataAnnotations.JIKKOU_IO_IGNORE)
+        return isAnnotatedWith(resource, JikkouMetadataAnnotations.JIKKOU_IO_IGNORE);
+    }
+
+    public static boolean isAnnotatedWithDelete(final HasMetadata resource) {
+        return isAnnotatedWith(resource, JikkouMetadataAnnotations.JIKKOU_IO_DELETE);
+    }
+
+    @NotNull
+    private static Boolean isAnnotatedWith(HasMetadata resource, String jikkouIoIgnore) {
+        return HasMetadata.getMetadataAnnotation(resource, jikkouIoIgnore)
                 .map(Object::toString)
                 .map(Boolean::parseBoolean)
                 .orElse(false);
     }
 
-    public static boolean isAnnotatedWithDelete(final HasMetadata resource) {
-        return HasMetadata.getMetadataAnnotation(resource, JikkouMetadataAnnotations.JIKKOU_IO_DELETE)
-                .map(Object::toString)
-                .map(Boolean::parseBoolean)
-                .orElse(false);
-    }
 }

--- a/jikkou-api/src/main/java/io/streamthoughts/jikkou/api/validation/ResourceValidationChain.java
+++ b/jikkou-api/src/main/java/io/streamthoughts/jikkou/api/validation/ResourceValidationChain.java
@@ -18,6 +18,7 @@
  */
 package io.streamthoughts.jikkou.api.validation;
 
+import io.streamthoughts.jikkou.JikkouMetadataAnnotations;
 import io.streamthoughts.jikkou.api.error.ValidationException;
 import io.streamthoughts.jikkou.api.model.GenericResourceListObject;
 import io.streamthoughts.jikkou.api.model.HasMetadata;
@@ -27,6 +28,8 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -47,7 +50,12 @@ public class ResourceValidationChain implements ResourceValidation<HasMetadata> 
     @Override
     public void validate(@NotNull final List<HasMetadata> resources) {
 
-        Map<ResourceType, List<HasMetadata>> grouped = new GenericResourceListObject(resources).groupByType();
+        List<HasMetadata> filtered = resources.stream()
+                .filter(Predicate.not(JikkouMetadataAnnotations::isAnnotatedWithByPassValidation))
+                .collect(Collectors.toList());
+
+        Map<ResourceType, List<HasMetadata>> grouped = new GenericResourceListObject(filtered)
+                .groupByType();
 
         List<ValidationException> exceptions = new ArrayList<>(resources.size());
         for (Map.Entry<ResourceType, List<HasMetadata>> entry : grouped.entrySet()) {

--- a/jikkou-api/src/test/java/io/streamthoughts/jikkou/api/validation/ResourceValidationChainTest.java
+++ b/jikkou-api/src/test/java/io/streamthoughts/jikkou/api/validation/ResourceValidationChainTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2023 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.jikkou.api.validation;
+
+import io.streamthoughts.jikkou.JikkouMetadataAnnotations;
+import io.streamthoughts.jikkou.api.TestResource;
+import io.streamthoughts.jikkou.api.model.ObjectMeta;
+import io.streamthoughts.jikkou.api.model.ResourceType;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class ResourceValidationChainTest {
+
+
+    @Test
+    void shouldNotRunValidationForResourceAnnotatedWithByPassTrue() {
+        // Given
+        ResourceValidation mkValidation = Mockito.mock(ResourceValidation.class);
+        TestResource resource = new TestResource()
+                .withMetadata(ObjectMeta
+                        .builder()
+                        .withAnnotation(JikkouMetadataAnnotations.JIKKOU_BYPASS_VALIDATIONS, true)
+                        .build()
+                );
+        // When
+        ResourceValidationChain chain = new ResourceValidationChain(List.of(mkValidation));
+
+        chain.validate(List.of(resource));
+
+        // Then
+        Mockito.verify(mkValidation, Mockito.never()).validate(Mockito.anyList());
+    }
+
+    @Test
+    void shouldRunValidationForResourceAnnotatedWithByPassFalse() {
+        // Given
+        ResourceValidation mkValidation = Mockito.mock(ResourceValidation.class);
+        Mockito.when(mkValidation.canAccept(Mockito.any(ResourceType.class)))
+                .thenReturn(true);
+
+        TestResource resource = new TestResource()
+                .withMetadata(ObjectMeta
+                        .builder()
+                        .withAnnotation(JikkouMetadataAnnotations.JIKKOU_BYPASS_VALIDATIONS, false)
+                        .build()
+                );
+        // When
+        ResourceValidationChain chain = new ResourceValidationChain(List.of(mkValidation));
+
+        chain.validate(List.of(resource));
+
+        // Then
+        Mockito.verify(mkValidation, Mockito.times(1)).validate(Mockito.anyList());
+    }
+}


### PR DESCRIPTION
This commit adds support to annotate a resource
with jikkou.io/bypass-validations to bypass validation chain

Resolves: #180