### PR TITLE
fix(schema-registry): Compare avro schemas using fingerprint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ docs/node_modules
 docs/resources
 docs/public
 docs/public
+
+# .*rc files
+.sdkmanrc

--- a/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/model/SchemaAndType.java
+++ b/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/model/SchemaAndType.java
@@ -6,9 +6,18 @@
  */
 package io.streamthoughts.jikkou.schema.registry.model;
 
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.streamthoughts.jikkou.core.data.json.Json;
+import io.streamthoughts.jikkou.schema.registry.avro.AvroSchema;
 import java.util.Objects;
+import lombok.Builder;
+import lombok.extern.jackson.Jacksonized;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaNormalization;
 import org.jetbrains.annotations.NotNull;
 
+@Builder
+@Jacksonized
 public class SchemaAndType {
 
     private static final SchemaAndType EMPTY = new SchemaAndType();
@@ -17,6 +26,7 @@ public class SchemaAndType {
         return EMPTY;
     }
 
+    @JsonValue
     private final String schema;
     private final SchemaType type;
 
@@ -39,6 +49,7 @@ public class SchemaAndType {
         this.type = Objects.requireNonNull(type, "type must not be null");
     }
 
+    @JsonValue
     public String schema() {
         return schema;
     }
@@ -53,12 +64,34 @@ public class SchemaAndType {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         SchemaAndType that = (SchemaAndType) o;
-        return Objects.equals(schema, that.schema) && type == that.type;
+        if (type == SchemaType.AVRO && type == that.type) {
+            return avroEquals(that);
+        } else if (type == SchemaType.JSON && type == that.type) {
+            return jsonEquals(that);
+        } else {
+            return Objects.equals(schema, that.schema) && type == that.type;
+        }
     }
 
     /** {@inheritDoc} **/
     @Override
     public int hashCode() {
         return Objects.hash(schema, type);
+    }
+
+    private boolean avroEquals(SchemaAndType that) {
+        Schema thisSchema = new AvroSchema(schema).schema();
+        Schema thatSchema = new AvroSchema(that.schema).schema();
+
+        return SchemaNormalization.parsingFingerprint64(thisSchema) ==
+                SchemaNormalization.parsingFingerprint64(thatSchema);
+    }
+
+    private boolean jsonEquals(SchemaAndType that) {
+        return Objects.equals(Json.normalize(schema), Json.normalize(that.schema));
+    }
+
+    public String toString() {
+        return schema;
     }
 }

--- a/providers/jikkou-provider-schema-registry/src/test/java/io/streamthoughts/jikkou/schema/registry/change/SchemaSubjectChangeComputerTest.java
+++ b/providers/jikkou-provider-schema-registry/src/test/java/io/streamthoughts/jikkou/schema/registry/change/SchemaSubjectChangeComputerTest.java
@@ -11,7 +11,6 @@ import static io.streamthoughts.jikkou.schema.registry.change.SchemaSubjectChang
 import static io.streamthoughts.jikkou.schema.registry.change.SchemaSubjectChangeComputer.DATA_SCHEMA;
 import static io.streamthoughts.jikkou.schema.registry.change.SchemaSubjectChangeComputer.DATA_SCHEMA_TYPE;
 
-import io.streamthoughts.jikkou.core.data.json.Json;
 import io.streamthoughts.jikkou.core.models.ObjectMeta;
 import io.streamthoughts.jikkou.core.models.change.GenericResourceChange;
 import io.streamthoughts.jikkou.core.models.change.ResourceChange;
@@ -19,6 +18,7 @@ import io.streamthoughts.jikkou.core.models.change.ResourceChangeSpec;
 import io.streamthoughts.jikkou.core.models.change.StateChange;
 import io.streamthoughts.jikkou.core.reconciler.Operation;
 import io.streamthoughts.jikkou.schema.registry.model.CompatibilityLevels;
+import io.streamthoughts.jikkou.schema.registry.model.SchemaAndType;
 import io.streamthoughts.jikkou.schema.registry.model.SchemaHandle;
 import io.streamthoughts.jikkou.schema.registry.model.SchemaType;
 import io.streamthoughts.jikkou.schema.registry.models.V1SchemaRegistrySubject;
@@ -85,7 +85,7 @@ class SchemaSubjectChangeComputerTest {
                                         "permanentDelete", false,
                                         "normalizeSchema", false
                                 ))
-                                .withChange(StateChange.create(DATA_SCHEMA, SCHEMA_V1.toString()))
+                                .withChange(StateChange.create(DATA_SCHEMA, new SchemaAndType(SCHEMA_V1.toString(), SchemaType.AVRO)))
                                 .withChange(StateChange.create(DATA_SCHEMA_TYPE, SchemaType.AVRO))
                                 .withChange(StateChange.create(DATA_REFERENCES, Collections.emptyList()))
                                 .build()
@@ -130,7 +130,7 @@ class SchemaSubjectChangeComputerTest {
                                         "normalizeSchema", false
                                 ))
                                 .withChange(StateChange.none(DATA_COMPATIBILITY_LEVEL, null))
-                                .withChange(StateChange.none(DATA_SCHEMA, Json.normalize(SCHEMA_V1.toString())))
+                                .withChange(StateChange.none(DATA_SCHEMA, new SchemaAndType(SCHEMA_V1.toString(), SchemaType.AVRO)))
                                 .withChange(StateChange.none(DATA_SCHEMA_TYPE, SchemaType.AVRO))
                                 .withChange(StateChange.none(DATA_REFERENCES, Collections.emptyList()))
                                 .build()
@@ -189,7 +189,7 @@ class SchemaSubjectChangeComputerTest {
                                         "normalizeSchema", false
                                 ))
                                 .withChange(StateChange.create(DATA_COMPATIBILITY_LEVEL, CompatibilityLevels.BACKWARD))
-                                .withChange(StateChange.none(DATA_SCHEMA, Json.normalize(SCHEMA_V1.toString())))
+                                .withChange(StateChange.none(DATA_SCHEMA, new SchemaAndType(SCHEMA_V1.toString(), SchemaType.AVRO)))
                                 .withChange(StateChange.none(DATA_SCHEMA_TYPE, SchemaType.AVRO))
                                 .withChange(StateChange.none(DATA_REFERENCES, Collections.emptyList()))
                                 .build()
@@ -249,8 +249,8 @@ class SchemaSubjectChangeComputerTest {
                                 .withChange(StateChange.none(DATA_SCHEMA_TYPE, SchemaType.AVRO))
                                 .withChange(StateChange.update(
                                         DATA_SCHEMA,
-                                        Json.normalize(SCHEMA_V1.toString()),
-                                        Json.normalize(SCHEMA_V2.toString()))
+                                        new SchemaAndType(SCHEMA_V1.toString(), SchemaType.AVRO),
+                                        new SchemaAndType(SCHEMA_V2.toString(), SchemaType.AVRO))
                                 )
                                 .withChange(StateChange.none(DATA_REFERENCES, Collections.emptyList()))
                                 .build()


### PR DESCRIPTION
This is a quick and dirty potential solution to #431. It changes schema comparison to use SchemaNormalization.parsingFingerPrint64() instead of a string comparison. 

