### PR TITLE
Remove duplicate caching for Maven

### DIFF
--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -94,13 +94,7 @@ jobs:
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRO }}
-
-      - name: 'Cache Maven packages'
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          cache: maven
 
       - name: 'Configure Git'
         run: |

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -31,13 +31,6 @@ jobs:
         check-latest: true
         cache: maven
 
-    - name: Cache Maven packages
-      uses: actions/cache@v4
-      with:
-        path: ~/.m2
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ runner.os }}-m2
-
     - name: Cache SonarCloud packages
       uses: actions/cache@v4
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,13 +158,7 @@ jobs:
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRO }}
-
-      - name: 'Cache Maven packages'
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          cache: maven
 
       - name: 'Configure Git'
         run: |


### PR DESCRIPTION
The built-in cache of [actions/setup-java](https://github.com/actions/setup-java) is already taking care of caching the local Maven repository (`~/.m2/repo`) and adding an additional explicit cache with [actions/cache](https://github.com/actions/cache) just wastes time and bandwidth.

See also: https://github.com/actions/setup-java#caching-packages-dependencies