### PR TITLE
ci: build arm64 docker images

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -70,6 +70,7 @@ jobs:
       uses: docker/build-push-action@v4
       with:
         context: docker
+        platforms: linux/amd64,linux/arm64
         file: docker/Dockerfile
         no-cache: true
         push: true
@@ -84,6 +85,7 @@ jobs:
       uses: docker/build-push-action@v4
       with:
         context: docker
+        platforms: linux/amd64,linux/arm64
         file: docker/Dockerfile
         no-cache: true
         push: true


### PR DESCRIPTION
Mac M1/M2 users cannot run easily the Dockerhub images as-is:

```shell
➜ docker pull streamthoughts/jikkou
Using default tag: latest
latest: Pulling from streamthoughts/jikkou
no matching manifest for linux/arm64/v8 in the manifest list entries
```