### PR TITLE
Add support for IAM authentication to MSK

### DIFF
--- a/jikkou-cli/pom.xml
+++ b/jikkou-cli/pom.xml
@@ -54,6 +54,10 @@
             <groupId>info.picocli</groupId>
             <artifactId>picocli</artifactId>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.msk</groupId>
+            <artifactId>aws-msk-iam-auth</artifactId>
+        </dependency>
         <!-- START dependencies for test -->
         <dependency>
             <groupId>org.mockito</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -205,6 +205,11 @@
                 <groupId>org.jsonschema2pojo</groupId>
                 <artifactId>jsonschema2pojo-maven-plugin</artifactId>
                 <version>1.2.1</version>
+	    </dependency>
+	    <dependency>
+                <groupId>software.amazon.msk</groupId>
+                <artifactId>aws-msk-iam-auth</artifactId>
+                <version>1.1.6</version>
             </dependency>
             <!-- START dependencies for Tests -->
             <dependency>


### PR DESCRIPTION
With this jar included within the bundle, it is possible to use a jikkou config like the below and manage a cluster:

```
{
  "amazoniam" : {
    "configFile" : null,
    "configProps" : {
      "kafka.client.security.protocol" : "SASL_SSL",
      "kafka.client.sasl.mechanism" : "AWS_MSK_IAM",
      "kafka.client.sasl.jaas.config" : "software.amazon.msk.auth.iam.IAMLoginModule required;",
      "kafka.client.sasl.client.callback.handler.class" : "software.amazon.msk.auth.iam.IAMClientCallbackHandler",
      "kafka.client.bootstrap.servers" : "IAM BOOTSTRAPSERVERS"
    }
  }
}
```