### PR TITLE
Apply subject configuration before schema registration to enforce intended compatibility and simplify workflow

### DIFF
--- a/providers/jikkou-provider-aiven/src/integration-test/java/io/streamthoughts/jikkou/extension/aiven/reconciler/AivenSchemaRegistrySubjectControllerIT.java
+++ b/providers/jikkou-provider-aiven/src/integration-test/java/io/streamthoughts/jikkou/extension/aiven/reconciler/AivenSchemaRegistrySubjectControllerIT.java
@@ -79,6 +79,14 @@ public class AivenSchemaRegistrySubjectControllerIT extends BaseExtensionProvide
                         }
                         """)
         );
+        // Update Config
+        enqueueResponse(new MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setResponseCode(200)
+                .setBody("""
+                        {}
+                        """)
+        );
         // Update Schema
         enqueueResponse(new MockResponse()
                 .setHeader("Content-Type", "application/json")
@@ -87,14 +95,6 @@ public class AivenSchemaRegistrySubjectControllerIT extends BaseExtensionProvide
                         {
                             "version": 1
                         }
-                        """)
-        );
-        // Update Config
-        enqueueResponse(new MockResponse()
-                .setHeader("Content-Type", "application/json")
-                .setResponseCode(200)
-                .setBody("""
-                        {}
                         """)
         );
         V1SchemaRegistrySubject resource = V1SchemaRegistrySubject

--- a/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/change/handler/CreateSchemaSubjectChangeHandler.java
+++ b/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/change/handler/CreateSchemaSubjectChangeHandler.java
@@ -51,7 +51,7 @@ public final class CreateSchemaSubjectChangeHandler
 
         List<ChangeResponse> results = new ArrayList<>();
         for (ResourceChange change : changes) {
-            Mono<Void> mono = registerSubjectVersion(change);
+            Mono<Void> mono = Mono.empty();
 
             StateChange compatibilityLevels = StateChangeList
                     .of(change.getSpec().getChanges())
@@ -60,6 +60,8 @@ public final class CreateSchemaSubjectChangeHandler
             if (compatibilityLevels != null) {
                 mono = mono.then(updateCompatibilityLevel(change));
             }
+
+            mono = mono.then(registerSubjectVersion(change));
 
             results.add(toChangeResponse(change, mono.toFuture()));
         }

--- a/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/change/handler/UpdateSchemaSubjectChangeHandler.java
+++ b/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/change/handler/UpdateSchemaSubjectChangeHandler.java
@@ -55,14 +55,6 @@ public final class UpdateSchemaSubjectChangeHandler
         for (ResourceChange change : changes) {
             Mono<Void> mono = Mono.empty();
 
-            StateChange schema = StateChangeList
-                    .of(change.getSpec().getChanges())
-                    .getLast(DATA_SCHEMA);
-
-            if (UPDATE == schema.getOp()) {
-                mono = mono.then(registerSubjectVersion(change));
-            }
-
             StateChange compatibilityLevels = StateChangeList
                     .of(change.getSpec().getChanges())
                     .getLast(DATA_COMPATIBILITY_LEVEL);
@@ -74,6 +66,15 @@ public final class UpdateSchemaSubjectChangeHandler
             if (DELETE == compatibilityLevels.getOp()) {
                 mono = mono.then(deleteCompatibilityLevel(change));
             }
+
+            StateChange schema = StateChangeList
+                    .of(change.getSpec().getChanges())
+                    .getLast(DATA_SCHEMA);
+
+            if (UPDATE == schema.getOp()) {
+                mono = mono.then(registerSubjectVersion(change));
+            }
+
             results.add(toChangeResponse(change, mono.toFuture()));
         }
         return results;


### PR DESCRIPTION
Currently, Jikkou registers a schema before applying the subject configuration. This ordering can cause two problems:

- **Schemas may not reflect the intended subject settings** because the previously configured state (global or subject‑specific) is applied during registration, which may not match the rules intended for the new schema.
- **Less intuitive workflow** since users may need to proceed in two steps (first adjust subject configuration, then register the schema), whereas they expect the configuration to apply immediately to the schema being deployed.

By applying the subject configuration first, Jikkou ensures that subject rules are taken into account correctly and that configuration feels more natural to users.