### PR TITLE
Use individual artifact names for GraalVM builds

### DIFF
--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -69,7 +69,7 @@ jobs:
       - name: 'Upload build artifact'
         uses: actions/upload-artifact@v4
         with:
-          name: artifacts
+          name: artifacts-${{ runner.os }}-${{ runner.arch }}
           path: |
             dist/*.zip
             dist/*.tar.gz


### PR DESCRIPTION
GraalVM builds are currently failing to complete because of artifact name conflicts:
https://github.com/streamthoughts/jikkou/actions/runs/8500518531/job/23282456057#step:10:24

> ```
> Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
> ```

This change set ensures that the artifact uploads contain the operating system and the machine architecture to distinguish them.