### PR TITLE
Add `SubjectNameRegexValidation` to support regex-based validation of subject names

### DIFF
--- a/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/SchemaRegistryExtensionProvider.java
+++ b/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/SchemaRegistryExtensionProvider.java
@@ -27,6 +27,7 @@ import io.streamthoughts.jikkou.schema.registry.transform.NormalizeSubjectSchema
 import io.streamthoughts.jikkou.schema.registry.validation.AvroSchemaValidation;
 import io.streamthoughts.jikkou.schema.registry.validation.CompatibilityLevelValidation;
 import io.streamthoughts.jikkou.schema.registry.validation.SchemaCompatibilityValidation;
+import io.streamthoughts.jikkou.schema.registry.validation.SubjectNameRegexValidation;
 import io.streamthoughts.jikkou.spi.BaseExtensionProvider;
 import org.jetbrains.annotations.NotNull;
 
@@ -116,6 +117,7 @@ public final class SchemaRegistryExtensionProvider extends BaseExtensionProvider
         registry.register(AvroSchemaValidation.class, AvroSchemaValidation::new);
         registry.register(SchemaCompatibilityValidation.class, SchemaCompatibilityValidation::new);
         registry.register(CompatibilityLevelValidation.class, CompatibilityLevelValidation::new);
+        registry.register(SubjectNameRegexValidation.class, SubjectNameRegexValidation::new);
 
         // Transformations
         registry.register(NormalizeSubjectSchemaTransformation.class, NormalizeSubjectSchemaTransformation::new);

--- a/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/validation/SubjectNameRegexValidation.java
+++ b/providers/jikkou-provider-schema-registry/src/main/java/io/streamthoughts/jikkou/schema/registry/validation/SubjectNameRegexValidation.java
@@ -1,0 +1,109 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.jikkou.schema.registry.validation;
+
+import io.streamthoughts.jikkou.core.annotation.Example;
+import io.streamthoughts.jikkou.core.annotation.SupportedResource;
+import io.streamthoughts.jikkou.core.annotation.Title;
+import io.streamthoughts.jikkou.core.config.ConfigProperty;
+import io.streamthoughts.jikkou.core.config.Configuration;
+import io.streamthoughts.jikkou.core.exceptions.ConfigException;
+import io.streamthoughts.jikkou.core.exceptions.ValidationException;
+import io.streamthoughts.jikkou.core.extension.ExtensionContext;
+import io.streamthoughts.jikkou.core.validation.Validation;
+import io.streamthoughts.jikkou.core.validation.ValidationError;
+import io.streamthoughts.jikkou.core.validation.ValidationResult;
+import io.streamthoughts.jikkou.schema.registry.models.V1SchemaRegistrySubject;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+import org.jetbrains.annotations.NotNull;
+
+@Title("SubjectNameRegexValidation ensures that subject names conform to a specified regular expression.")
+@Example(
+        title = "Validate that subject names conform to a defined regex.",
+        full = true,
+        code = {"""
+                validations:
+                - name: "subjectMustHaveValidName"
+                  type: "io.streamthoughts.jikkou.schema.registry.validation.SubjectNameRegexValidation"
+                  priority: 100
+                  config:
+                    subjectNameRegex: "[a-zA-Z0-9\\\\._\\\\-]+"
+                """
+        }
+)
+
+@SupportedResource(type = V1SchemaRegistrySubject.class)
+public class SubjectNameRegexValidation implements Validation<V1SchemaRegistrySubject> {
+
+    public static final ConfigProperty<String> VALIDATION_SUBJECT_NAME_REGEX_CONFIG = ConfigProperty
+            .ofString("subjectNameRegex");
+
+    private Pattern pattern;
+
+    /**
+     * Empty constructor used by {@link Configuration}.
+     */
+    public SubjectNameRegexValidation() {}
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void init(@NotNull final ExtensionContext context) {
+        final Optional<String> regex = VALIDATION_SUBJECT_NAME_REGEX_CONFIG.getOptional(context.configuration());
+        pattern = regex
+                .map(pattern -> {
+                    if (pattern.isEmpty()) {
+                        throw new ConfigException(
+                                String.format("The '%s' configuration property is set with an empty regexp",
+                                        VALIDATION_SUBJECT_NAME_REGEX_CONFIG.key()
+                                )
+                        );
+                    }
+                    return pattern;
+                })
+                .map(this::compile)
+                .orElseThrow(() -> new ConfigException(
+                        String.format("The '%s' configuration property is required for %s",
+                                VALIDATION_SUBJECT_NAME_REGEX_CONFIG.key(),
+                                SubjectNameRegexValidation.class.getSimpleName()
+                        )
+                ));
+
+    }
+
+    private Pattern compile(final String regex) {
+        try {
+            return Pattern.compile(regex);
+        } catch (PatternSyntaxException e) {
+            throw new ConfigException(
+                    String.format("The '%s' configuration property is set with an invalid regexp '%s'",
+                            VALIDATION_SUBJECT_NAME_REGEX_CONFIG.key(),
+                            regex
+                    )
+            );
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ValidationResult validate(final @NotNull V1SchemaRegistrySubject resource) throws ValidationException {
+        if (!pattern.matcher(resource.getMetadata().getName()).matches()) {
+            String error = String.format(
+                    "Name for subject '%s' does not match the configured regex: %s",
+                    resource.getMetadata().getName(),
+                    pattern
+            );
+            return ValidationResult.failure(new ValidationError(getName(), resource, error));
+        }
+        return ValidationResult.success();
+    }
+}

--- a/providers/jikkou-provider-schema-registry/src/test/java/io/streamthoughts/jikkou/schema/registry/SchemaRegistryExtensionProviderTest.java
+++ b/providers/jikkou-provider-schema-registry/src/test/java/io/streamthoughts/jikkou/schema/registry/SchemaRegistryExtensionProviderTest.java
@@ -100,6 +100,6 @@ class SchemaRegistryExtensionProviderTest {
         List<ExtensionDescriptor<Validation>> allSchemaValidationDescriptors = registry
                 .findAllDescriptorsByClass(Validation.class,
                         Qualifiers.bySupportedResource(ResourceType.of(V1SchemaRegistrySubject.class)));
-        Assertions.assertEquals(3, allSchemaValidationDescriptors.size());
+        Assertions.assertEquals(4, allSchemaValidationDescriptors.size());
     }
 }

--- a/providers/jikkou-provider-schema-registry/src/test/java/io/streamthoughts/jikkou/schema/registry/validation/SubjectNameRegexValidationTest.java
+++ b/providers/jikkou-provider-schema-registry/src/test/java/io/streamthoughts/jikkou/schema/registry/validation/SubjectNameRegexValidationTest.java
@@ -1,0 +1,72 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.jikkou.schema.registry.validation;
+
+import static io.streamthoughts.jikkou.schema.registry.validation.SubjectNameRegexValidation.VALIDATION_SUBJECT_NAME_REGEX_CONFIG;
+
+import io.streamthoughts.jikkou.core.config.Configuration;
+import io.streamthoughts.jikkou.core.exceptions.ConfigException;
+import io.streamthoughts.jikkou.core.extension.ExtensionContext;
+import io.streamthoughts.jikkou.core.models.ObjectMeta;
+import io.streamthoughts.jikkou.core.validation.ValidationResult;
+import io.streamthoughts.jikkou.schema.registry.models.V1SchemaRegistrySubject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class SubjectNameRegexValidationTest {
+
+    SubjectNameRegexValidation validation;
+
+    @BeforeEach
+    void before() {
+        validation = new SubjectNameRegexValidation();
+    }
+
+    @Test
+    void shouldThrowExceptionForMissingConfig() {
+        ExtensionContext context = Mockito.mock(ExtensionContext.class);
+        Mockito.when(context.configuration()).thenReturn(Configuration.empty());
+        Assertions.assertThrows(ConfigException.class, () -> validation.init(context));
+    }
+
+    @Test
+    void shouldThrowExceptionForInvalidRegex() {
+        // Given
+        ExtensionContext context = Mockito.mock(ExtensionContext.class);
+        Mockito.when(context.configuration()).thenReturn(VALIDATION_SUBJECT_NAME_REGEX_CONFIG.asConfiguration(""));
+
+        // When
+        Assertions.assertThrows(ConfigException.class, () -> new SubjectNameRegexValidation().init(context));
+    }
+
+    @Test
+    void shouldNotThrowExceptionForSubjectNameNotMatching() {
+        // Given
+        ExtensionContext context = Mockito.mock(ExtensionContext.class);
+        Mockito.when(context.configuration()).thenReturn(VALIDATION_SUBJECT_NAME_REGEX_CONFIG.asConfiguration("(test)(|-(key|value))"));
+
+        var validation = new SubjectNameRegexValidation();
+        validation.init(context);
+
+        new SubjectNameRegexValidation();
+        var subject = V1SchemaRegistrySubject.builder()
+                .withMetadata(ObjectMeta
+                        .builder()
+                        .withName("test-key")
+                        .build()
+                )
+                .build();
+
+        // When
+        ValidationResult result = validation.validate(subject);
+
+        // Then
+        Assertions.assertTrue(result.isValid());
+    }
+}


### PR DESCRIPTION
This PR adds `SubjectNameRegexValidation`, a new validation class that complements the existing `TopicNameRegexValidation`. It allows enforcing naming conventions for Schema Registry subjects using a user‑defined regular expression.