### PR TITLE
Support subject modes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,5 @@ docs/node_modules
 docs/resources
 docs/public
 docs/public
+
+.sdkmanrc

--- a/providers/jikkou-provider-aiven/src/main/java/io/streamthoughts/jikkou/extension/aiven/api/AivenAsyncSchemaRegistryApi.java
+++ b/providers/jikkou-provider-aiven/src/main/java/io/streamthoughts/jikkou/extension/aiven/api/AivenAsyncSchemaRegistryApi.java
@@ -8,12 +8,7 @@ package io.streamthoughts.jikkou.extension.aiven.api;
 
 import io.streamthoughts.jikkou.extension.aiven.api.data.CompatibilityCheckResponse;
 import io.streamthoughts.jikkou.schema.registry.api.AsyncSchemaRegistryApi;
-import io.streamthoughts.jikkou.schema.registry.api.data.CompatibilityCheck;
-import io.streamthoughts.jikkou.schema.registry.api.data.CompatibilityLevelObject;
-import io.streamthoughts.jikkou.schema.registry.api.data.CompatibilityObject;
-import io.streamthoughts.jikkou.schema.registry.api.data.SubjectSchemaId;
-import io.streamthoughts.jikkou.schema.registry.api.data.SubjectSchemaRegistration;
-import io.streamthoughts.jikkou.schema.registry.api.data.SubjectSchemaVersion;
+import io.streamthoughts.jikkou.schema.registry.api.data.*;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -170,5 +165,20 @@ public final class AivenAsyncSchemaRegistryApi implements AsyncSchemaRegistryApi
     @Override
     public void close() {
         api.close();
+    }
+
+    @Override
+    public CompletableFuture<ModeObject> getSubjectMode(@NotNull String subject, boolean defaultToGlobal) {
+        throw new UnsupportedOperationException("Aiven schema registry does not support subject mode");
+    }
+
+    @Override
+    public CompletableFuture<ModeObject> updateSubjectMode(@NotNull String subject, @NotNull ModeObject mode) {
+        throw new UnsupportedOperationException("Aiven schema registry does not support subject mode");
+    }
+
+    @Override
+    public CompletableFuture<ModeObject> deleteSubjectMode(@NotNull String subject) {
+        throw new UnsupportedOperationException("Aiven schema registry does not support subject mode");
     }
 }

--- a/providers/jikkou-provider-aiven/src/main/java/io/streamthoughts/jikkou/extension/aiven/api/AivenAsyncSchemaRegistryApi.java
+++ b/providers/jikkou-provider-aiven/src/main/java/io/streamthoughts/jikkou/extension/aiven/api/AivenAsyncSchemaRegistryApi.java
@@ -63,8 +63,10 @@ public final class AivenAsyncSchemaRegistryApi implements AsyncSchemaRegistryApi
     public CompletableFuture<SubjectSchemaId> registerSubjectVersion(@NotNull String subject,
                                                                      @NotNull SubjectSchemaRegistration schema,
                                                                      boolean normalize) {
-        // Drop references - not supported through the Aiven's API.
+        // Drop id, version, and references - not supported through the Aiven's API.
         SubjectSchemaRegistration registration = new SubjectSchemaRegistration(
+                null,
+                null,
                 schema.schema(),
                 schema.schemaType(),
                 null

--- a/providers/jikkou-provider-aiven/src/main/java/io/streamthoughts/jikkou/extension/aiven/reconciler/AivenSchemaRegistrySubjectCollector.java
+++ b/providers/jikkou-provider-aiven/src/main/java/io/streamthoughts/jikkou/extension/aiven/reconciler/AivenSchemaRegistrySubjectCollector.java
@@ -162,7 +162,7 @@ public class AivenSchemaRegistrySubjectCollector implements Collector<V1SchemaRe
                         () -> Pair.of(subjectSchemaVersion, api.getSchemaRegistrySubjectCompatibility(subject))))
                 .thenApply(pair ->
                         // Create SchemaRegistrySubject object
-                        factory.createSchemaRegistrySubject(pair._1().version(), pair._2().compatibilityLevel())
+                        factory.createSchemaRegistrySubject(pair._1().version(), pair._2().compatibilityLevel(), null)
                 );
     }
 }

--- a/providers/jikkou-provider-schema-registry/src/integration-test/java/io/streamthoughts/jikkou/schema/registry/api/AsyncSchemaRegistryApiTest.java
+++ b/providers/jikkou-provider-schema-registry/src/integration-test/java/io/streamthoughts/jikkou/schema/registry/api/AsyncSchemaRegistryApiTest.java
@@ -126,7 +126,7 @@ class AsyncSchemaRegistryApiTest {
         // When
         CompletableFuture<SubjectSchemaId> future = async.registerSubjectVersion(
                 TEST_SUBJECT,
-                new SubjectSchemaRegistration(AVRO_SCHEMA, SchemaType.AVRO),
+                new SubjectSchemaRegistration(null, null, AVRO_SCHEMA, SchemaType.AVRO),
                 true
         );
 
@@ -213,7 +213,7 @@ class AsyncSchemaRegistryApiTest {
                 TEST_SUBJECT,
                 "-1",
                 true,
-                new SubjectSchemaRegistration(AVRO_SCHEMA, SchemaType.AVRO)
+                new SubjectSchemaRegistration(null, null, AVRO_SCHEMA, SchemaType.AVRO)
         );
 
         // Then
@@ -230,7 +230,7 @@ class AsyncSchemaRegistryApiTest {
                 TEST_SUBJECT,
                 "-1",
                 true,
-                new SubjectSchemaRegistration(AVRO_SCHEMA_NOT_COMPATIBLE, SchemaType.AVRO)
+                new SubjectSchemaRegistration(null, null, AVRO_SCHEMA_NOT_COMPATIBLE, SchemaType.AVRO)
         );
 
         // Then

--- a/providers/jikkou-provider-schema-registry/src/integration-test/java/io/streamthoughts/jikkou/schema/registry/reconciler/SchemaRegistrySubjectCollectorTest.java
+++ b/providers/jikkou-provider-schema-registry/src/integration-test/java/io/streamthoughts/jikkou/schema/registry/reconciler/SchemaRegistrySubjectCollectorTest.java
@@ -33,7 +33,7 @@ class SchemaRegistrySubjectCollectorTest extends AbstractIntegrationTest {
         AsyncSchemaRegistryApi api = getAsyncSchemaRegistryApi();
         api.registerSubjectVersion(
                 TEST_SUBJECT,
-                new SubjectSchemaRegistration(AVRO_SCHEMA, SchemaType.AVRO),
+                new SubjectSchemaRegistration(null, null, AVRO_SCHEMA, SchemaType.AVRO),
                 false
         ).get();
     }

--- a/providers/jikkou-provider-schema-registry/src/integration-test/java/io/streamthoughts/jikkou/schema/registry/reconciler/SchemaRegistrySubjectCollectorTest.java
+++ b/providers/jikkou-provider-schema-registry/src/integration-test/java/io/streamthoughts/jikkou/schema/registry/reconciler/SchemaRegistrySubjectCollectorTest.java
@@ -12,6 +12,7 @@ import io.streamthoughts.jikkou.schema.registry.AbstractIntegrationTest;
 import io.streamthoughts.jikkou.schema.registry.api.AsyncSchemaRegistryApi;
 import io.streamthoughts.jikkou.schema.registry.api.data.SubjectSchemaRegistration;
 import io.streamthoughts.jikkou.schema.registry.model.CompatibilityLevels;
+import io.streamthoughts.jikkou.schema.registry.model.Modes;
 import io.streamthoughts.jikkou.schema.registry.model.SchemaType;
 import io.streamthoughts.jikkou.schema.registry.models.V1SchemaRegistrySubject;
 import java.util.List;
@@ -38,9 +39,10 @@ class SchemaRegistrySubjectCollectorTest extends AbstractIntegrationTest {
     }
 
     @Test
-    public void shouldGetAllSchemasWithGlobalCompatibilityLevelTrue() {
+    public void shouldGetAllSchemasWithGlobalCompatibilityLevelAndGlobalModeTrue() {
         // Given
         collector.defaultToGlobalCompatibilityLevel(true);
+        collector.defaultToGlobalMode(true);
 
         // When
         List<V1SchemaRegistrySubject> resources = collector.listAll(Configuration.empty(), Selectors.NO_SELECTOR)
@@ -54,12 +56,14 @@ class SchemaRegistrySubjectCollectorTest extends AbstractIntegrationTest {
         Assertions.assertEquals(TEST_SUBJECT, subject.getMetadata().getName());
         Assertions.assertEquals(SchemaType.AVRO, subject.getSpec().getSchemaType());
         Assertions.assertEquals(CompatibilityLevels.BACKWARD, subject.getSpec().getCompatibilityLevel());
+        Assertions.assertEquals(Modes.READWRITE, subject.getSpec().getMode());
     }
 
     @Test
-    public void shouldGetAllSchemasWithGlobalCompatibilityLevelFalse() {
+    public void shouldGetAllSchemasWithGlobalCompatibilityLevelAndGlobalModeFalse() {
         // Given
         collector.defaultToGlobalCompatibilityLevel(false);
+        collector.defaultToGlobalMode(false);
 
         // When
         List<V1SchemaRegistrySubject> resources = collector.listAll(Configuration.empty(), Selectors.NO_SELECTOR)
@@ -73,5 +77,6 @@ class SchemaRegistrySubjectCollectorTest extends AbstractIntegrationTest {
         Assertions.assertEquals(TEST_SUBJECT, subject.getMetadata().getName());
         Assertions.assertEquals(SchemaType.AVRO, subject.getSpec().getSchemaType());
         Assertions.assertNull(subject.getSpec().getCompatibilityLevel());
+        Assertions.assertNull(subject.getSpec().getMode());
     }
 }

--- a/providers/jikkou-provider-schema-registry/src/integration-test/java/io/streamthoughts/jikkou/schema/registry/reconciler/SchemaRegistrySubjectControllerTest.java
+++ b/providers/jikkou-provider-schema-registry/src/integration-test/java/io/streamthoughts/jikkou/schema/registry/reconciler/SchemaRegistrySubjectControllerTest.java
@@ -26,11 +26,13 @@ import io.streamthoughts.jikkou.core.resource.DefaultResourceRegistry;
 import io.streamthoughts.jikkou.schema.registry.AbstractIntegrationTest;
 import io.streamthoughts.jikkou.schema.registry.SchemaRegistryAnnotations;
 import io.streamthoughts.jikkou.schema.registry.api.SchemaRegistryClientConfig;
+import io.streamthoughts.jikkou.schema.registry.model.Modes;
 import io.streamthoughts.jikkou.schema.registry.model.SchemaHandle;
 import io.streamthoughts.jikkou.schema.registry.model.SchemaType;
 import io.streamthoughts.jikkou.schema.registry.models.V1SchemaRegistrySubject;
 import io.streamthoughts.jikkou.schema.registry.models.V1SchemaRegistrySubjectSpec;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -82,5 +84,42 @@ class SchemaRegistrySubjectControllerTest extends AbstractIntegrationTest {
         Assertions.assertEquals(Optional.of(1), data.getMetadata().findAnnotationByKey(SchemaRegistryAnnotations.JIKKOU_IO_SCHEMA_REGISTRY_SCHEMA_ID));
         Assertions.assertEquals(Operation.CREATE, data.getSpec().getOp());
         Assertions.assertEquals(SchemaType.AVRO, data.getSpec().getChanges().getLast("schemaType", TypeConverter.of(SchemaType.class)).getAfter());
+    }
+
+    @Test
+    void shouldImportSchemaForNewResource() {
+        // Given
+        V1SchemaRegistrySubject resource = V1SchemaRegistrySubject.builder()
+                .withMetadata(ObjectMeta.builder()
+                        .withName(TEST_SUBJECT)
+                        .withAnnotations(Map.of(
+                                SchemaRegistryAnnotations.JIKKOU_IO_SCHEMA_REGISTRY_SCHEMA_ID, 123,
+                                SchemaRegistryAnnotations.JIKKOU_IO_SCHEMA_REGISTRY_SCHEMA_VERSION, 4
+                        ))
+                        .build()
+                )
+                .withSpec(V1SchemaRegistrySubjectSpec
+                        .builder()
+                        .withSchemaType(SchemaType.AVRO)
+                        .withSchema(new SchemaHandle(AVRO_SCHEMA))
+                        .withMode(Modes.IMPORT)
+                        .build())
+                .build();
+        // When
+        ApiChangeResultList result = api.reconcile(
+                ResourceListObject.of(List.of(resource)),
+                ReconciliationMode.CREATE,
+                ReconciliationContext.builder().dryRun(false).build()
+        );
+        // Then
+        List<ChangeResult> results = result.results();
+        Assertions.assertEquals(1, results.size());
+        ChangeResult change = results.getFirst();
+        ResourceChange data = change.change();
+        Assertions.assertEquals(Optional.of(123), data.getMetadata().findAnnotationByKey(SchemaRegistryAnnotations.JIKKOU_IO_SCHEMA_REGISTRY_SCHEMA_ID));
+        Assertions.assertEquals(Optional.of(4), data.getMetadata().findAnnotationByKey(SchemaRegistryAnnotations.JIKKOU_IO_SCHEMA_REGISTRY_SCHEMA_VERSION));
+        Assertions.assertEquals(Operation.CREATE, data.getSpec().getOp());
+        Assertions.assertEquals(SchemaType.AVRO, data.getSpec().getChanges().getLast("schemaType", TypeConverter.of(SchemaType.class)).getAfter());
+        Assertions.assertEquals(Modes.IMPORT, data.getSpec().getChanges().getLast("mode", TypeConverter.of(Modes.class)).getAfter());
     }
 }

--- a/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/SchemaRegistryAnnotations.java
+++ b/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/SchemaRegistryAnnotations.java
@@ -23,7 +23,10 @@ package io.streamthoughts.jikkou.schema.registry;/*
  * limitations under the License.
  */
 
+import io.streamthoughts.jikkou.core.data.TypeConverter;
 import io.streamthoughts.jikkou.core.models.CoreAnnotations;
+import io.streamthoughts.jikkou.core.models.HasMetadata;
+import io.streamthoughts.jikkou.core.models.NamedValue;
 import io.streamthoughts.jikkou.schema.registry.models.V1SchemaRegistrySubject;
 
 public final class SchemaRegistryAnnotations {
@@ -41,5 +44,19 @@ public final class SchemaRegistryAnnotations {
 
     public static boolean isAnnotatedWitPermananteDelete(V1SchemaRegistrySubject subject) {
         return CoreAnnotations.isAnnotatedWith(subject, JIKKOU_IO_SCHEMA_REGISTRY_PERMANANTE_DELETE);
+    }
+
+    public static String schemaId(V1SchemaRegistrySubject subject) {
+        return HasMetadata.getMetadataAnnotation(subject, JIKKOU_IO_SCHEMA_REGISTRY_SCHEMA_ID)
+                .map(NamedValue::getValue)
+                .map(o -> TypeConverter.String().convertValue(o))
+                .orElse("");
+    }
+
+    public static String version(V1SchemaRegistrySubject subject) {
+        return HasMetadata.getMetadataAnnotation(subject, JIKKOU_IO_SCHEMA_REGISTRY_SCHEMA_VERSION)
+                .map(NamedValue::getValue)
+                .map(o -> TypeConverter.String().convertValue(o))
+                .orElse("");
     }
 }

--- a/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/V1SchemaRegistrySubjectFactory.java
+++ b/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/V1SchemaRegistrySubjectFactory.java
@@ -9,6 +9,7 @@ package io.streamthoughts.jikkou.schema.registry;
 import io.streamthoughts.jikkou.core.models.ObjectMeta;
 import io.streamthoughts.jikkou.schema.registry.api.data.SubjectSchemaVersion;
 import io.streamthoughts.jikkou.schema.registry.model.CompatibilityLevels;
+import io.streamthoughts.jikkou.schema.registry.model.Modes;
 import io.streamthoughts.jikkou.schema.registry.model.SchemaHandle;
 import io.streamthoughts.jikkou.schema.registry.model.SchemaType;
 import io.streamthoughts.jikkou.schema.registry.models.SchemaRegistry;
@@ -36,7 +37,8 @@ public final class V1SchemaRegistrySubjectFactory {
 
     @NotNull
     public V1SchemaRegistrySubject createSchemaRegistrySubject(@NotNull SubjectSchemaVersion subjectSchema,
-                                                               @Nullable CompatibilityLevels compatibilityLevels) {
+                                                               @Nullable CompatibilityLevels compatibilityLevels,
+                                                               @Nullable Modes modes) {
         SchemaType schemaType = Optional.ofNullable(subjectSchema.schemaType())
                 .map(SchemaType::getForNameIgnoreCase)
                 .orElse(SchemaType.defaultType());
@@ -53,6 +55,10 @@ public final class V1SchemaRegistrySubjectFactory {
 
         if (compatibilityLevels != null) {
             specBuilder = specBuilder.withCompatibilityLevel(compatibilityLevels);
+        }
+
+        if (modes != null) {
+            specBuilder = specBuilder.withMode(modes);
         }
 
         V1SchemaRegistrySubject res = V1SchemaRegistrySubject

--- a/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/api/AsyncSchemaRegistryApi.java
+++ b/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/api/AsyncSchemaRegistryApi.java
@@ -6,12 +6,7 @@
  */
 package io.streamthoughts.jikkou.schema.registry.api;
 
-import io.streamthoughts.jikkou.schema.registry.api.data.CompatibilityCheck;
-import io.streamthoughts.jikkou.schema.registry.api.data.CompatibilityLevelObject;
-import io.streamthoughts.jikkou.schema.registry.api.data.CompatibilityObject;
-import io.streamthoughts.jikkou.schema.registry.api.data.SubjectSchemaId;
-import io.streamthoughts.jikkou.schema.registry.api.data.SubjectSchemaRegistration;
-import io.streamthoughts.jikkou.schema.registry.api.data.SubjectSchemaVersion;
+import io.streamthoughts.jikkou.schema.registry.api.data.*;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.jetbrains.annotations.NotNull;
@@ -93,6 +88,34 @@ public interface AsyncSchemaRegistryApi extends AutoCloseable {
      * @return the compatibility level.
      */
     CompletableFuture<CompatibilityObject> deleteSubjectCompatibilityLevel(@NotNull String subject);
+
+    /**
+     * Gets mode level for the specified subject.
+     *
+     * @param subject         the name of the subject.
+     * @param defaultToGlobal flag to default to global mode.
+     * @return                the mode.
+     */
+    CompletableFuture<ModeObject> getSubjectMode(@NotNull String subject,
+                                                 boolean defaultToGlobal);
+
+    /**
+     * Updates mode for the specified subject.
+     *
+     * @param subject       the name of the subject.
+     * @param mode          the new mode for the subject.
+     * @return              the updated mode.
+     */
+    CompletableFuture<ModeObject> updateSubjectMode(@NotNull String subject,
+                                                    @NotNull ModeObject mode);
+
+    /**
+     * Deletes the specified subject-level mode and reverts to the global default.
+     *
+     * @param subject the name of the subject.
+     * @return        the mode.
+     */
+    CompletableFuture<ModeObject> deleteSubjectMode(@NotNull String subject);
 
     CompletableFuture<CompatibilityCheck> testCompatibility(@NotNull String subject,
                                                             String version,

--- a/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/api/DefaultAsyncSchemaRegistryApi.java
+++ b/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/api/DefaultAsyncSchemaRegistryApi.java
@@ -6,12 +6,7 @@
  */
 package io.streamthoughts.jikkou.schema.registry.api;
 
-import io.streamthoughts.jikkou.schema.registry.api.data.CompatibilityCheck;
-import io.streamthoughts.jikkou.schema.registry.api.data.CompatibilityLevelObject;
-import io.streamthoughts.jikkou.schema.registry.api.data.CompatibilityObject;
-import io.streamthoughts.jikkou.schema.registry.api.data.SubjectSchemaId;
-import io.streamthoughts.jikkou.schema.registry.api.data.SubjectSchemaRegistration;
-import io.streamthoughts.jikkou.schema.registry.api.data.SubjectSchemaVersion;
+import io.streamthoughts.jikkou.schema.registry.api.data.*;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
@@ -102,6 +97,21 @@ public final class DefaultAsyncSchemaRegistryApi implements AutoCloseable, Async
     public CompletableFuture<CompatibilityObject> deleteSubjectCompatibilityLevel(@NotNull final String subject) {
         return CompletableFuture.supplyAsync(() -> api.deleteConfigCompatibility(subject));
 
+    }
+
+    @Override
+    public CompletableFuture<ModeObject> getSubjectMode(@NotNull String subject, boolean defaultToGlobal) {
+        return CompletableFuture.supplyAsync(() -> api.getMode(subject, defaultToGlobal));
+    }
+
+    @Override
+    public CompletableFuture<ModeObject> updateSubjectMode(@NotNull String subject, @NotNull ModeObject mode) {
+        return CompletableFuture.supplyAsync(() -> api.updateMode(subject, mode));
+    }
+
+    @Override
+    public CompletableFuture<ModeObject> deleteSubjectMode(@NotNull final String subject) {
+        return CompletableFuture.supplyAsync(() -> api.deleteMode(subject));
     }
 
     /**

--- a/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/api/SchemaRegistryApi.java
+++ b/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/api/SchemaRegistryApi.java
@@ -6,14 +6,7 @@
  */
 package io.streamthoughts.jikkou.schema.registry.api;
 
-import io.streamthoughts.jikkou.schema.registry.api.data.CompatibilityCheck;
-import io.streamthoughts.jikkou.schema.registry.api.data.CompatibilityLevelObject;
-import io.streamthoughts.jikkou.schema.registry.api.data.CompatibilityObject;
-import io.streamthoughts.jikkou.schema.registry.api.data.SchemaString;
-import io.streamthoughts.jikkou.schema.registry.api.data.SubjectSchemaId;
-import io.streamthoughts.jikkou.schema.registry.api.data.SubjectSchemaRegistration;
-import io.streamthoughts.jikkou.schema.registry.api.data.SubjectSchemaVersion;
-import io.streamthoughts.jikkou.schema.registry.api.data.SubjectVersion;
+import io.streamthoughts.jikkou.schema.registry.api.data.*;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.DefaultValue;
@@ -228,6 +221,34 @@ public interface SchemaRegistryApi extends AutoCloseable {
     @Path("config/{subject}")
     @Produces("application/vnd.schemaregistry.v1+json")
     CompatibilityObject deleteConfigCompatibility(@PathParam("subject") String subject);
+
+    /*
+     * ----------------------------------------------------------------------------------------------------------------
+     * MODE
+     * ----------------------------------------------------------------------------------------------------------------
+     */
+
+    @GET
+    @Path("mode/{subject}")
+    @Produces("application/vnd.schemaregistry.v1+json")
+    ModeObject getMode(@PathParam("subject") String subject,
+                       @QueryParam("defaultToGlobal") @DefaultValue("false") boolean defaultToGlobal);
+
+    @PUT
+    @Path("mode/{subject}")
+    @Consumes({"application/vnd.schemaregistry.v1+json", "application/vnd.schemaregistry+json", "application/json"})
+    ModeObject updateMode(@PathParam("subject") String subject, ModeObject mode);
+
+    /**
+     * Deletes the specified subject-level mode and reverts to the global default.
+     *
+     * @param subject the name of the subject.
+     * @return the mode.
+     */
+    @DELETE
+    @Path("mode/{subject}")
+    @Produces("application/vnd.schemaregistry.v1+json")
+    ModeObject deleteMode(@PathParam("subject") String subject);
 
     /*
      * ----------------------------------------------------------------------------------------------------------------

--- a/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/api/data/ModeObject.java
+++ b/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/api/data/ModeObject.java
@@ -1,0 +1,29 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.jikkou.schema.registry.api.data;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.streamthoughts.jikkou.core.annotation.Reflectable;
+import java.beans.ConstructorProperties;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * ModeObject.
+ *
+ * @param mode a mode string.
+ */
+@Reflectable
+public record ModeObject(@NotNull String mode) {
+    @ConstructorProperties({
+            "mode"
+    })
+    public ModeObject {}
+
+    @Override
+    @JsonProperty("mode")
+    public String mode() { return mode; }
+}

--- a/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/api/data/SubjectSchemaRegistration.java
+++ b/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/api/data/SubjectSchemaRegistration.java
@@ -7,6 +7,7 @@
 package io.streamthoughts.jikkou.schema.registry.api.data;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.streamthoughts.jikkou.core.annotation.Reflectable;
 import io.streamthoughts.jikkou.schema.registry.model.SchemaType;
@@ -16,6 +17,8 @@ import java.util.List;
 @Reflectable
 public final class SubjectSchemaRegistration {
 
+    private final String id;
+    private final String version;
     private final String schema;
     private final SchemaType schemaType;
     private final List<SubjectSchemaReference> references;
@@ -26,9 +29,11 @@ public final class SubjectSchemaRegistration {
      * @param schema     subject under which the schema will be registered.
      * @param schemaType the schema format.
      */
-    public SubjectSchemaRegistration(String schema,
+    public SubjectSchemaRegistration(String id,
+                                     String version,
+                                     String schema,
                                      SchemaType schemaType) {
-        this(schema, schemaType, Collections.emptyList());
+        this(id, version, schema, schemaType, Collections.emptyList());
     }
 
     /**
@@ -39,13 +44,25 @@ public final class SubjectSchemaRegistration {
      * @param references specifies the names of referenced schemas.
      */
     @JsonCreator
-    public SubjectSchemaRegistration(@JsonProperty("schema") String schema,
+    public SubjectSchemaRegistration(@JsonProperty("id") String id,
+                                     @JsonProperty("version") String version,
+                                     @JsonProperty("schema") String schema,
                                      @JsonProperty("schemaType") SchemaType schemaType,
                                      @JsonProperty("references") List<SubjectSchemaReference> references) {
+        this.id = id;
+        this.version = version;
         this.schema = schema;
         this.schemaType = schemaType;
         this.references = references;
     }
+
+    @JsonProperty("id")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public String id() { return id; }
+
+    @JsonProperty("version")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public String version() { return version; }
 
     @JsonProperty("schema")
     public String schema() {

--- a/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/change/SchemaSubjectChangeComputer.java
+++ b/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/change/SchemaSubjectChangeComputer.java
@@ -117,7 +117,9 @@ public final class SchemaSubjectChangeComputer extends ResourceChangeComputer<St
         private SchemaSubjectChangeOptions getOptions(@NotNull V1SchemaRegistrySubject subject) {
             return new SchemaSubjectChangeOptions(
                     SchemaRegistryAnnotations.isAnnotatedWitPermananteDelete(subject),
-                    SchemaRegistryAnnotations.isAnnotatedWithNormalizeSchema(subject)
+                    SchemaRegistryAnnotations.isAnnotatedWithNormalizeSchema(subject),
+                    SchemaRegistryAnnotations.schemaId(subject),
+                    SchemaRegistryAnnotations.version(subject)
             );
         }
 

--- a/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/change/SchemaSubjectChangeComputer.java
+++ b/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/change/SchemaSubjectChangeComputer.java
@@ -31,6 +31,7 @@ import org.jetbrains.annotations.NotNull;
 public final class SchemaSubjectChangeComputer extends ResourceChangeComputer<String, V1SchemaRegistrySubject, ResourceChange> {
 
     public static final String DATA_COMPATIBILITY_LEVEL = "compatibilityLevel";
+    public static final String DATA_MODE = "mode";
     public static final String DATA_SCHEMA = "schema";
     public static final String DATA_SCHEMA_TYPE = "schemaType";
     public static final String DATA_REFERENCES = "references";
@@ -78,6 +79,11 @@ public final class SchemaSubjectChangeComputer extends ResourceChangeComputer<St
                     StateChange.create(DATA_COMPATIBILITY_LEVEL, after.getSpec().getCompatibilityLevel()));
             }
 
+            if (after.getSpec().getMode() != null) {
+                specBuilder = specBuilder.withChange(
+                    StateChange.create(DATA_MODE, after.getSpec().getMode()));
+            }
+
             return GenericResourceChange
                     .builder(V1SchemaRegistrySubject.class)
                     .withMetadata(after.getMetadata())
@@ -89,6 +95,7 @@ public final class SchemaSubjectChangeComputer extends ResourceChangeComputer<St
         public ResourceChange createChangeForUpdate(String key, V1SchemaRegistrySubject before, V1SchemaRegistrySubject after) {
             StateChangeList<StateChange> changes = StateChangeList.emptyList()
                     .with(getChangeForCompatibility(before, after))
+                    .with(getChangeForMode(before, after))
                     .with(getChangeForSchema(before, after))
                     .with(getChangeForSchemaType(before, after))
                     .with(getChangeForReferences(before, after));
@@ -149,6 +156,16 @@ public final class SchemaSubjectChangeComputer extends ResourceChangeComputer<St
                     DATA_COMPATIBILITY_LEVEL,
                     Optional.ofNullable(before).map(o -> o.getSpec().getCompatibilityLevel()).orElse(null),
                     Optional.ofNullable(after).map(o -> o.getSpec().getCompatibilityLevel()).orElse(null)
+            );
+        }
+
+        @NotNull
+        private StateChange getChangeForMode(V1SchemaRegistrySubject before,
+                                             V1SchemaRegistrySubject after) {
+            return StateChange.with(
+                    DATA_MODE,
+                    Optional.ofNullable(before).map(o -> o.getSpec().getMode()).orElse(null),
+                    Optional.ofNullable(after).map(o -> o.getSpec().getMode()).orElse(null)
             );
         }
 

--- a/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/change/SchemaSubjectChangeOptions.java
+++ b/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/change/SchemaSubjectChangeOptions.java
@@ -16,12 +16,16 @@ import java.beans.ConstructorProperties;
 @Reflectable
 public record SchemaSubjectChangeOptions(
         @JsonProperty("permanentDelete") boolean permanentDelete,
-        @JsonProperty("normalizeSchema") boolean normalizeSchema
+        @JsonProperty("normalizeSchema") boolean normalizeSchema,
+        @JsonProperty("schemaId") String schemaId,
+        @JsonProperty("version") String version
 ) {
 
     @ConstructorProperties({
             "permanentDelete",
-            "normalizeSchema"
+            "normalizeSchema",
+            "schemaId",
+            "version"
     })
     public SchemaSubjectChangeOptions {
 

--- a/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/change/handler/AbstractSchemaSubjectChangeHandler.java
+++ b/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/change/handler/AbstractSchemaSubjectChangeHandler.java
@@ -105,8 +105,12 @@ public abstract class AbstractSchemaSubjectChangeHandler implements ChangeHandle
         SchemaSubjectChangeOptions options = getSchemaSubjectChangeOptions(change);
 
         final String subjectName = change.getMetadata().getName();
+        final String id = options.schemaId();
+        final String version = options.version();
         if (LOG.isInfoEnabled()) {
-            LOG.info("Registering new Schema Registry subject version: subject '{}', optimization={}, schema={}.",
+            LOG.info("Registering new Schema Registry subject version: id '{}', version '{}' subject '{}', optimization={}, schema={}.",
+                    id,
+                    version,
                     subjectName,
                     options.normalizeSchema(),
                     schema
@@ -121,7 +125,7 @@ public abstract class AbstractSchemaSubjectChangeHandler implements ChangeHandle
         return api
                 .registerSubjectVersion(
                         subjectName,
-                        new SubjectSchemaRegistration(schema, type, references),
+                        new SubjectSchemaRegistration(id, version, schema, type, references),
                         options.normalizeSchema()
                 )
                 .thenApply(subjectSchemaId -> {
@@ -131,12 +135,12 @@ public abstract class AbstractSchemaSubjectChangeHandler implements ChangeHandle
                                 subjectName,
                                 subjectSchemaId.id()
                         );
-                        change.getMetadata()
-                                .addAnnotationIfAbsent(
-                                        SchemaRegistryAnnotations.JIKKOU_IO_SCHEMA_REGISTRY_SCHEMA_ID,
-                                        subjectSchemaId.id()
-                                );
                     }
+                    change.getMetadata()
+                            .addAnnotationIfAbsent(
+                                    SchemaRegistryAnnotations.JIKKOU_IO_SCHEMA_REGISTRY_SCHEMA_ID,
+                                    subjectSchemaId.id()
+                            );
                     return null;
                 });
     }

--- a/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/change/handler/CreateSchemaSubjectChangeHandler.java
+++ b/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/change/handler/CreateSchemaSubjectChangeHandler.java
@@ -7,6 +7,7 @@
 package io.streamthoughts.jikkou.schema.registry.change.handler;
 
 import static io.streamthoughts.jikkou.schema.registry.change.SchemaSubjectChangeComputer.DATA_COMPATIBILITY_LEVEL;
+import static io.streamthoughts.jikkou.schema.registry.change.SchemaSubjectChangeComputer.DATA_MODE;
 
 import io.streamthoughts.jikkou.core.models.change.ResourceChange;
 import io.streamthoughts.jikkou.core.models.change.StateChange;
@@ -59,6 +60,14 @@ public final class CreateSchemaSubjectChangeHandler
 
             if (compatibilityLevels != null) {
                 future = future.thenComposeAsync(unused -> updateCompatibilityLevel(change));
+            }
+
+            StateChange modes = StateChangeList
+                    .of(change.getSpec().getChanges())
+                    .getLast(DATA_MODE);
+
+            if (modes != null) {
+                future = future.thenComposeAsync(unused -> updateMode(change));
             }
 
             results.add(toChangeResponse(change, future));

--- a/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/collections/V1SchemaRegistrySubjectList.java
+++ b/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/collections/V1SchemaRegistrySubjectList.java
@@ -11,11 +11,10 @@ import io.streamthoughts.jikkou.core.annotation.Kind;
 import io.streamthoughts.jikkou.core.models.DefaultResourceListObject;
 import io.streamthoughts.jikkou.core.models.ObjectMeta;
 import io.streamthoughts.jikkou.schema.registry.models.V1SchemaRegistrySubject;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-
 import java.beans.ConstructorProperties;
 import java.util.List;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @ApiVersion("kafka.jikkou.io/v1beta2")
 @Kind("SchemaRegistrySubjectList")

--- a/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/model/Modes.java
+++ b/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/model/Modes.java
@@ -1,0 +1,17 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.jikkou.schema.registry.model;
+
+/**
+ * Schema modes
+ */
+public enum Modes {
+
+    IMPORT,
+    READONLY,
+    READWRITE
+}

--- a/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/models/V1SchemaRegistrySubjectSpec.java
+++ b/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/models/V1SchemaRegistrySubjectSpec.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.streamthoughts.jikkou.core.annotation.Reflectable;
 import io.streamthoughts.jikkou.schema.registry.api.data.SubjectSchemaReference;
 import io.streamthoughts.jikkou.schema.registry.model.CompatibilityLevels;
+import io.streamthoughts.jikkou.schema.registry.model.Modes;
 import io.streamthoughts.jikkou.schema.registry.model.SchemaHandle;
 import io.streamthoughts.jikkou.schema.registry.model.SchemaType;
 import java.beans.ConstructorProperties;
@@ -31,6 +32,7 @@ import lombok.extern.jackson.Jacksonized;
 @Setter
 @JsonPropertyOrder({
     "compatibilityLevel",
+    "mode",
     "schemaRegistry",
     "schemaType",
     "schema",
@@ -48,6 +50,13 @@ public class V1SchemaRegistrySubjectSpec {
     @JsonProperty("compatibilityLevel")
     @JsonPropertyDescription("The schema compatibility level for this subject.")
     private CompatibilityLevels compatibilityLevel;
+    /**
+     * The mode for this subject: IMPORT, READONLY, READWRITE.
+     * 
+     */
+    @JsonProperty("mode")
+    @JsonPropertyDescription("The mode for this subject: IMPORT, READONLY, READWRITE.")
+    private Modes mode;
     @JsonProperty("schemaRegistry")
     private SchemaRegistry schemaRegistry;
     /**
@@ -77,6 +86,7 @@ public class V1SchemaRegistrySubjectSpec {
 
     /**
      * 
+     * @param mode
      * @param schema
      * @param schemaRegistry
      * @param references
@@ -85,14 +95,16 @@ public class V1SchemaRegistrySubjectSpec {
      */
     @ConstructorProperties({
         "compatibilityLevel",
+        "mode",
         "schemaRegistry",
         "schemaType",
         "schema",
         "references"
     })
-    public V1SchemaRegistrySubjectSpec(CompatibilityLevels compatibilityLevel, SchemaRegistry schemaRegistry, SchemaType schemaType, SchemaHandle schema, List<SubjectSchemaReference> references) {
+    public V1SchemaRegistrySubjectSpec(CompatibilityLevels compatibilityLevel, Modes mode, SchemaRegistry schemaRegistry, SchemaType schemaType, SchemaHandle schema, List<SubjectSchemaReference> references) {
         super();
         this.compatibilityLevel = compatibilityLevel;
+        this.mode = mode;
         this.schemaRegistry = schemaRegistry;
         this.schemaType = schemaType;
         this.schema = schema;
@@ -106,6 +118,15 @@ public class V1SchemaRegistrySubjectSpec {
     @JsonProperty("compatibilityLevel")
     public CompatibilityLevels getCompatibilityLevel() {
         return compatibilityLevel;
+    }
+
+    /**
+     * The mode for this subject: IMPORT, READONLY, READWRITE.
+     * 
+     */
+    @JsonProperty("mode")
+    public Modes getMode() {
+        return mode;
     }
 
     @JsonProperty("schemaRegistry")
@@ -144,6 +165,10 @@ public class V1SchemaRegistrySubjectSpec {
         sb.append('=');
         sb.append(((this.compatibilityLevel == null)?"<null>":this.compatibilityLevel));
         sb.append(',');
+        sb.append("mode");
+        sb.append('=');
+        sb.append(((this.mode == null)?"<null>":this.mode));
+        sb.append(',');
         sb.append("schemaRegistry");
         sb.append('=');
         sb.append(((this.schemaRegistry == null)?"<null>":this.schemaRegistry));
@@ -171,6 +196,7 @@ public class V1SchemaRegistrySubjectSpec {
     @Override
     public int hashCode() {
         int result = 1;
+        result = ((result* 31)+((this.mode == null)? 0 :this.mode.hashCode()));
         result = ((result* 31)+((this.schemaType == null)? 0 :this.schemaType.hashCode()));
         result = ((result* 31)+((this.schema == null)? 0 :this.schema.hashCode()));
         result = ((result* 31)+((this.schemaRegistry == null)? 0 :this.schemaRegistry.hashCode()));
@@ -188,7 +214,7 @@ public class V1SchemaRegistrySubjectSpec {
             return false;
         }
         V1SchemaRegistrySubjectSpec rhs = ((V1SchemaRegistrySubjectSpec) other);
-        return ((((((this.schemaType == rhs.schemaType)||((this.schemaType!= null)&&this.schemaType.equals(rhs.schemaType)))&&((this.schema == rhs.schema)||((this.schema!= null)&&this.schema.equals(rhs.schema))))&&((this.schemaRegistry == rhs.schemaRegistry)||((this.schemaRegistry!= null)&&this.schemaRegistry.equals(rhs.schemaRegistry))))&&((this.references == rhs.references)||((this.references!= null)&&this.references.equals(rhs.references))))&&((this.compatibilityLevel == rhs.compatibilityLevel)||((this.compatibilityLevel!= null)&&this.compatibilityLevel.equals(rhs.compatibilityLevel))));
+        return (((((((this.mode == rhs.mode)||((this.mode!= null)&&this.mode.equals(rhs.mode)))&&((this.schemaType == rhs.schemaType)||((this.schemaType!= null)&&this.schemaType.equals(rhs.schemaType))))&&((this.schema == rhs.schema)||((this.schema!= null)&&this.schema.equals(rhs.schema))))&&((this.schemaRegistry == rhs.schemaRegistry)||((this.schemaRegistry!= null)&&this.schemaRegistry.equals(rhs.schemaRegistry))))&&((this.references == rhs.references)||((this.references!= null)&&this.references.equals(rhs.references))))&&((this.compatibilityLevel == rhs.compatibilityLevel)||((this.compatibilityLevel!= null)&&this.compatibilityLevel.equals(rhs.compatibilityLevel))));
     }
 
 }

--- a/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/reconciler/SchemaRegistrySubjectCollector.java
+++ b/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/reconciler/SchemaRegistrySubjectCollector.java
@@ -7,7 +7,6 @@
 package io.streamthoughts.jikkou.schema.registry.reconciler;
 
 import io.streamthoughts.jikkou.common.utils.AsyncUtils;
-import io.streamthoughts.jikkou.common.utils.Pair;
 import io.streamthoughts.jikkou.core.annotation.SupportedResource;
 import io.streamthoughts.jikkou.core.config.Configuration;
 import io.streamthoughts.jikkou.core.exceptions.JikkouRuntimeException;
@@ -22,8 +21,10 @@ import io.streamthoughts.jikkou.schema.registry.api.AsyncSchemaRegistryApi;
 import io.streamthoughts.jikkou.schema.registry.api.DefaultAsyncSchemaRegistryApi;
 import io.streamthoughts.jikkou.schema.registry.api.SchemaRegistryApiFactory;
 import io.streamthoughts.jikkou.schema.registry.api.SchemaRegistryClientConfig;
+import io.streamthoughts.jikkou.schema.registry.api.data.SubjectSchemaVersion;
 import io.streamthoughts.jikkou.schema.registry.collections.V1SchemaRegistrySubjectList;
 import io.streamthoughts.jikkou.schema.registry.model.CompatibilityLevels;
+import io.streamthoughts.jikkou.schema.registry.model.Modes;
 import io.streamthoughts.jikkou.schema.registry.models.V1SchemaRegistrySubject;
 import jakarta.ws.rs.core.Response;
 import java.util.List;
@@ -40,6 +41,8 @@ public class SchemaRegistrySubjectCollector extends ContextualExtension implemen
     private boolean prettyPrintSchema = true;
 
     private boolean defaultToGlobalCompatibilityLevel = true;
+
+    private boolean defaultToGlobalMode = true;
 
     private V1SchemaRegistrySubjectFactory schemaRegistrySubjectFactory;
 
@@ -115,12 +118,17 @@ public class SchemaRegistrySubjectCollector extends ContextualExtension implemen
         return this;
     }
 
+    public SchemaRegistrySubjectCollector defaultToGlobalMode(final boolean defaultToGlobalMode) {
+        this.defaultToGlobalMode = defaultToGlobalMode;
+        return this;
+    }
+
     @NotNull
     private List<CompletableFuture<V1SchemaRegistrySubject>> getAllSchemaRegistrySubjectsAsync(final List<String> subjects,
                                                                                                final AsyncSchemaRegistryApi api) {
         return subjects.stream()
                 .map(subject -> getSchemaRegistrySubjectAsync(
-                        api, subject, defaultToGlobalCompatibilityLevel, schemaRegistrySubjectFactory))
+                        api, subject, defaultToGlobalCompatibilityLevel, defaultToGlobalMode, schemaRegistrySubjectFactory))
                 .toList();
     }
 
@@ -128,42 +136,53 @@ public class SchemaRegistrySubjectCollector extends ContextualExtension implemen
     private static CompletableFuture<V1SchemaRegistrySubject> getSchemaRegistrySubjectAsync(@NotNull AsyncSchemaRegistryApi api,
                                                                                             @NotNull String subject,
                                                                                             boolean defaultToGlobalCompatibilityLevel,
+                                                                                            boolean defaultToGlobalMode,
                                                                                             @NotNull V1SchemaRegistrySubjectFactory factory) {
 
-        return api
-                // Get Schema Registry Latest Subject Version
-                .getLatestSubjectSchema(subject)
-                // Get Schema Registry Subject Compatibility
-                .thenCompose(subjectSchemaVersion -> api
-                        .getSubjectCompatibilityLevel(subject, defaultToGlobalCompatibilityLevel)
-                        .thenApply(compatibilityObject -> CompatibilityLevels.valueOf(compatibilityObject.compatibilityLevel()))
-                        .exceptionally(t -> {
-                                    if (t.getCause() != null) t = t.getCause();
+        CompletableFuture<SubjectSchemaVersion> schemaSubjectFuture = api.getLatestSubjectSchema(subject);
+        CompletableFuture<CompatibilityLevels> compatibilityLevelsFuture = getSubjectCompatibilityLevel(api, subject, defaultToGlobalCompatibilityLevel)
+                .exceptionally(SchemaRegistrySubjectCollector::handleNotFound);
+        CompletableFuture<Modes> modesFuture = getSubjectMode(api, subject, defaultToGlobalMode)
+                .exceptionally(SchemaRegistrySubjectCollector::handleNotFound);
 
-                                    if (t instanceof RestClientException exception) {
-                                        if (exception.response()
-                                                .map(Response::getStatus)
-                                                .filter(status -> status.equals(404))
-                                                .isPresent()) {
-                                            return null;
-                                        }
-                                    }
-                                    if (t instanceof RuntimeException re) {
-                                        throw re;
-                                    }
-                                    throw new JikkouRuntimeException(t);
-                                }
-                        )
-                        .thenApply(compatibilityLevelObject ->
-                                Pair.of(subjectSchemaVersion, compatibilityLevelObject)
-                        )
-                )
-                // Create SchemaRegistrySubject object
-                .thenApply(tuple ->
-                        factory.createSchemaRegistrySubject(
-                                tuple._1(),
-                                tuple._2()
-                        )
-                );
+        return CompletableFuture.allOf(schemaSubjectFuture, compatibilityLevelsFuture, modesFuture)
+                .thenApplyAsync(it -> {
+                    SubjectSchemaVersion subjectSchema = schemaSubjectFuture.join();
+                    CompatibilityLevels compatibilityLevels = compatibilityLevelsFuture.join();
+                    Modes modes = modesFuture.join();
+
+                    return factory.createSchemaRegistrySubject(subjectSchema, compatibilityLevels, modes);
+                });
+    }
+
+    private static CompletableFuture<CompatibilityLevels> getSubjectCompatibilityLevel(@NotNull AsyncSchemaRegistryApi api,
+                                                                                       @NotNull String subject,
+                                                                                       boolean defaultToGlobalCompatibilityLevel) {
+        return api.getSubjectCompatibilityLevel(subject, defaultToGlobalCompatibilityLevel)
+                .thenApply(compatibilityObject -> CompatibilityLevels.valueOf(compatibilityObject.compatibilityLevel()));
+    }
+
+    private static CompletableFuture<Modes> getSubjectMode(@NotNull AsyncSchemaRegistryApi api,
+                                                           @NotNull String subject,
+                                                           boolean defaultToGlobalMode) {
+        return api.getSubjectMode(subject, defaultToGlobalMode)
+                .thenApply(modeObject -> Modes.valueOf(modeObject.mode()));
+    }
+
+    private static <T> T handleNotFound(Throwable t) {
+        if (t.getCause() != null) t = t.getCause();
+
+        if (t instanceof RestClientException exception) {
+            if (exception.response()
+                    .map(Response::getStatus)
+                    .filter(status -> status.equals(404))
+                    .isPresent()) {
+                return null;
+            }
+        }
+        if (t instanceof RuntimeException re) {
+            throw re;
+        }
+        throw new JikkouRuntimeException(t);
     }
 }

--- a/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/reconciler/SchemaRegistrySubjectController.java
+++ b/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/reconciler/SchemaRegistrySubjectController.java
@@ -107,7 +107,8 @@ public class SchemaRegistrySubjectController
         // Get existing resources from the environment.
         SchemaRegistrySubjectCollector collector = new SchemaRegistrySubjectCollector(configuration)
             .prettyPrintSchema(false)
-            .defaultToGlobalCompatibilityLevel(false);
+            .defaultToGlobalCompatibilityLevel(false)
+            .defaultToGlobalMode(false);
 
         List<V1SchemaRegistrySubject> actualSubjects = collector.listAll(context.configuration(), Selectors.NO_SELECTOR).stream()
             .filter(context.selector()::apply)

--- a/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/validation/SchemaCompatibilityValidation.java
+++ b/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/validation/SchemaCompatibilityValidation.java
@@ -60,6 +60,8 @@ public class SchemaCompatibilityValidation implements Validation<V1SchemaRegistr
         V1SchemaRegistrySubjectSpec spec = resource.getSpec();
 
         SubjectSchemaRegistration registration = new SubjectSchemaRegistration(
+                null,
+                null,
                 spec.getSchema().value(),
                 spec.getSchemaType(),
                 spec.getReferences()

--- a/providers/jikkou-provider-schema-registry/src/main/json/V1SchemaRegistrySubject.json
+++ b/providers/jikkou-provider-schema-registry/src/main/json/V1SchemaRegistrySubject.json
@@ -63,6 +63,11 @@
           "description": "The schema compatibility level for this subject.",
           "existingJavaType": "io.streamthoughts.jikkou.schema.registry.model.CompatibilityLevels"
         },
+        "mode": {
+          "type": "string",
+          "description": "The mode for this subject: IMPORT, READONLY, READWRITE.",
+          "existingJavaType": "io.streamthoughts.jikkou.schema.registry.model.Modes"
+        },
         "schemaRegistry": {
           "type": "object",
           "additionalProperties": {

--- a/providers/jikkou-provider-schema-registry/src/test/java/io/streamthoughts/jikkou/schema/registry/change/SchemaSubjectChangeComputerTest.java
+++ b/providers/jikkou-provider-schema-registry/src/test/java/io/streamthoughts/jikkou/schema/registry/change/SchemaSubjectChangeComputerTest.java
@@ -81,7 +81,9 @@ class SchemaSubjectChangeComputerTest {
                                 .withOperation(Operation.CREATE)
                                 .withData(Map.of(
                                         "permanentDelete", false,
-                                        "normalizeSchema", false
+                                        "normalizeSchema", false,
+                                        "schemaId", "",
+                                        "version", ""
                                 ))
                                 .withChange(StateChange.create(DATA_SCHEMA, SCHEMA_V1.toString()))
                                 .withChange(StateChange.create(DATA_SCHEMA_TYPE, SchemaType.AVRO))
@@ -125,7 +127,9 @@ class SchemaSubjectChangeComputerTest {
                                 .withOperation(Operation.NONE)
                                 .withData(Map.of(
                                         "permanentDelete", false,
-                                        "normalizeSchema", false
+                                        "normalizeSchema", false,
+                                        "schemaId", "",
+                                        "version", ""
                                 ))
                                 .withChange(StateChange.none(DATA_COMPATIBILITY_LEVEL, null))
                                 .withChange(StateChange.none(DATA_MODE, null))
@@ -185,7 +189,9 @@ class SchemaSubjectChangeComputerTest {
                                 .withOperation(Operation.UPDATE)
                                 .withData(Map.of(
                                         "permanentDelete", false,
-                                        "normalizeSchema", false
+                                        "normalizeSchema", false,
+                                        "schemaId", "",
+                                        "version", ""
                                 ))
                                 .withChange(StateChange.create(DATA_COMPATIBILITY_LEVEL, CompatibilityLevels.BACKWARD))
                                 .withChange(StateChange.none(DATA_MODE, null))
@@ -245,7 +251,9 @@ class SchemaSubjectChangeComputerTest {
                                 .withOperation(Operation.UPDATE)
                                 .withData(Map.of(
                                         "permanentDelete", false,
-                                        "normalizeSchema", false
+                                        "normalizeSchema", false,
+                                        "schemaId", "",
+                                        "version", ""
                                 ))
                                 .withChange(StateChange.create(DATA_MODE, Modes.IMPORT))
                                 .withChange(StateChange.none(DATA_COMPATIBILITY_LEVEL, null))
@@ -303,7 +311,9 @@ class SchemaSubjectChangeComputerTest {
                                 .withOperation(Operation.UPDATE)
                                 .withData(Map.of(
                                         "permanentDelete", false,
-                                        "normalizeSchema", false
+                                        "normalizeSchema", false,
+                                        "schemaId", "",
+                                        "version", ""
                                 ))
                                 .withChange(StateChange.none(DATA_COMPATIBILITY_LEVEL, null))
                                 .withChange(StateChange.none(DATA_MODE, null))

--- a/providers/jikkou-provider-schema-registry/src/test/resources/datasets/resource-subject-test.yaml
+++ b/providers/jikkou-provider-schema-registry/src/test/resources/datasets/resource-subject-test.yaml
@@ -8,6 +8,7 @@ metadata:
     schemaregistry.jikkou.io/normalize-schema: true
 spec:
   compatibilityLevel: "FULL_TRANSITIVE"
+  mode: "IMPORT"
   schemaType: "AVRO"
   schema:
     $ref: classpath://datasets/avro-schema.avsc


### PR DESCRIPTION
- Add support for changing mode: READWRITE, READONLY, IMPORT. [Docs](https://docs.confluent.io/platform/current/schema-registry/develop/api.html#mode)
- Add support for specifying the id and version when creating a schema subject version. [Docs](https://docs.confluent.io/platform/current/schema-registry/develop/api.html#mode)