### PR TITLE
fix(server): use blocking executor for API resources

### DIFF
--- a/server/jikkou-api-server/src/main/java/io/streamthoughts/jikkou/rest/resources/ApiActionResource.java
+++ b/server/jikkou-api-server/src/main/java/io/streamthoughts/jikkou/rest/resources/ApiActionResource.java
@@ -17,6 +17,8 @@ import io.micronaut.http.annotation.PathVariable;
 import io.micronaut.http.annotation.Post;
 import io.micronaut.http.annotation.Produces;
 import io.micronaut.http.hateoas.Link;
+import io.micronaut.scheduling.TaskExecutors;
+import io.micronaut.scheduling.annotation.ExecuteOn;
 import io.micronaut.security.annotation.Secured;
 import io.micronaut.security.rules.SecurityRule;
 import io.streamthoughts.jikkou.core.JikkouApi;
@@ -33,6 +35,7 @@ import java.util.Objects;
 
 @Controller("/api/v1/actions")
 @Secured(SecurityRule.IS_AUTHENTICATED)
+@ExecuteOn(TaskExecutors.BLOCKING)
 public class ApiActionResource extends AbstractController {
 
     private final JikkouApi api;

--- a/server/jikkou-api-server/src/main/java/io/streamthoughts/jikkou/rest/resources/ApiExtensionResource.java
+++ b/server/jikkou-api-server/src/main/java/io/streamthoughts/jikkou/rest/resources/ApiExtensionResource.java
@@ -14,6 +14,8 @@ import io.micronaut.http.annotation.PathVariable;
 import io.micronaut.http.annotation.Produces;
 import io.micronaut.http.annotation.QueryValue;
 import io.micronaut.http.hateoas.Link;
+import io.micronaut.scheduling.TaskExecutors;
+import io.micronaut.scheduling.annotation.ExecuteOn;
 import io.micronaut.security.annotation.Secured;
 import io.micronaut.security.rules.SecurityRule;
 import io.streamthoughts.jikkou.common.utils.Strings;
@@ -30,6 +32,7 @@ import org.jetbrains.annotations.NotNull;
 
 @Controller("/api/v1/extensions")
 @Secured(SecurityRule.IS_AUTHENTICATED)
+@ExecuteOn(TaskExecutors.BLOCKING)
 public class ApiExtensionResource extends AbstractController {
 
     private static final String NO_VALUE = "";

--- a/server/jikkou-api-server/src/main/java/io/streamthoughts/jikkou/rest/resources/ApiGroupListResource.java
+++ b/server/jikkou-api-server/src/main/java/io/streamthoughts/jikkou/rest/resources/ApiGroupListResource.java
@@ -13,6 +13,8 @@ import io.micronaut.http.annotation.Get;
 import io.micronaut.http.annotation.Produces;
 import io.micronaut.http.hateoas.Link;
 import io.micronaut.http.hateoas.Resource;
+import io.micronaut.scheduling.TaskExecutors;
+import io.micronaut.scheduling.annotation.ExecuteOn;
 import io.micronaut.security.annotation.Secured;
 import io.micronaut.security.rules.SecurityRule;
 import io.streamthoughts.jikkou.core.JikkouApi;
@@ -32,6 +34,7 @@ import org.jetbrains.annotations.NotNull;
 
 @Controller("/apis")
 @Secured(SecurityRule.IS_AUTHENTICATED)
+@ExecuteOn(TaskExecutors.BLOCKING)
 public class ApiGroupListResource extends AbstractController {
 
     private final JikkouApi api;

--- a/server/jikkou-api-server/src/main/java/io/streamthoughts/jikkou/rest/resources/ApiResource.java
+++ b/server/jikkou-api-server/src/main/java/io/streamthoughts/jikkou/rest/resources/ApiResource.java
@@ -23,6 +23,8 @@ import io.micronaut.http.annotation.PathVariable;
 import io.micronaut.http.annotation.Post;
 import io.micronaut.http.annotation.QueryValue;
 import io.micronaut.http.hateoas.Link;
+import io.micronaut.scheduling.TaskExecutors;
+import io.micronaut.scheduling.annotation.ExecuteOn;
 import io.micronaut.security.annotation.Secured;
 import io.micronaut.security.rules.SecurityRule;
 import io.streamthoughts.jikkou.core.ReconciliationContext;
@@ -49,6 +51,7 @@ import org.jetbrains.annotations.NotNull;
 
 @Controller
 @Secured(SecurityRule.IS_AUTHENTICATED)
+@ExecuteOn(TaskExecutors.BLOCKING)
 public class ApiResource extends AbstractController {
 
     private final ReconciliationContextAdapter adapter;


### PR DESCRIPTION
**Fix blocking calls on Netty event loop**

Controllers performing blocking Kafka Admin operations or calls to the Schema Registy calls were previously executing on Micronaut’s Netty event loop, causing runtime errors like IllegalStateException: block() not allowed on Netty event loop. 

This PR adds @ExecuteOn(TaskExecutors.BLOCKING) to those controllers, moving execution to the blocking thread pool. No functional changes, only ensures safe threading for the endpoints.