### PR TITLE
fix(kafka-connect): support initial_state when creating connectors

### DIFF
--- a/providers/jikkou-provider-kafka-connect/src/main/java/io/streamthoughts/jikkou/kafka/connect/api/KafkaConnectApi.java
+++ b/providers/jikkou-provider-kafka-connect/src/main/java/io/streamthoughts/jikkou/kafka/connect/api/KafkaConnectApi.java
@@ -7,6 +7,7 @@
 package io.streamthoughts.jikkou.kafka.connect.api;
 
 import io.streamthoughts.jikkou.kafka.connect.api.data.ConnectCluster;
+import io.streamthoughts.jikkou.kafka.connect.api.data.ConnectorCreateRequest;
 import io.streamthoughts.jikkou.kafka.connect.api.data.ConnectorInfoResponse;
 import io.streamthoughts.jikkou.kafka.connect.api.data.ConnectorStatusResponse;
 import jakarta.ws.rs.Consumes;
@@ -57,6 +58,19 @@ public interface KafkaConnectApi extends AutoCloseable {
     @GET
     @Path("connectors")
     List<String> listConnectors();
+
+    /**
+     * Create a new connector with the given configuration and optional initial state.
+     * This method supports KIP-980, allowing the connector to be created in a specific
+     * initial state (RUNNING, STOPPED, or PAUSED).
+     *
+     * @param request the connector creation request containing name, config, and optional initial state.
+     * @return information about the created connector
+     */
+    @POST
+    @Path("connectors")
+    @Consumes(MediaType.APPLICATION_JSON)
+    ConnectorInfoResponse createConnector(ConnectorCreateRequest request);
 
     /**
      * Create a new connector using the given configuration, or update the configuration

--- a/providers/jikkou-provider-kafka-connect/src/main/java/io/streamthoughts/jikkou/kafka/connect/api/data/ConnectorCreateRequest.java
+++ b/providers/jikkou-provider-kafka-connect/src/main/java/io/streamthoughts/jikkou/kafka/connect/api/data/ConnectorCreateRequest.java
@@ -1,0 +1,41 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.jikkou.kafka.connect.api.data;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.streamthoughts.jikkou.core.annotation.Reflectable;
+import jakarta.validation.constraints.NotNull;
+import java.io.Serializable;
+import java.util.Map;
+
+/**
+ * Request body for creating a new connector via POST /connectors.
+ *
+ * @param name         the name of the connector.
+ * @param config       the configuration of the connector.
+ * @param initialState the initial state of the connector (RUNNING, STOPPED, or PAUSED).
+ *                     This field is optional; if not specified, the connector starts in RUNNING state.
+ * @see io.streamthoughts.jikkou.kafka.connect.api.KafkaConnectApi#createConnector(ConnectorCreateRequest)
+ */
+@Reflectable
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ConnectorCreateRequest(@JsonProperty("name") @NotNull String name,
+                                     @JsonProperty("config") @NotNull Map<String, Object> config,
+                                     @JsonProperty("initial_state") String initialState
+) implements Serializable {
+
+    /**
+     * Creates a ConnectorCreateRequest with default RUNNING state.
+     *
+     * @param name   the connector name.
+     * @param config the connector configuration.
+     */
+    public ConnectorCreateRequest(String name, Map<String, Object> config) {
+        this(name, config, null);
+    }
+}

--- a/providers/jikkou-provider-kafka-connect/src/test/java/io/streamthoughts/jikkou/kafka/connect/change/KafkaConnectorChangeHandlerTest.java
+++ b/providers/jikkou-provider-kafka-connect/src/test/java/io/streamthoughts/jikkou/kafka/connect/change/KafkaConnectorChangeHandlerTest.java
@@ -15,10 +15,12 @@ import io.streamthoughts.jikkou.core.models.change.StateChange;
 import io.streamthoughts.jikkou.core.reconciler.ChangeResponse;
 import io.streamthoughts.jikkou.core.reconciler.Operation;
 import io.streamthoughts.jikkou.kafka.connect.api.KafkaConnectApi;
+import io.streamthoughts.jikkou.kafka.connect.api.data.ConnectorCreateRequest;
 import io.streamthoughts.jikkou.kafka.connect.models.KafkaConnectorState;
 import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 class KafkaConnectorChangeHandlerTest {
@@ -26,7 +28,7 @@ class KafkaConnectorChangeHandlerTest {
     public static final String TEST_CONNECTOR_NAME = "test";
 
     @Test
-    void shouldUpdateConfigForAddChange() {
+    void shouldCreateConnectorWithNoInitialStateForRunningState() {
         KafkaConnectApi mkKafkaConnectApi = Mockito.mock(KafkaConnectApi.class);
         KafkaConnectorChangeHandler handler = new KafkaConnectorChangeHandler(mkKafkaConnectApi, TEST_CONNECTOR_NAME);
 
@@ -51,8 +53,86 @@ class KafkaConnectorChangeHandlerTest {
         Assertions.assertEquals(1, results.size());
 
         AsyncUtils.getValue(results.getFirst().getResults());
+
+        ArgumentCaptor<ConnectorCreateRequest> requestCaptor = ArgumentCaptor.forClass(ConnectorCreateRequest.class);
         Mockito.verify(mkKafkaConnectApi, Mockito.times(1))
-                .createOrUpdateConnector(Mockito.eq(TEST_CONNECTOR_NAME), Mockito.anyMap());
+                .createConnector(requestCaptor.capture());
+
+        ConnectorCreateRequest request = requestCaptor.getValue();
+        Assertions.assertEquals(TEST_CONNECTOR_NAME, request.name());
+        Assertions.assertNull(request.initialState());
+    }
+
+    @Test
+    void shouldCreateConnectorWithStoppedInitialState() {
+        KafkaConnectApi mkKafkaConnectApi = Mockito.mock(KafkaConnectApi.class);
+        KafkaConnectorChangeHandler handler = new KafkaConnectorChangeHandler(mkKafkaConnectApi, TEST_CONNECTOR_NAME);
+
+        ResourceChange change = GenericResourceChange
+                .builder()
+                .withMetadata(ObjectMeta
+                        .builder()
+                        .withName(TEST_CONNECTOR_NAME)
+                        .build()
+                )
+                .withSpec(ResourceChangeSpec
+                        .builder()
+                        .withOperation(Operation.CREATE)
+                        .withChange(StateChange.create("connectorClass", "???"))
+                        .withChange(StateChange.create("tasksMax", 1))
+                        .withChange(StateChange.create("state", KafkaConnectorState.STOPPED))
+                        .build()
+                )
+                .build();
+
+        List<ChangeResponse> results = handler.handleChanges(List.of(change));
+        Assertions.assertEquals(1, results.size());
+
+        AsyncUtils.getValue(results.getFirst().getResults());
+
+        ArgumentCaptor<ConnectorCreateRequest> requestCaptor = ArgumentCaptor.forClass(ConnectorCreateRequest.class);
+        Mockito.verify(mkKafkaConnectApi, Mockito.times(1))
+                .createConnector(requestCaptor.capture());
+
+        ConnectorCreateRequest request = requestCaptor.getValue();
+        Assertions.assertEquals(TEST_CONNECTOR_NAME, request.name());
+        Assertions.assertEquals("STOPPED", request.initialState());
+    }
+
+    @Test
+    void shouldCreateConnectorWithPausedInitialState() {
+        KafkaConnectApi mkKafkaConnectApi = Mockito.mock(KafkaConnectApi.class);
+        KafkaConnectorChangeHandler handler = new KafkaConnectorChangeHandler(mkKafkaConnectApi, TEST_CONNECTOR_NAME);
+
+        ResourceChange change = GenericResourceChange
+                .builder()
+                .withMetadata(ObjectMeta
+                        .builder()
+                        .withName(TEST_CONNECTOR_NAME)
+                        .build()
+                )
+                .withSpec(ResourceChangeSpec
+                        .builder()
+                        .withOperation(Operation.CREATE)
+                        .withChange(StateChange.create("connectorClass", "???"))
+                        .withChange(StateChange.create("tasksMax", 1))
+                        .withChange(StateChange.create("state", KafkaConnectorState.PAUSED))
+                        .build()
+                )
+                .build();
+
+        List<ChangeResponse> results = handler.handleChanges(List.of(change));
+        Assertions.assertEquals(1, results.size());
+
+        AsyncUtils.getValue(results.getFirst().getResults());
+
+        ArgumentCaptor<ConnectorCreateRequest> requestCaptor = ArgumentCaptor.forClass(ConnectorCreateRequest.class);
+        Mockito.verify(mkKafkaConnectApi, Mockito.times(1))
+                .createConnector(requestCaptor.capture());
+
+        ConnectorCreateRequest request = requestCaptor.getValue();
+        Assertions.assertEquals(TEST_CONNECTOR_NAME, request.name());
+        Assertions.assertEquals("PAUSED", request.initialState());
     }
 
     @Test


### PR DESCRIPTION
…IP-980)

This fixes issue #637 where connectors could not be created with an initial state of STOPPED or PAUSED. The connector would always start in RUNNING state regardless of the desired state specified in the YAML configuration.

Changes:
- Add ConnectorCreateRequest record for POST /connectors API
- Add createConnector method to KafkaConnectApi using POST endpoint
- Update KafkaConnectorChangeHandler to use POST with initial_state for CREATE
- Update tests to verify initial_state is passed correctly

Closes #637