### PR TITLE
Add support for Schema Registry import mode 

### DIFF
--- a/providers/jikkou-provider-aiven/src/integration-test/java/io/streamthoughts/jikkou/extension/aiven/reconciler/AivenSchemaRegistrySubjectControllerIT.java
+++ b/providers/jikkou-provider-aiven/src/integration-test/java/io/streamthoughts/jikkou/extension/aiven/reconciler/AivenSchemaRegistrySubjectControllerIT.java
@@ -137,7 +137,9 @@ public class AivenSchemaRegistrySubjectControllerIT extends BaseExtensionProvide
                 .withOperation(Operation.CREATE)
                 .withData(Map.of(
                     "permanentDelete", false,
-                    "normalizeSchema", false
+                    "normalizeSchema", false,
+                    "schemaId", "",
+                    "version", ""
                 ))
                 .withChange(StateChange.create(DATA_COMPATIBILITY_LEVEL, CompatibilityLevels.BACKWARD))
                 .withChange(StateChange.create(DATA_SCHEMA, new SchemaAndType(AVRO_SCHEMA_V1, SchemaType.AVRO)))
@@ -231,7 +233,9 @@ public class AivenSchemaRegistrySubjectControllerIT extends BaseExtensionProvide
                 .withOperation(Operation.UPDATE)
                 .withData(Map.of(
                     "permanentDelete", false,
-                    "normalizeSchema", false
+                    "normalizeSchema", false,
+                    "schemaId", "",
+                    "version", ""
                 ))
                 .withChange(StateChange.none(DATA_COMPATIBILITY_LEVEL, CompatibilityLevels.BACKWARD))
                 .withChange(StateChange.update(DATA_SCHEMA, new SchemaAndType(AVRO_SCHEMA_V1, SchemaType.AVRO), new SchemaAndType(AVRO_SCHEMA_V2, SchemaType.AVRO)))

--- a/providers/jikkou-provider-aiven/src/main/java/io/streamthoughts/jikkou/extension/aiven/api/AivenAsyncSchemaRegistryApi.java
+++ b/providers/jikkou-provider-aiven/src/main/java/io/streamthoughts/jikkou/extension/aiven/api/AivenAsyncSchemaRegistryApi.java
@@ -8,7 +8,13 @@ package io.streamthoughts.jikkou.extension.aiven.api;
 
 import io.streamthoughts.jikkou.extension.aiven.api.data.CompatibilityCheckResponse;
 import io.streamthoughts.jikkou.schema.registry.api.AsyncSchemaRegistryApi;
-import io.streamthoughts.jikkou.schema.registry.api.data.*;
+import io.streamthoughts.jikkou.schema.registry.api.data.CompatibilityCheck;
+import io.streamthoughts.jikkou.schema.registry.api.data.CompatibilityLevelObject;
+import io.streamthoughts.jikkou.schema.registry.api.data.CompatibilityObject;
+import io.streamthoughts.jikkou.schema.registry.api.data.ModeObject;
+import io.streamthoughts.jikkou.schema.registry.api.data.SubjectSchemaId;
+import io.streamthoughts.jikkou.schema.registry.api.data.SubjectSchemaRegistration;
+import io.streamthoughts.jikkou.schema.registry.api.data.SubjectSchemaVersion;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -47,9 +53,9 @@ public final class AivenAsyncSchemaRegistryApi implements AsyncSchemaRegistryApi
     public Mono<List<Integer>> deleteSubjectVersions(@NotNull String subject,
                                                      boolean permanent) {
         return Mono.fromCallable(() -> {
-                    api.deleteSchemaRegistrySubject(subject);
-                    return Collections.emptyList();
-                }
+                api.deleteSchemaRegistrySubject(subject);
+                return Collections.emptyList();
+            }
         );
     }
 
@@ -62,12 +68,12 @@ public final class AivenAsyncSchemaRegistryApi implements AsyncSchemaRegistryApi
                                                         boolean normalize) {
         // Drop references - not supported through the Aiven's API.
         SubjectSchemaRegistration registration = new SubjectSchemaRegistration(
-                schema.schema(),
-                schema.schemaType(),
-                null
+            schema.schema(),
+            schema.schemaType(),
+            null
         );
         return Mono.fromCallable(
-                () -> new SubjectSchemaId(api.registerSchemaRegistrySubjectVersion(subject, registration).version())
+            () -> new SubjectSchemaId(api.registerSchemaRegistrySubjectVersion(subject, registration).version())
         );
     }
 
@@ -77,7 +83,7 @@ public final class AivenAsyncSchemaRegistryApi implements AsyncSchemaRegistryApi
     @Override
     public Mono<SubjectSchemaVersion> getLatestSubjectSchema(@NotNull String subject) {
         return Mono.fromCallable(
-                () -> api.getSchemaRegistryLatestSubjectVersion(subject).version()
+            () -> api.getSchemaRegistryLatestSubjectVersion(subject).version()
         );
     }
 
@@ -87,7 +93,7 @@ public final class AivenAsyncSchemaRegistryApi implements AsyncSchemaRegistryApi
     @Override
     public Mono<CompatibilityLevelObject> getGlobalCompatibility() {
         return Mono.fromCallable(
-                () -> new CompatibilityLevelObject(api.getSchemaRegistryGlobalCompatibility().compatibilityLevel().name())
+            () -> new CompatibilityLevelObject(api.getSchemaRegistryGlobalCompatibility().compatibilityLevel().name())
         );
     }
 
@@ -98,7 +104,7 @@ public final class AivenAsyncSchemaRegistryApi implements AsyncSchemaRegistryApi
     public Mono<CompatibilityLevelObject> getSubjectCompatibilityLevel(@NotNull String subject,
                                                                        boolean defaultToGlobal) {
         return Mono.fromCallable(
-                () -> new CompatibilityLevelObject(api.getSchemaRegistrySubjectCompatibility(subject).compatibilityLevel().name())
+            () -> new CompatibilityLevelObject(api.getSchemaRegistrySubjectCompatibility(subject).compatibilityLevel().name())
         );
     }
 
@@ -109,10 +115,10 @@ public final class AivenAsyncSchemaRegistryApi implements AsyncSchemaRegistryApi
     public Mono<CompatibilityObject> updateSubjectCompatibilityLevel(@NotNull String subject,
                                                                      @NotNull CompatibilityObject compatibility) {
         return Mono.fromCallable(
-                () -> {
-                    api.updateSchemaRegistrySubjectCompatibility(subject, compatibility);
-                    return new CompatibilityObject(compatibility.compatibility());
-                }
+            () -> {
+                api.updateSchemaRegistrySubjectCompatibility(subject, compatibility);
+                return new CompatibilityObject(compatibility.compatibility());
+            }
         );
     }
 
@@ -122,8 +128,8 @@ public final class AivenAsyncSchemaRegistryApi implements AsyncSchemaRegistryApi
     @Override
     public Mono<CompatibilityObject> deleteSubjectCompatibilityLevel(@NotNull String subject) {
         throw new AivenApiClientException(
-                "Deleting configuration for Schema Registry subject is not supported by " +
-                        "the Aiven API (for more information: https://api.aiven.io/doc/)."
+            "Deleting configuration for Schema Registry subject is not supported by " +
+                "the Aiven API (for more information: https://api.aiven.io/doc/)."
         );
     }
 
@@ -136,13 +142,13 @@ public final class AivenAsyncSchemaRegistryApi implements AsyncSchemaRegistryApi
                                                       boolean verbose,
                                                       @NotNull SubjectSchemaRegistration schema) {
         return Mono.fromCallable(
-                () -> {
-                    CompatibilityCheckResponse response = api.checkSchemaRegistryCompatibility(subject, version, schema);
-                    return new CompatibilityCheck(
-                            response.isCompatible(),
-                            Optional.ofNullable(response.message()).map(List::of).orElse(Collections.emptyList())
-                    );
-                }
+            () -> {
+                CompatibilityCheckResponse response = api.checkSchemaRegistryCompatibility(subject, version, schema);
+                return new CompatibilityCheck(
+                    response.isCompatible(),
+                    Optional.ofNullable(response.message()).map(List::of).orElse(Collections.emptyList())
+                );
+            }
         );
     }
 
@@ -162,5 +168,37 @@ public final class AivenAsyncSchemaRegistryApi implements AsyncSchemaRegistryApi
     @Override
     public void close() {
         api.close();
+    }
+
+    /**
+     * {@inheritDoc}
+     **/
+    @Override
+    public Mono<ModeObject> getGlobalMode() {
+        throw new UnsupportedOperationException("Aiven schema registry does not support subject mode");
+    }
+
+    /**
+     * {@inheritDoc}
+     **/
+    @Override
+    public Mono<ModeObject> getSubjectMode(@NotNull String subject, boolean defaultToGlobal) {
+        throw new UnsupportedOperationException("Aiven schema registry does not support subject mode");
+    }
+
+    /**
+     * {@inheritDoc}
+     **/
+    @Override
+    public Mono<ModeObject> updateSubjectMode(@NotNull String subject, @NotNull ModeObject mode) {
+        throw new UnsupportedOperationException("Aiven schema registry does not support subject mode");
+    }
+
+    /**
+     * {@inheritDoc}
+     **/
+    @Override
+    public Mono<ModeObject> deleteSubjectMode(@NotNull String subject) {
+        throw new UnsupportedOperationException("Aiven schema registry does not support subject mode");
     }
 }

--- a/providers/jikkou-provider-aiven/src/main/java/io/streamthoughts/jikkou/extension/aiven/api/AivenAsyncSchemaRegistryApi.java
+++ b/providers/jikkou-provider-aiven/src/main/java/io/streamthoughts/jikkou/extension/aiven/api/AivenAsyncSchemaRegistryApi.java
@@ -66,8 +66,10 @@ public final class AivenAsyncSchemaRegistryApi implements AsyncSchemaRegistryApi
     public Mono<SubjectSchemaId> registerSubjectVersion(@NotNull String subject,
                                                         @NotNull SubjectSchemaRegistration schema,
                                                         boolean normalize) {
-        // Drop references - not supported through the Aiven's API.
+        // Drop id, version, and references - not supported through the Aiven's API.
         SubjectSchemaRegistration registration = new SubjectSchemaRegistration(
+            null,
+            null,
             schema.schema(),
             schema.schemaType(),
             null

--- a/providers/jikkou-provider-aiven/src/main/java/io/streamthoughts/jikkou/extension/aiven/reconciler/AivenSchemaRegistrySubjectCollector.java
+++ b/providers/jikkou-provider-aiven/src/main/java/io/streamthoughts/jikkou/extension/aiven/reconciler/AivenSchemaRegistrySubjectCollector.java
@@ -163,7 +163,7 @@ public class AivenSchemaRegistrySubjectCollector implements Collector<V1SchemaRe
                         () -> Pair.of(subjectSchemaVersion, api.getSchemaRegistrySubjectCompatibility(subject))))
                 .thenApply(pair ->
                         // Create SchemaRegistrySubject object
-                        factory.createSchemaRegistrySubject(pair._1().version(), pair._2().compatibilityLevel())
+                        factory.createSchemaRegistrySubject(pair._1().version(), pair._2().compatibilityLevel(), null)
                 );
     }
 }

--- a/providers/jikkou-provider-schema-registry/src/integration-test/java/io/streamthoughts/jikkou/schema/registry/AbstractIntegrationTest.java
+++ b/providers/jikkou-provider-schema-registry/src/integration-test/java/io/streamthoughts/jikkou/schema/registry/AbstractIntegrationTest.java
@@ -33,42 +33,43 @@ public class AbstractIntegrationTest {
     public static final String TEST_SUBJECT = "test";
 
     public static final String AVRO_SCHEMA = """
-            {
-              "namespace": "example.avro",
-              "type": "record",
-              "name": "User",
-              "fields": [
-                 {"name": "name", "type": "string"},
-                 {"name": "favorite_number",  "type": ["int", "null"]},
-                 {"name": "favorite_color", "type": ["string", "null"]}
-              ]
-            }
-            """;
+        {
+          "namespace": "example.avro",
+          "type": "record",
+          "name": "User",
+          "fields": [
+             {"name": "name", "type": "string"},
+             {"name": "favorite_number",  "type": ["int", "null"]},
+             {"name": "favorite_color", "type": ["string", "null"]}
+          ]
+        }
+        """;
 
     private static final Network KAFKA_NETWORK = Network.newNetwork();
 
-    public static final String CONFLUENT_PLATFORM_VERSION = "7.4.0";
+    public static final String CONFLUENT_PLATFORM_VERSION = "8.0.3";
+
     @Container
     final KafkaContainer kafkaContainer = new KafkaContainer(
-            DockerImageName.parse("confluentinc/cp-kafka").withTag(CONFLUENT_PLATFORM_VERSION)).withKraft()
-            .withNetwork(KAFKA_NETWORK)
-            .withEnv("KAFKA_TRANSACTION_STATE_LOG_MIN_ISR", "1")
-            .withEnv("KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR", "1")
-            .withLogConsumer(new Slf4jLogConsumer(LOG));
+        DockerImageName.parse("confluentinc/cp-kafka").withTag(CONFLUENT_PLATFORM_VERSION)).withKraft()
+        .withNetwork(KAFKA_NETWORK)
+        .withEnv("KAFKA_TRANSACTION_STATE_LOG_MIN_ISR", "1")
+        .withEnv("KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR", "1")
+        .withLogConsumer(new Slf4jLogConsumer(LOG));
 
     @Container
     final SchemaRegistryContainer schemaRegistry =
-            new SchemaRegistryContainer(CONFLUENT_PLATFORM_VERSION)
-                    .withNetwork(KAFKA_NETWORK)
-                    .withKafka(kafkaContainer)
-                    .withLogConsumer(new Slf4jLogConsumer(LOG))
-                    .dependsOn(kafkaContainer);
+        new SchemaRegistryContainer(CONFLUENT_PLATFORM_VERSION)
+            .withNetwork(KAFKA_NETWORK)
+            .withKafka(kafkaContainer)
+            .withLogConsumer(new Slf4jLogConsumer(LOG))
+            .dependsOn(kafkaContainer);
 
     public AsyncSchemaRegistryApi getAsyncSchemaRegistryApi() {
         SchemaRegistryApi api = RestClientBuilder
-                .newBuilder()
-                .baseUri(schemaRegistry.getSchemaRegistryUrl())
-                .build(SchemaRegistryApi.class);
+            .newBuilder()
+            .baseUri(schemaRegistry.getSchemaRegistryUrl())
+            .build(SchemaRegistryApi.class);
         return new DefaultAsyncSchemaRegistryApi(api);
     }
 

--- a/providers/jikkou-provider-schema-registry/src/integration-test/java/io/streamthoughts/jikkou/schema/registry/api/AsyncSchemaRegistryApiTest.java
+++ b/providers/jikkou-provider-schema-registry/src/integration-test/java/io/streamthoughts/jikkou/schema/registry/api/AsyncSchemaRegistryApiTest.java
@@ -126,7 +126,7 @@ class AsyncSchemaRegistryApiTest {
         // When
         Mono<SubjectSchemaId> future = async.registerSubjectVersion(
                 TEST_SUBJECT,
-                new SubjectSchemaRegistration(AVRO_SCHEMA, SchemaType.AVRO),
+                new SubjectSchemaRegistration(null, null, AVRO_SCHEMA, SchemaType.AVRO),
                 true
         );
 
@@ -206,7 +206,7 @@ class AsyncSchemaRegistryApiTest {
                 TEST_SUBJECT,
                 "-1",
                 true,
-                new SubjectSchemaRegistration(AVRO_SCHEMA, SchemaType.AVRO)
+                new SubjectSchemaRegistration(null, null, AVRO_SCHEMA, SchemaType.AVRO)
         );
 
         // Then
@@ -223,7 +223,7 @@ class AsyncSchemaRegistryApiTest {
                 TEST_SUBJECT,
                 "-1",
                 true,
-                new SubjectSchemaRegistration(AVRO_SCHEMA_NOT_COMPATIBLE, SchemaType.AVRO)
+                new SubjectSchemaRegistration(null, null, AVRO_SCHEMA_NOT_COMPATIBLE, SchemaType.AVRO)
         );
 
         // Then

--- a/providers/jikkou-provider-schema-registry/src/integration-test/java/io/streamthoughts/jikkou/schema/registry/reconciler/SchemaRegistrySubjectCollectorTest.java
+++ b/providers/jikkou-provider-schema-registry/src/integration-test/java/io/streamthoughts/jikkou/schema/registry/reconciler/SchemaRegistrySubjectCollectorTest.java
@@ -26,7 +26,7 @@ class SchemaRegistrySubjectCollectorTest extends BaseExtensionProviderIT {
         AsyncSchemaRegistryApi api = getAsyncSchemaRegistryApi();
         api.registerSubjectVersion(
                 TEST_SUBJECT,
-                new SubjectSchemaRegistration(AVRO_SCHEMA, SchemaType.AVRO),
+                new SubjectSchemaRegistration(null, null, AVRO_SCHEMA, SchemaType.AVRO),
                 false
         ).block();
     }

--- a/providers/jikkou-provider-schema-registry/src/integration-test/java/io/streamthoughts/jikkou/schema/registry/reconciler/SchemaRegistrySubjectControllerTest.java
+++ b/providers/jikkou-provider-schema-registry/src/integration-test/java/io/streamthoughts/jikkou/schema/registry/reconciler/SchemaRegistrySubjectControllerTest.java
@@ -19,9 +19,11 @@ import io.streamthoughts.jikkou.core.reconciler.ChangeResult;
 import io.streamthoughts.jikkou.core.reconciler.Operation;
 import io.streamthoughts.jikkou.schema.registry.BaseExtensionProviderIT;
 import io.streamthoughts.jikkou.schema.registry.SchemaRegistryAnnotations;
+import io.streamthoughts.jikkou.schema.registry.model.Modes;
 import io.streamthoughts.jikkou.schema.registry.models.V1SchemaRegistrySubject;
 import io.streamthoughts.jikkou.schema.registry.models.V1SchemaRegistrySubjectSpec;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -56,5 +58,42 @@ class SchemaRegistrySubjectControllerTest extends BaseExtensionProviderIT {
         Assertions.assertEquals(Optional.of(1), data.getMetadata().findAnnotationByKey(SchemaRegistryAnnotations.SCHEMA_REGISTRY_SCHEMA_ID));
         Assertions.assertEquals(Operation.CREATE, data.getSpec().getOp());
         Assertions.assertEquals(SchemaType.AVRO, data.getSpec().getChanges().getLast("schemaType", TypeConverter.of(SchemaType.class)).getAfter());
+    }
+
+    @Test
+    void shouldImportSchemaForNewResource() {
+        // Given
+        V1SchemaRegistrySubject resource = V1SchemaRegistrySubject.builder()
+            .withMetadata(ObjectMeta.builder()
+                .withName(TEST_SUBJECT)
+                .withAnnotations(Map.of(
+                    SchemaRegistryAnnotations.SCHEMA_REGISTRY_SCHEMA_ID, 123,
+                    SchemaRegistryAnnotations.SCHEMA_REGISTRY_SCHEMA_VERSION, 4
+                ))
+                .build()
+            )
+            .withSpec(V1SchemaRegistrySubjectSpec
+                .builder()
+                .withSchemaType(SchemaType.AVRO)
+                .withSchema(new SchemaHandle(AVRO_SCHEMA))
+                .withMode(Modes.IMPORT)
+                .build())
+            .build();
+        // When
+        ApiChangeResultList result = api.reconcile(
+            ResourceList.of(List.of(resource)),
+            ReconciliationMode.CREATE,
+            ReconciliationContext.builder().dryRun(false).build()
+        );
+        // Then
+        List<ChangeResult> results = result.results();
+        Assertions.assertEquals(1, results.size());
+        ChangeResult change = results.getFirst();
+        ResourceChange data = change.change();
+        Assertions.assertEquals(Optional.of(123), data.getMetadata().findAnnotationByKey(SchemaRegistryAnnotations.SCHEMA_REGISTRY_SCHEMA_ID));
+        Assertions.assertEquals(Optional.of(4), data.getMetadata().findAnnotationByKey(SchemaRegistryAnnotations.SCHEMA_REGISTRY_SCHEMA_VERSION));
+        Assertions.assertEquals(Operation.CREATE, data.getSpec().getOp());
+        Assertions.assertEquals(SchemaType.AVRO, data.getSpec().getChanges().getLast("schemaType", TypeConverter.of(SchemaType.class)).getAfter());
+        Assertions.assertEquals(Modes.IMPORT, data.getSpec().getChanges().getLast("mode", TypeConverter.of(Modes.class)).getAfter());
     }
 }

--- a/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/SchemaRegistryAnnotations.java
+++ b/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/SchemaRegistryAnnotations.java
@@ -6,7 +6,10 @@
  */
 package io.streamthoughts.jikkou.schema.registry;
 
+import io.streamthoughts.jikkou.core.data.TypeConverter;
 import io.streamthoughts.jikkou.core.models.CoreAnnotations;
+import io.streamthoughts.jikkou.core.models.HasMetadata;
+import io.streamthoughts.jikkou.core.models.NamedValue;
 import io.streamthoughts.jikkou.schema.registry.models.V1SchemaRegistrySubject;
 
 public final class SchemaRegistryAnnotations {
@@ -35,5 +38,19 @@ public final class SchemaRegistryAnnotations {
 
     public boolean useCanonicalFingerPrint() {
         return CoreAnnotations.isAnnotatedWith(resource, SCHEMA_REGISTRY_USE_CANONICAL_FINGERPRINT);
+    }
+
+    public String schemaId() {
+        return HasMetadata.getMetadataAnnotation(resource, SCHEMA_REGISTRY_SCHEMA_ID)
+            .map(NamedValue::getValue)
+            .map(o -> TypeConverter.String().convertValue(o))
+            .orElse("");
+    }
+
+    public String version() {
+        return HasMetadata.getMetadataAnnotation(resource, SCHEMA_REGISTRY_SCHEMA_VERSION)
+            .map(NamedValue::getValue)
+            .map(o -> TypeConverter.String().convertValue(o))
+            .orElse("");
     }
 }

--- a/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/api/AsyncSchemaRegistryApi.java
+++ b/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/api/AsyncSchemaRegistryApi.java
@@ -89,10 +89,44 @@ public interface AsyncSchemaRegistryApi extends AutoCloseable {
      */
     Mono<CompatibilityObject> deleteSubjectCompatibilityLevel(@NotNull String subject);
 
+
     Mono<CompatibilityCheck> testCompatibility(@NotNull String subject,
                                                String version,
                                                boolean verbose,
                                                @NotNull SubjectSchemaRegistration schema);
+
+    /**
+     * Gets the schema registry global mode.
+     *
+     * @return                the mode.
+     */
+    Mono<ModeObject> getGlobalMode();
+
+    /**
+     * Gets mode level for the specified subject.
+     *
+     * @param subject         the name of the subject.
+     * @param defaultToGlobal flag to default to global mode.
+     * @return                the mode.
+     */
+    Mono<ModeObject> getSubjectMode(@NotNull String subject, boolean defaultToGlobal);
+
+    /**
+     * Updates mode for the specified subject.
+     *
+     * @param subject       the name of the subject.
+     * @param mode          the new mode for the subject.
+     * @return              the updated mode.
+     */
+    Mono<ModeObject> updateSubjectMode(@NotNull String subject, @NotNull ModeObject mode);
+
+    /**
+     * Deletes the specified subject-level mode and reverts to the global default.
+     *
+     * @param subject the name of the subject.
+     * @return        the mode.
+     */
+    Mono<ModeObject> deleteSubjectMode(@NotNull String subject);
 
     Mono<CompatibilityCheck> testCompatibilityLatest(@NotNull String subject,
                                                      boolean verbose,

--- a/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/api/DefaultAsyncSchemaRegistryApi.java
+++ b/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/api/DefaultAsyncSchemaRegistryApi.java
@@ -6,7 +6,13 @@
  */
 package io.streamthoughts.jikkou.schema.registry.api;
 
-import io.streamthoughts.jikkou.schema.registry.api.data.*;
+import io.streamthoughts.jikkou.schema.registry.api.data.CompatibilityCheck;
+import io.streamthoughts.jikkou.schema.registry.api.data.CompatibilityLevelObject;
+import io.streamthoughts.jikkou.schema.registry.api.data.CompatibilityObject;
+import io.streamthoughts.jikkou.schema.registry.api.data.ModeObject;
+import io.streamthoughts.jikkou.schema.registry.api.data.SubjectSchemaId;
+import io.streamthoughts.jikkou.schema.registry.api.data.SubjectSchemaRegistration;
+import io.streamthoughts.jikkou.schema.registry.api.data.SubjectSchemaVersion;
 import java.util.List;
 import java.util.Objects;
 import org.jetbrains.annotations.NotNull;
@@ -41,7 +47,7 @@ public final class DefaultAsyncSchemaRegistryApi implements AutoCloseable, Async
      */
     @Override
     public Mono<List<Integer>> deleteSubjectVersions(@NotNull final String subject,
-                                                                  boolean permanent) {
+                                                     boolean permanent) {
         return Mono.fromCallable(() -> api.deleteSubjectVersions(subject, permanent));
     }
 
@@ -50,8 +56,8 @@ public final class DefaultAsyncSchemaRegistryApi implements AutoCloseable, Async
      */
     @Override
     public Mono<SubjectSchemaId> registerSubjectVersion(@NotNull final String subject,
-                                                                     @NotNull final SubjectSchemaRegistration schema,
-                                                                     boolean normalize) {
+                                                        @NotNull final SubjectSchemaRegistration schema,
+                                                        boolean normalize) {
         return Mono.fromCallable(() -> api.registerSchema(subject, schema, normalize));
     }
 
@@ -77,7 +83,7 @@ public final class DefaultAsyncSchemaRegistryApi implements AutoCloseable, Async
      */
     @Override
     public Mono<CompatibilityLevelObject> getSubjectCompatibilityLevel(@NotNull final String subject,
-                                                                                    boolean defaultToGlobal) {
+                                                                       boolean defaultToGlobal) {
         return Mono.fromCallable(() -> api.getConfigCompatibility(subject, defaultToGlobal));
     }
 
@@ -86,7 +92,7 @@ public final class DefaultAsyncSchemaRegistryApi implements AutoCloseable, Async
      */
     @Override
     public Mono<CompatibilityObject> updateSubjectCompatibilityLevel(@NotNull final String subject,
-                                                                                  @NotNull final CompatibilityObject compatibility) {
+                                                                     @NotNull final CompatibilityObject compatibility) {
         return Mono.fromCallable(() -> api.updateConfigCompatibility(subject, compatibility));
     }
 
@@ -119,11 +125,11 @@ public final class DefaultAsyncSchemaRegistryApi implements AutoCloseable, Async
      */
     @Override
     public Mono<CompatibilityCheck> testCompatibility(@NotNull final String subject,
-                                                                   String version,
-                                                                   boolean verbose,
-                                                                   @NotNull final SubjectSchemaRegistration schema) {
+                                                      String version,
+                                                      boolean verbose,
+                                                      @NotNull final SubjectSchemaRegistration schema) {
         return Mono.fromCallable(
-                () -> api.testCompatibility(subject, Integer.parseInt(version), verbose, schema)
+            () -> api.testCompatibility(subject, Integer.parseInt(version), verbose, schema)
         );
     }
 

--- a/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/api/DefaultAsyncSchemaRegistryApi.java
+++ b/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/api/DefaultAsyncSchemaRegistryApi.java
@@ -6,12 +6,7 @@
  */
 package io.streamthoughts.jikkou.schema.registry.api;
 
-import io.streamthoughts.jikkou.schema.registry.api.data.CompatibilityCheck;
-import io.streamthoughts.jikkou.schema.registry.api.data.CompatibilityLevelObject;
-import io.streamthoughts.jikkou.schema.registry.api.data.CompatibilityObject;
-import io.streamthoughts.jikkou.schema.registry.api.data.SubjectSchemaId;
-import io.streamthoughts.jikkou.schema.registry.api.data.SubjectSchemaRegistration;
-import io.streamthoughts.jikkou.schema.registry.api.data.SubjectSchemaVersion;
+import io.streamthoughts.jikkou.schema.registry.api.data.*;
 import java.util.List;
 import java.util.Objects;
 import org.jetbrains.annotations.NotNull;
@@ -104,6 +99,21 @@ public final class DefaultAsyncSchemaRegistryApi implements AutoCloseable, Async
 
     }
 
+    @Override
+    public Mono<ModeObject> getSubjectMode(@NotNull String subject, boolean defaultToGlobal) {
+        return Mono.fromCallable(() -> api.getMode(subject, defaultToGlobal));
+    }
+
+    @Override
+    public Mono<ModeObject> updateSubjectMode(@NotNull String subject, @NotNull ModeObject mode) {
+        return Mono.fromCallable(() -> api.updateMode(subject, mode));
+    }
+
+    @Override
+    public Mono<ModeObject> deleteSubjectMode(@NotNull final String subject) {
+        return Mono.fromCallable(() -> api.deleteMode(subject));
+    }
+
     /**
      * @see SchemaRegistryApi#deleteConfigCompatibility(String)
      */
@@ -115,6 +125,14 @@ public final class DefaultAsyncSchemaRegistryApi implements AutoCloseable, Async
         return Mono.fromCallable(
                 () -> api.testCompatibility(subject, Integer.parseInt(version), verbose, schema)
         );
+    }
+
+    /**
+     * @see SchemaRegistryApi#getMode()
+     */
+    @Override
+    public Mono<ModeObject> getGlobalMode() {
+        return Mono.fromCallable(api::getMode);
     }
 
     /**

--- a/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/api/SchemaRegistryApi.java
+++ b/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/api/SchemaRegistryApi.java
@@ -9,6 +9,7 @@ package io.streamthoughts.jikkou.schema.registry.api;
 import io.streamthoughts.jikkou.schema.registry.api.data.CompatibilityCheck;
 import io.streamthoughts.jikkou.schema.registry.api.data.CompatibilityLevelObject;
 import io.streamthoughts.jikkou.schema.registry.api.data.CompatibilityObject;
+import io.streamthoughts.jikkou.schema.registry.api.data.ModeObject;
 import io.streamthoughts.jikkou.schema.registry.api.data.SchemaString;
 import io.streamthoughts.jikkou.schema.registry.api.data.SubjectSchemaId;
 import io.streamthoughts.jikkou.schema.registry.api.data.SubjectSchemaRegistration;
@@ -228,6 +229,44 @@ public interface SchemaRegistryApi extends AutoCloseable {
     @Path("config/{subject}")
     @Produces("application/vnd.schemaregistry.v1+json")
     CompatibilityObject deleteConfigCompatibility(@PathParam("subject") String subject);
+
+    /*
+     * ----------------------------------------------------------------------------------------------------------------
+     * MODE
+     * ----------------------------------------------------------------------------------------------------------------
+     */
+
+    /**
+     * Get the current mode for Schema Registry at a global level.
+     *
+     * @return the mode.
+     */
+    @GET
+    @Path("mode")
+    @Produces("application/vnd.schemaregistry.v1+json")
+    ModeObject getMode();
+
+    @GET
+    @Path("mode/{subject}")
+    @Produces("application/vnd.schemaregistry.v1+json")
+    ModeObject getMode(@PathParam("subject") String subject,
+                       @QueryParam("defaultToGlobal") @DefaultValue("false") boolean defaultToGlobal);
+
+    @PUT
+    @Path("mode/{subject}")
+    @Consumes({"application/vnd.schemaregistry.v1+json", "application/vnd.schemaregistry+json", "application/json"})
+    ModeObject updateMode(@PathParam("subject") String subject, ModeObject mode);
+
+    /**
+     * Deletes the specified subject-level mode and reverts to the global default.
+     *
+     * @param subject the name of the subject.
+     * @return the mode.
+     */
+    @DELETE
+    @Path("mode/{subject}")
+    @Produces("application/vnd.schemaregistry.v1+json")
+    ModeObject deleteMode(@PathParam("subject") String subject);
 
     /*
      * ----------------------------------------------------------------------------------------------------------------

--- a/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/api/data/ModeObject.java
+++ b/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/api/data/ModeObject.java
@@ -1,0 +1,32 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.jikkou.schema.registry.api.data;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.streamthoughts.jikkou.core.annotation.Reflectable;
+import java.beans.ConstructorProperties;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * ModeObject.
+ *
+ * @param mode a mode string.
+ */
+@Reflectable
+public record ModeObject(@NotNull String mode) {
+    @ConstructorProperties({
+        "mode"
+    })
+    public ModeObject {
+    }
+
+    @Override
+    @JsonProperty("mode")
+    public String mode() {
+        return mode;
+    }
+}

--- a/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/api/data/SubjectSchemaRegistration.java
+++ b/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/api/data/SubjectSchemaRegistration.java
@@ -6,6 +6,7 @@
  */
 package io.streamthoughts.jikkou.schema.registry.api.data;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.streamthoughts.jikkou.core.annotation.Reflectable;
 import io.streamthoughts.jikkou.core.data.SchemaType;
@@ -14,6 +15,10 @@ import java.util.List;
 
 @Reflectable
 public record SubjectSchemaRegistration(
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonProperty("id") String id,
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonProperty("version") String version,
     @JsonProperty("schema") String schema,
     @JsonProperty("schemaType") SchemaType schemaType,
     @JsonProperty("references") List<SubjectSchemaReference> references
@@ -25,8 +30,10 @@ public record SubjectSchemaRegistration(
      * @param schema     subject under which the schema will be registered.
      * @param schemaType the schema format.
      */
-    public SubjectSchemaRegistration(String schema,
+    public SubjectSchemaRegistration(String id,
+                                     String version,
+                                     String schema,
                                      SchemaType schemaType) {
-        this(schema, schemaType, Collections.emptyList());
+        this(id, version, schema, schemaType, Collections.emptyList());
     }
 }

--- a/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/change/SchemaSubjectChangeComputer.java
+++ b/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/change/SchemaSubjectChangeComputer.java
@@ -29,6 +29,7 @@ import org.jetbrains.annotations.NotNull;
 public final class SchemaSubjectChangeComputer extends ResourceChangeComputer<String, V1SchemaRegistrySubject> {
 
     public static final String DATA_COMPATIBILITY_LEVEL = "compatibilityLevel";
+    public static final String DATA_MODE = "mode";
     public static final String DATA_SCHEMA = "schema";
     public static final String DATA_SCHEMA_TYPE = "schemaType";
     public static final String DATA_REFERENCES = "references";
@@ -76,6 +77,11 @@ public final class SchemaSubjectChangeComputer extends ResourceChangeComputer<St
                     StateChange.create(DATA_COMPATIBILITY_LEVEL, after.getSpec().getCompatibilityLevel()));
             }
 
+            if (after.getSpec().getMode() != null) {
+                specBuilder = specBuilder.withChange(
+                    StateChange.create(DATA_MODE, after.getSpec().getMode()));
+            }
+
             return GenericResourceChange
                 .builder(V1SchemaRegistrySubject.class)
                 .withMetadata(after.getMetadata())
@@ -86,6 +92,7 @@ public final class SchemaSubjectChangeComputer extends ResourceChangeComputer<St
         @Override
         public ResourceChange createChangeForUpdate(String key, V1SchemaRegistrySubject before, V1SchemaRegistrySubject after) {
             StateChangeList<StateChange> changes = StateChangeList.emptyList()
+                .with(getChangeForMode(before, after))
                 .with(getChangeForCompatibility(before, after))
                 .with(getChangeForSchema(before, after))
                 .with(getChangeForSchemaType(before, after))
@@ -148,6 +155,16 @@ public final class SchemaSubjectChangeComputer extends ResourceChangeComputer<St
                 DATA_COMPATIBILITY_LEVEL,
                 Optional.ofNullable(before).map(o -> o.getSpec().getCompatibilityLevel()).orElse(null),
                 Optional.ofNullable(after).map(o -> o.getSpec().getCompatibilityLevel()).orElse(null)
+            );
+        }
+
+        @NotNull
+        private StateChange getChangeForMode(V1SchemaRegistrySubject before,
+                                             V1SchemaRegistrySubject after) {
+            return StateChange.with(
+                    DATA_MODE,
+                    Optional.ofNullable(before).map(o -> o.getSpec().getMode()).orElse(null),
+                    Optional.ofNullable(after).map(o -> o.getSpec().getMode()).orElse(null)
             );
         }
 

--- a/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/change/SchemaSubjectChangeComputer.java
+++ b/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/change/SchemaSubjectChangeComputer.java
@@ -116,7 +116,9 @@ public final class SchemaSubjectChangeComputer extends ResourceChangeComputer<St
             SchemaRegistryAnnotations annotations = new SchemaRegistryAnnotations(subject);
             return new SchemaSubjectChangeOptions(
                 annotations.permananteDelete(),
-                annotations.normalizeSchema()
+                annotations.normalizeSchema(),
+                annotations.schemaId(),
+                annotations.version()
             );
         }
 

--- a/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/change/SchemaSubjectChangeOptions.java
+++ b/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/change/SchemaSubjectChangeOptions.java
@@ -16,12 +16,16 @@ import java.beans.ConstructorProperties;
 @Reflectable
 public record SchemaSubjectChangeOptions(
         @JsonProperty("permanentDelete") boolean permanentDelete,
-        @JsonProperty("normalizeSchema") boolean normalizeSchema
+        @JsonProperty("normalizeSchema") boolean normalizeSchema,
+        @JsonProperty("schemaId") String schemaId,
+        @JsonProperty("version") String version
 ) {
 
     @ConstructorProperties({
             "permanentDelete",
-            "normalizeSchema"
+            "normalizeSchema",
+            "schemaId",
+            "version"
     })
     public SchemaSubjectChangeOptions {
 

--- a/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/change/handler/AbstractSchemaSubjectChangeHandler.java
+++ b/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/change/handler/AbstractSchemaSubjectChangeHandler.java
@@ -114,8 +114,12 @@ public abstract class AbstractSchemaSubjectChangeHandler implements ChangeHandle
         SchemaSubjectChangeOptions options = getSchemaSubjectChangeOptions(change);
 
         final String subjectName = change.getMetadata().getName();
+        final String id = options.schemaId();
+        final String version = options.version();
         if (LOG.isInfoEnabled()) {
-            LOG.info("Registering new Schema Registry subject version: subject '{}', optimization={}, schema={}.",
+            LOG.info("Registering new Schema Registry subject version: id '{}', version '{}' subject '{}', optimization={}, schema={}.",
+                    id,
+                    version,
                     subjectName,
                     options.normalizeSchema(),
                     schema
@@ -130,7 +134,7 @@ public abstract class AbstractSchemaSubjectChangeHandler implements ChangeHandle
         return api
                 .registerSubjectVersion(
                         subjectName,
-                        new SubjectSchemaRegistration(schema, type, references),
+                        new SubjectSchemaRegistration(id, version, schema, type, references),
                         options.normalizeSchema()
                 )
                 .handle((subjectSchemaId, sink) -> {

--- a/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/change/handler/CreateSchemaSubjectChangeHandler.java
+++ b/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/change/handler/CreateSchemaSubjectChangeHandler.java
@@ -7,6 +7,7 @@
 package io.streamthoughts.jikkou.schema.registry.change.handler;
 
 import static io.streamthoughts.jikkou.schema.registry.change.SchemaSubjectChangeComputer.DATA_COMPATIBILITY_LEVEL;
+import static io.streamthoughts.jikkou.schema.registry.change.SchemaSubjectChangeComputer.DATA_MODE;
 
 import io.streamthoughts.jikkou.core.models.change.ResourceChange;
 import io.streamthoughts.jikkou.core.models.change.StateChange;
@@ -54,11 +55,19 @@ public final class CreateSchemaSubjectChangeHandler
             Mono<Void> mono = Mono.empty();
 
             StateChange compatibilityLevels = StateChangeList
-                    .of(change.getSpec().getChanges())
-                    .getLast(DATA_COMPATIBILITY_LEVEL);
+                .of(change.getSpec().getChanges())
+                .getLast(DATA_COMPATIBILITY_LEVEL);
 
             if (compatibilityLevels != null) {
                 mono = mono.then(updateCompatibilityLevel(change));
+            }
+
+            StateChange modes = StateChangeList
+                .of(change.getSpec().getChanges())
+                .getLast(DATA_MODE);
+
+            if (modes != null) {
+                mono = mono.then(updateMode(change));
             }
 
             mono = mono.then(registerSubjectVersion(change));

--- a/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/model/Modes.java
+++ b/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/model/Modes.java
@@ -1,0 +1,20 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.jikkou.schema.registry.model;
+
+import io.streamthoughts.jikkou.core.annotation.Reflectable;
+
+/**
+ * Schema modes
+ */
+@Reflectable
+public enum Modes {
+    IMPORT,
+    READONLY,
+    READWRITE,
+    FORWARD
+}

--- a/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/models/V1SchemaRegistrySubjectSpec.java
+++ b/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/models/V1SchemaRegistrySubjectSpec.java
@@ -15,6 +15,7 @@ import io.streamthoughts.jikkou.core.data.SchemaHandle;
 import io.streamthoughts.jikkou.core.data.SchemaType;
 import io.streamthoughts.jikkou.schema.registry.api.data.SubjectSchemaReference;
 import io.streamthoughts.jikkou.schema.registry.model.CompatibilityLevels;
+import io.streamthoughts.jikkou.schema.registry.model.Modes;
 import java.beans.ConstructorProperties;
 import java.util.ArrayList;
 import java.util.List;
@@ -31,6 +32,7 @@ import lombok.extern.jackson.Jacksonized;
 @Setter
 @JsonPropertyOrder({
     "compatibilityLevel",
+    "mode",
     "schemaRegistry",
     "schemaType",
     "schema",
@@ -48,6 +50,13 @@ public class V1SchemaRegistrySubjectSpec {
     @JsonProperty("compatibilityLevel")
     @JsonPropertyDescription("The schema compatibility level for this subject.")
     private CompatibilityLevels compatibilityLevel;
+    /**
+     * The mode for this subject: IMPORT, READONLY, READWRITE.
+     * 
+     */
+    @JsonProperty("mode")
+    @JsonPropertyDescription("The mode for this subject: IMPORT, READONLY, READWRITE.")
+    private Modes mode;
     @JsonProperty("schemaRegistry")
     private SchemaRegistry schemaRegistry;
     /**
@@ -77,6 +86,7 @@ public class V1SchemaRegistrySubjectSpec {
 
     /**
      * 
+     * @param mode
      * @param schema
      * @param schemaRegistry
      * @param references
@@ -85,14 +95,16 @@ public class V1SchemaRegistrySubjectSpec {
      */
     @ConstructorProperties({
         "compatibilityLevel",
+        "mode",
         "schemaRegistry",
         "schemaType",
         "schema",
         "references"
     })
-    public V1SchemaRegistrySubjectSpec(CompatibilityLevels compatibilityLevel, SchemaRegistry schemaRegistry, SchemaType schemaType, SchemaHandle schema, List<SubjectSchemaReference> references) {
+    public V1SchemaRegistrySubjectSpec(CompatibilityLevels compatibilityLevel, Modes mode, SchemaRegistry schemaRegistry, SchemaType schemaType, SchemaHandle schema, List<SubjectSchemaReference> references) {
         super();
         this.compatibilityLevel = compatibilityLevel;
+        this.mode = mode;
         this.schemaRegistry = schemaRegistry;
         this.schemaType = schemaType;
         this.schema = schema;
@@ -106,6 +118,15 @@ public class V1SchemaRegistrySubjectSpec {
     @JsonProperty("compatibilityLevel")
     public CompatibilityLevels getCompatibilityLevel() {
         return compatibilityLevel;
+    }
+
+    /**
+     * The mode for this subject: IMPORT, READONLY, READWRITE.
+     * 
+     */
+    @JsonProperty("mode")
+    public Modes getMode() {
+        return mode;
     }
 
     @JsonProperty("schemaRegistry")
@@ -144,6 +165,10 @@ public class V1SchemaRegistrySubjectSpec {
         sb.append('=');
         sb.append(((this.compatibilityLevel == null)?"<null>":this.compatibilityLevel));
         sb.append(',');
+        sb.append("mode");
+        sb.append('=');
+        sb.append(((this.mode == null)?"<null>":this.mode));
+        sb.append(',');
         sb.append("schemaRegistry");
         sb.append('=');
         sb.append(((this.schemaRegistry == null)?"<null>":this.schemaRegistry));
@@ -171,6 +196,7 @@ public class V1SchemaRegistrySubjectSpec {
     @Override
     public int hashCode() {
         int result = 1;
+        result = ((result* 31)+((this.mode == null)? 0 :this.mode.hashCode()));
         result = ((result* 31)+((this.schemaType == null)? 0 :this.schemaType.hashCode()));
         result = ((result* 31)+((this.schema == null)? 0 :this.schema.hashCode()));
         result = ((result* 31)+((this.schemaRegistry == null)? 0 :this.schemaRegistry.hashCode()));
@@ -188,7 +214,7 @@ public class V1SchemaRegistrySubjectSpec {
             return false;
         }
         V1SchemaRegistrySubjectSpec rhs = ((V1SchemaRegistrySubjectSpec) other);
-        return ((((((this.schemaType == rhs.schemaType)||((this.schemaType!= null)&&this.schemaType.equals(rhs.schemaType)))&&((this.schema == rhs.schema)||((this.schema!= null)&&this.schema.equals(rhs.schema))))&&((this.schemaRegistry == rhs.schemaRegistry)||((this.schemaRegistry!= null)&&this.schemaRegistry.equals(rhs.schemaRegistry))))&&((this.references == rhs.references)||((this.references!= null)&&this.references.equals(rhs.references))))&&((this.compatibilityLevel == rhs.compatibilityLevel)||((this.compatibilityLevel!= null)&&this.compatibilityLevel.equals(rhs.compatibilityLevel))));
+        return (((((((this.mode == rhs.mode)||((this.mode!= null)&&this.mode.equals(rhs.mode)))&&((this.schemaType == rhs.schemaType)||((this.schemaType!= null)&&this.schemaType.equals(rhs.schemaType))))&&((this.schema == rhs.schema)||((this.schema!= null)&&this.schema.equals(rhs.schema))))&&((this.schemaRegistry == rhs.schemaRegistry)||((this.schemaRegistry!= null)&&this.schemaRegistry.equals(rhs.schemaRegistry))))&&((this.references == rhs.references)||((this.references!= null)&&this.references.equals(rhs.references))))&&((this.compatibilityLevel == rhs.compatibilityLevel)||((this.compatibilityLevel!= null)&&this.compatibilityLevel.equals(rhs.compatibilityLevel))));
     }
 
 }

--- a/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/reconciler/SchemaRegistrySubjectCollector.java
+++ b/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/reconciler/SchemaRegistrySubjectCollector.java
@@ -153,7 +153,7 @@ public class SchemaRegistrySubjectCollector extends ContextualExtension implemen
         this.prettyPrintSchema = prettyPrintSchema;
         return this;
     }
-    
+
     private static <T> Mono<T> emptyOn404(Throwable t) {
         return t instanceof RestClientException rce && isNotFound(rce)
             ? Mono.empty()

--- a/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/reconciler/SchemaRegistrySubjectCollector.java
+++ b/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/reconciler/SchemaRegistrySubjectCollector.java
@@ -6,6 +6,7 @@
  */
 package io.streamthoughts.jikkou.schema.registry.reconciler;
 
+import com.google.common.base.Strings;
 import io.streamthoughts.jikkou.core.annotation.SupportedResource;
 import io.streamthoughts.jikkou.core.config.ConfigProperty;
 import io.streamthoughts.jikkou.core.config.Configuration;
@@ -22,8 +23,11 @@ import io.streamthoughts.jikkou.schema.registry.api.AsyncSchemaRegistryApi;
 import io.streamthoughts.jikkou.schema.registry.api.DefaultAsyncSchemaRegistryApi;
 import io.streamthoughts.jikkou.schema.registry.api.SchemaRegistryApiFactory;
 import io.streamthoughts.jikkou.schema.registry.api.SchemaRegistryClientConfig;
+import io.streamthoughts.jikkou.schema.registry.api.data.CompatibilityLevelObject;
+import io.streamthoughts.jikkou.schema.registry.api.data.ModeObject;
 import io.streamthoughts.jikkou.schema.registry.collections.V1SchemaRegistrySubjectList;
 import io.streamthoughts.jikkou.schema.registry.model.CompatibilityLevels;
+import io.streamthoughts.jikkou.schema.registry.model.Modes;
 import io.streamthoughts.jikkou.schema.registry.models.V1SchemaRegistrySubject;
 import jakarta.ws.rs.core.Response;
 import java.util.List;
@@ -33,6 +37,8 @@ import reactor.core.publisher.Mono;
 
 @SupportedResource(type = V1SchemaRegistrySubject.class)
 public class SchemaRegistrySubjectCollector extends ContextualExtension implements Collector<V1SchemaRegistrySubject> {
+
+    public static final String EMPTY_STRING = "";
 
     public interface Config {
         ConfigProperty<Boolean> DEFAULT_GLOBAL_COMPATIBILITY_LEVEL = ConfigProperty
@@ -102,21 +108,33 @@ public class SchemaRegistrySubjectCollector extends ContextualExtension implemen
     private ResourceList<V1SchemaRegistrySubject> listAll(@NotNull Configuration configuration,
                                                           @NotNull Flux<String> subjects,
                                                           @NotNull AsyncSchemaRegistryApi api) {
-        Flux<V1SchemaRegistrySubject> flux = subjects
-            // Get Schema Registry Latest Subject Version
-            .flatMap(api::getLatestSubjectSchema)
-            .onErrorResume(t -> t instanceof RestClientException rce && isNotFound(rce) ? Mono.empty() : Mono.error(t))
-            // Get Schema Registry Subject Compatibility
-            .flatMap(subjectSchemaVersion -> api
-                .getSubjectCompatibilityLevel(subjectSchemaVersion.subject(), Config.DEFAULT_GLOBAL_COMPATIBILITY_LEVEL.get(configuration))
-                .map(compatibilityObject ->
-                    CompatibilityLevels.valueOf(compatibilityObject.compatibilityLevel()))
-                .map(compatibilityLevels ->
-                    schemaRegistrySubjectFactory.createSchemaRegistrySubject(subjectSchemaVersion, compatibilityLevels))
-                .onErrorResume(t -> t instanceof RestClientException rce && isNotFound(rce) ?
-                    Mono.just(schemaRegistrySubjectFactory.createSchemaRegistrySubject(subjectSchemaVersion, null)) :
-                    Mono.error(t))
-            );
+        Flux<V1SchemaRegistrySubject> flux =
+            subjects
+                // Get Schema Registry Latest Subject Version
+                .flatMap(api::getLatestSubjectSchema)
+                .onErrorResume(SchemaRegistrySubjectCollector::emptyOn404)
+                .flatMap(subjectSchemaVersion -> {
+                    // Get Schema Registry Subject Compatibility
+                    Mono<String> compatibilityMono =
+                        api.getSubjectCompatibilityLevel(
+                                subjectSchemaVersion.subject(),
+                                Config.DEFAULT_GLOBAL_COMPATIBILITY_LEVEL.get(configuration)
+                            )
+                            .map(CompatibilityLevelObject::compatibilityLevel)
+                            .onErrorResume(SchemaRegistrySubjectCollector::emptyOn404);
+                    // Get Schema Registry Subject Mode
+                    Mono<String> modeMono =
+                        api.getGlobalMode()
+                            .map(ModeObject::mode)
+                            .onErrorResume(SchemaRegistrySubjectCollector::emptyOn404);
+
+                    return Mono.zip(compatibilityMono.defaultIfEmpty(EMPTY_STRING), modeMono.defaultIfEmpty(EMPTY_STRING))
+                        .map(tuple -> {
+                            CompatibilityLevels compatibilityLevel = Strings.isNullOrEmpty(tuple.getT1()) ? null : CompatibilityLevels.valueOf(tuple.getT1());
+                            Modes mode = Strings.isNullOrEmpty(tuple.getT1()) ? null : Modes.valueOf(tuple.getT2());
+                            return schemaRegistrySubjectFactory.createSchemaRegistrySubject(subjectSchemaVersion, compatibilityLevel, mode);
+                        });
+                });
         try {
             return new V1SchemaRegistrySubjectList.Builder().withItems(flux.collectList().block()).build();
         } catch (Exception e) {
@@ -134,5 +152,11 @@ public class SchemaRegistrySubjectCollector extends ContextualExtension implemen
     SchemaRegistrySubjectCollector prettyPrintSchema(final boolean prettyPrintSchema) {
         this.prettyPrintSchema = prettyPrintSchema;
         return this;
+    }
+    
+    private static <T> Mono<T> emptyOn404(Throwable t) {
+        return t instanceof RestClientException rce && isNotFound(rce)
+            ? Mono.empty()
+            : Mono.error(t);
     }
 }

--- a/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/validation/SchemaCompatibilityValidation.java
+++ b/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/validation/SchemaCompatibilityValidation.java
@@ -60,6 +60,8 @@ public class SchemaCompatibilityValidation implements Validation<V1SchemaRegistr
         V1SchemaRegistrySubjectSpec spec = resource.getSpec();
 
         SubjectSchemaRegistration registration = new SubjectSchemaRegistration(
+                null,
+                null,
                 spec.getSchema().value(),
                 spec.getSchemaType(),
                 spec.getReferences()

--- a/providers/jikkou-provider-schema-registry/src/main/json/V1SchemaRegistrySubject.json
+++ b/providers/jikkou-provider-schema-registry/src/main/json/V1SchemaRegistrySubject.json
@@ -63,6 +63,11 @@
           "description": "The schema compatibility level for this subject.",
           "existingJavaType": "io.streamthoughts.jikkou.schema.registry.model.CompatibilityLevels"
         },
+        "mode": {
+          "type": "string",
+          "description": "The mode for this subject: IMPORT, READONLY, READWRITE.",
+          "existingJavaType": "io.streamthoughts.jikkou.schema.registry.model.Modes"
+        },
         "schemaRegistry": {
           "type": "object",
           "additionalProperties": {

--- a/providers/jikkou-provider-schema-registry/src/test/java/io/streamthoughts/jikkou/schema/registry/change/SchemaSubjectChangeComputerTest.java
+++ b/providers/jikkou-provider-schema-registry/src/test/java/io/streamthoughts/jikkou/schema/registry/change/SchemaSubjectChangeComputerTest.java
@@ -86,7 +86,9 @@ class SchemaSubjectChangeComputerTest {
                     .withOperation(Operation.CREATE)
                     .withData(Map.of(
                         "permanentDelete", false,
-                        "normalizeSchema", false
+                        "normalizeSchema", false,
+                        "schemaId", "",
+                        "version", ""
                     ))
                     .withChange(StateChange.create(DATA_SCHEMA, new SchemaAndType(SCHEMA_V1.toString(), SchemaType.AVRO)))
                     .withChange(StateChange.create(DATA_SCHEMA_TYPE, SchemaType.AVRO))
@@ -131,7 +133,9 @@ class SchemaSubjectChangeComputerTest {
                     .withOperation(Operation.NONE)
                     .withData(Map.of(
                         "permanentDelete", false,
-                        "normalizeSchema", false
+                        "normalizeSchema", false,
+                        "schemaId", "",
+                        "version", ""
                     ))
                     .withChange(StateChange.none(DATA_COMPATIBILITY_LEVEL, null))
                     .withChange(StateChange.none(DATA_SCHEMA, new SchemaAndType(SCHEMA_V1.toString(), SchemaType.AVRO)))
@@ -191,7 +195,9 @@ class SchemaSubjectChangeComputerTest {
                     .withOperation(Operation.UPDATE)
                     .withData(Map.of(
                         "permanentDelete", false,
-                        "normalizeSchema", false
+                        "normalizeSchema", false,
+                        "schemaId", "",
+                        "version", ""
                     ))
                     .withChange(StateChange.create(DATA_COMPATIBILITY_LEVEL, CompatibilityLevels.BACKWARD))
                     .withChange(StateChange.none(DATA_SCHEMA, new SchemaAndType(SCHEMA_V1.toString(), SchemaType.AVRO)))
@@ -249,7 +255,9 @@ class SchemaSubjectChangeComputerTest {
                     .withOperation(Operation.UPDATE)
                     .withData(Map.of(
                         "permanentDelete", false,
-                        "normalizeSchema", false
+                        "normalizeSchema", false,
+                        "schemaId", "",
+                        "version", ""
                     ))
                     .withChange(StateChange.none(DATA_COMPATIBILITY_LEVEL, null))
                     .withChange(StateChange.none(DATA_SCHEMA_TYPE, SchemaType.AVRO))

--- a/providers/jikkou-provider-schema-registry/src/test/resources/datasets/resource-subject-test.yaml
+++ b/providers/jikkou-provider-schema-registry/src/test/resources/datasets/resource-subject-test.yaml
@@ -8,6 +8,7 @@ metadata:
     schemaregistry.jikkou.io/normalize-schema: true
 spec:
   compatibilityLevel: "FULL_TRANSITIVE"
+  mode: "IMPORT"
   schemaType: "AVRO"
   schema:
     $ref: classpath://datasets/avro-schema.avsc


### PR DESCRIPTION
* Add support for changing mode: READWRITE, READONLY, IMPORT. [Docs](https://docs.confluent.io/platform/current/schema-registry/develop/api.html#mode)
* Add support for specifying the id and version when creating a schema subject version. [Docs](https://docs.confluent.io/platform/current/schema-registry/develop/api.html#mode)