### PR TITLE
fix(docs): Use correct URL for OpenAPI spec

### DIFF
--- a/docs/content/en/docs/Jikkou Api Server/API References/index.md
+++ b/docs/content/en/docs/Jikkou Api Server/API References/index.md
@@ -3,5 +3,5 @@ title: "Jikkou - API References"
 type: openapi
 description: "Jikkou - API References"
 linkTitle: "API References"
-specUrl: "https://raw.githubusercontent.com/streamthoughts/jikkou/main/jikkou-api/openapi/openapi.yaml"
+specUrl: "https://raw.githubusercontent.com/streamthoughts/jikkou/main/server/openapi/openapi.yaml"
 ---


### PR DESCRIPTION
This broke in 02904f5117dbd03771979ac719dc7f7ecfbcc760.