### PR TITLE
docs(readme):Fatjar Link Outdated

### DIFF
--- a/docs/content/en/docs/Install/_index.md
+++ b/docs/content/en/docs/Install/_index.md
@@ -28,7 +28,7 @@ sdk install jikkou
 Every [`release`](https://github.com/streamthoughts/jikkou/releases) released versions of Jikkou is available:
 
 * As a zip/tar.gz package from [GitHub Releases](https://github.com/streamthoughts/jikkou/releases) (for Linux, MacOS)
-* As a fatJar available from [Maven Central](https://repo.maven.apache.org/maven2/io/streamthoughts/jikkou/0.30.0/)
+* As a fatJar available from [Maven Central](https://repo.maven.apache.org/maven2/io/streamthoughts/jikkou-cli/0.30.0/)
 * As a docker image available from [Docker Hub](https://hub.docker.com/r/streamthoughts/jikkou).
 
 These are the official ways to get Jikkou releases that you manually downloaded and installed.


### PR DESCRIPTION
I was trying to run jikkou using a Fatjar and ran into this link. After browsing for a bit I noticed the link was wrong, as well as other things described in the issue. For this MR I am only making a small change to the README file not fixing the upload to Maven.

Issue: https://github.com/streamthoughts/jikkou/issues/302