### PR TITLE
Skip analysis with SonarScanner if token is missing

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -52,4 +52,5 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        SONAR_SKIP: ${{ secrets.SONAR_TOKEN && 'false' || 'true' }} # skip analysis if token is missing
       run: ./mvnw -ntp -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=streamthoughts_jikkou

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,7 @@
         <sonar.java.binaries>target</sonar.java.binaries>
         <sonar.java.source>${jdk.version}</sonar.java.source>
         <sonar.language>java</sonar.language>
+        <sonar.skip>${env.SONAR_SKIP}</sonar.skip>
         <!-- START Maven plugin versions -->
         <maven-clean-plugin.version>3.3.1</maven-clean-plugin.version>
         <maven-compiler-plugin.version>3.12.1</maven-compiler-plugin.version>


### PR DESCRIPTION
Skip analysis with [SonarScanner for Maven](https://docs.sonarsource.com/sonarqube/10.4/analyzing-source-code/scanners/sonarscanner-for-maven/) if the `SONAR_TOKEN` environment variable is missing.

This will allow pull requests to get a green pipeline. 😉

Example run: https://github.com/joschi/jikkou/actions/runs/8486508905/job/23253010629