### PR TITLE
fix(schema-registry): perform soft delete before hard delete for permanent deletion

### DIFF
--- a/providers/jikkou-provider-aiven/src/test/java/io/streamthoughts/jikkou/extension/aiven/api/AivenAsyncSchemaRegistryApiTest.java
+++ b/providers/jikkou-provider-aiven/src/test/java/io/streamthoughts/jikkou/extension/aiven/api/AivenAsyncSchemaRegistryApiTest.java
@@ -1,0 +1,54 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.jikkou.extension.aiven.api;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.streamthoughts.jikkou.extension.aiven.api.data.MessageErrorsResponse;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+class AivenAsyncSchemaRegistryApiTest {
+
+    private static final String TEST_SUBJECT = "test-subject";
+
+    @Test
+    void shouldCallDeleteWhenPermanentIsFalse() {
+        // Given
+        AivenApiClient apiClient = mock(AivenApiClient.class);
+        when(apiClient.deleteSchemaRegistrySubject(eq(TEST_SUBJECT)))
+                .thenReturn(new MessageErrorsResponse("", Collections.emptyList()));
+
+        AivenAsyncSchemaRegistryApi api = new AivenAsyncSchemaRegistryApi(apiClient);
+
+        // When
+        api.deleteSubjectVersions(TEST_SUBJECT, false).block();
+
+        // Then
+        verify(apiClient, times(1)).deleteSchemaRegistrySubject(TEST_SUBJECT);
+    }
+
+    @Test
+    void shouldCallDeleteWhenPermanentIsTrue() {
+        // Given
+        AivenApiClient apiClient = mock(AivenApiClient.class);
+        when(apiClient.deleteSchemaRegistrySubject(eq(TEST_SUBJECT)))
+                .thenReturn(new MessageErrorsResponse("", Collections.emptyList()));
+
+        AivenAsyncSchemaRegistryApi api = new AivenAsyncSchemaRegistryApi(apiClient);
+
+        // When
+        api.deleteSubjectVersions(TEST_SUBJECT, true).block();
+
+        // Then
+        verify(apiClient, times(1)).deleteSchemaRegistrySubject(TEST_SUBJECT);
+    }
+}

--- a/providers/jikkou-provider-schema-registry/src/integration-test/java/io/streamthoughts/jikkou/schema/registry/reconciler/SchemaRegistrySubjectDeleteTest.java
+++ b/providers/jikkou-provider-schema-registry/src/integration-test/java/io/streamthoughts/jikkou/schema/registry/reconciler/SchemaRegistrySubjectDeleteTest.java
@@ -1,0 +1,134 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.jikkou.schema.registry.reconciler;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.streamthoughts.jikkou.core.ReconciliationContext;
+import io.streamthoughts.jikkou.core.ReconciliationMode;
+import io.streamthoughts.jikkou.core.config.Configuration;
+import io.streamthoughts.jikkou.core.data.SchemaHandle;
+import io.streamthoughts.jikkou.core.data.SchemaType;
+import io.streamthoughts.jikkou.core.models.ApiChangeResultList;
+import io.streamthoughts.jikkou.core.models.CoreAnnotations;
+import io.streamthoughts.jikkou.core.models.ObjectMeta;
+import io.streamthoughts.jikkou.core.models.ResourceList;
+import io.streamthoughts.jikkou.core.models.change.ResourceChange;
+import io.streamthoughts.jikkou.core.reconciler.ChangeResult;
+import io.streamthoughts.jikkou.core.reconciler.Operation;
+import io.streamthoughts.jikkou.core.selector.Selectors;
+import io.streamthoughts.jikkou.schema.registry.BaseExtensionProviderIT;
+import io.streamthoughts.jikkou.schema.registry.SchemaRegistryAnnotations;
+import io.streamthoughts.jikkou.schema.registry.models.V1SchemaRegistrySubject;
+import io.streamthoughts.jikkou.schema.registry.models.V1SchemaRegistrySubjectSpec;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class SchemaRegistrySubjectDeleteTest extends BaseExtensionProviderIT {
+
+    @Test
+    void shouldSoftDeleteSchemaSubject() {
+        // Given - register a schema first
+        V1SchemaRegistrySubject resource = createSubjectResource(TEST_SUBJECT);
+        api.reconcile(
+                ResourceList.of(List.of(resource)),
+                ReconciliationMode.CREATE,
+                ReconciliationContext.builder().dryRun(false).build());
+
+        // When - delete the schema (soft delete only)
+        V1SchemaRegistrySubject deleteResource = V1SchemaRegistrySubject.builder()
+                .withMetadata(ObjectMeta.builder()
+                        .withName(TEST_SUBJECT)
+                        .withAnnotations(Map.of(
+                                CoreAnnotations.JIKKOU_IO_DELETE, true))
+                        .build())
+                .withSpec(V1SchemaRegistrySubjectSpec.builder()
+                        .withSchemaType(SchemaType.AVRO)
+                        .withSchema(new SchemaHandle(AVRO_SCHEMA))
+                        .build())
+                .build();
+
+        ApiChangeResultList result = api.reconcile(
+                ResourceList.of(List.of(deleteResource)),
+                ReconciliationMode.DELETE,
+                ReconciliationContext.builder().dryRun(false).build());
+
+        // Then
+        List<ChangeResult> results = result.results();
+        assertEquals(1, results.size());
+        ResourceChange change = results.getFirst().change();
+        assertEquals(Operation.DELETE, change.getSpec().getOp());
+
+        // Verify subject is no longer listed
+        ResourceList<V1SchemaRegistrySubject> subjects =
+                api.listResources(V1SchemaRegistrySubject.class, Selectors.NO_SELECTOR, Configuration.empty());
+        assertTrue(subjects.stream().noneMatch(s -> TEST_SUBJECT.equals(s.getMetadata().getName())));
+    }
+
+    @Test
+    void shouldPermanentlyDeleteSchemaSubject() {
+        // Given - register a schema first
+        V1SchemaRegistrySubject resource = createSubjectResource(TEST_SUBJECT);
+        api.reconcile(
+                ResourceList.of(List.of(resource)),
+                ReconciliationMode.CREATE,
+                ReconciliationContext.builder().dryRun(false).build());
+
+        // When - permanently delete the schema (soft + hard delete)
+        V1SchemaRegistrySubject deleteResource = V1SchemaRegistrySubject.builder()
+                .withMetadata(ObjectMeta.builder()
+                        .withName(TEST_SUBJECT)
+                        .withAnnotations(Map.of(
+                                CoreAnnotations.JIKKOU_IO_DELETE, true,
+                                SchemaRegistryAnnotations.SCHEMA_REGISTRY_PERMANANTE_DELETE, true))
+                        .build())
+                .withSpec(V1SchemaRegistrySubjectSpec.builder()
+                        .withSchemaType(SchemaType.AVRO)
+                        .withSchema(new SchemaHandle(AVRO_SCHEMA))
+                        .build())
+                .build();
+
+        ApiChangeResultList result = api.reconcile(
+                ResourceList.of(List.of(deleteResource)),
+                ReconciliationMode.DELETE,
+                ReconciliationContext.builder().dryRun(false).build());
+
+        // Then
+        List<ChangeResult> results = result.results();
+        assertEquals(1, results.size());
+        ResourceChange change = results.getFirst().change();
+        assertEquals(Operation.DELETE, change.getSpec().getOp());
+
+        // Verify subject is no longer listed
+        ResourceList<V1SchemaRegistrySubject> subjects =
+                api.listResources(V1SchemaRegistrySubject.class, Selectors.NO_SELECTOR, Configuration.empty());
+        assertTrue(subjects.stream().noneMatch(s -> TEST_SUBJECT.equals(s.getMetadata().getName())));
+
+        // Verify the subject can be re-registered (only possible after hard delete)
+        V1SchemaRegistrySubject reRegister = createSubjectResource(TEST_SUBJECT);
+        ApiChangeResultList reRegisterResult = api.reconcile(
+                ResourceList.of(List.of(reRegister)),
+                ReconciliationMode.CREATE,
+                ReconciliationContext.builder().dryRun(false).build());
+        assertEquals(1, reRegisterResult.results().size());
+        assertEquals(Operation.CREATE, reRegisterResult.results().getFirst().change().getSpec().getOp());
+    }
+
+    private V1SchemaRegistrySubject createSubjectResource(String subjectName) {
+        return V1SchemaRegistrySubject.builder()
+                .withMetadata(ObjectMeta.builder()
+                        .withName(subjectName)
+                        .build())
+                .withSpec(V1SchemaRegistrySubjectSpec.builder()
+                        .withSchemaType(SchemaType.AVRO)
+                        .withSchema(new SchemaHandle(AVRO_SCHEMA))
+                        .build())
+                .build();
+    }
+}

--- a/providers/jikkou-provider-schema-registry/src/test/java/io/streamthoughts/jikkou/schema/registry/api/DefaultAsyncSchemaRegistryApiTest.java
+++ b/providers/jikkou-provider-schema-registry/src/test/java/io/streamthoughts/jikkou/schema/registry/api/DefaultAsyncSchemaRegistryApiTest.java
@@ -1,0 +1,52 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.jikkou.schema.registry.api;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class DefaultAsyncSchemaRegistryApiTest {
+
+    private static final String TEST_SUBJECT = "test-subject";
+
+    @Test
+    void shouldDelegateSoftDeleteToApi() {
+        // Given
+        SchemaRegistryApi schemaRegistryApi = mock(SchemaRegistryApi.class);
+        when(schemaRegistryApi.deleteSubjectVersions(eq(TEST_SUBJECT), eq(false)))
+                .thenReturn(List.of(1, 2));
+
+        DefaultAsyncSchemaRegistryApi asyncApi = new DefaultAsyncSchemaRegistryApi(schemaRegistryApi);
+
+        // When
+        asyncApi.deleteSubjectVersions(TEST_SUBJECT, false).block();
+
+        // Then
+        verify(schemaRegistryApi).deleteSubjectVersions(TEST_SUBJECT, false);
+    }
+
+    @Test
+    void shouldDelegateHardDeleteToApi() {
+        // Given
+        SchemaRegistryApi schemaRegistryApi = mock(SchemaRegistryApi.class);
+        when(schemaRegistryApi.deleteSubjectVersions(eq(TEST_SUBJECT), eq(true)))
+                .thenReturn(List.of(1, 2));
+
+        DefaultAsyncSchemaRegistryApi asyncApi = new DefaultAsyncSchemaRegistryApi(schemaRegistryApi);
+
+        // When
+        asyncApi.deleteSubjectVersions(TEST_SUBJECT, true).block();
+
+        // Then
+        verify(schemaRegistryApi).deleteSubjectVersions(TEST_SUBJECT, true);
+    }
+}

--- a/providers/jikkou-provider-schema-registry/src/test/java/io/streamthoughts/jikkou/schema/registry/change/handler/DeleteSchemaSubjectChangeHandlerTest.java
+++ b/providers/jikkou-provider-schema-registry/src/test/java/io/streamthoughts/jikkou/schema/registry/change/handler/DeleteSchemaSubjectChangeHandlerTest.java
@@ -1,0 +1,118 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.jikkou.schema.registry.change.handler;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.streamthoughts.jikkou.core.models.ObjectMeta;
+import io.streamthoughts.jikkou.core.models.change.GenericResourceChange;
+import io.streamthoughts.jikkou.core.models.change.ResourceChange;
+import io.streamthoughts.jikkou.core.models.change.ResourceChangeSpec;
+import io.streamthoughts.jikkou.core.reconciler.ChangeResponse;
+import io.streamthoughts.jikkou.core.reconciler.Operation;
+import io.streamthoughts.jikkou.schema.registry.api.AsyncSchemaRegistryApi;
+import io.streamthoughts.jikkou.schema.registry.models.V1SchemaRegistrySubject;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+import reactor.core.publisher.Mono;
+
+class DeleteSchemaSubjectChangeHandlerTest {
+
+    private static final String TEST_SUBJECT = "test-subject";
+
+    @Test
+    void shouldPerformSoftDeleteOnlyWhenPermanentDeleteIsFalse() {
+        // Given
+        AsyncSchemaRegistryApi api = mock(AsyncSchemaRegistryApi.class);
+        when(api.deleteSubjectVersions(eq(TEST_SUBJECT), eq(false)))
+            .thenReturn(Mono.just(List.of(1, 2)));
+
+        DeleteSchemaSubjectChangeHandler handler = new DeleteSchemaSubjectChangeHandler(api);
+        ResourceChange change = createDeleteChange(false);
+
+        // When
+        List<ChangeResponse> responses = handler.handleChanges(List.of(change));
+        responses.forEach(r -> r.getResults().join());
+
+        // Then
+        verify(api).deleteSubjectVersions(TEST_SUBJECT, false);
+        verify(api, never()).deleteSubjectVersions(eq(TEST_SUBJECT), eq(true));
+    }
+
+    @Test
+    void shouldPerformSoftDeleteOnlyWhenPermanentDeleteIsEmpty() {
+        // Given
+        AsyncSchemaRegistryApi api = mock(AsyncSchemaRegistryApi.class);
+        when(api.deleteSubjectVersions(eq(TEST_SUBJECT), eq(false)))
+            .thenReturn(Mono.just(List.of(1, 2)));
+
+        DeleteSchemaSubjectChangeHandler handler = new DeleteSchemaSubjectChangeHandler(api);
+        ResourceChange change = createDeleteChange(null);
+
+        // When
+        List<ChangeResponse> responses = handler.handleChanges(List.of(change));
+        responses.forEach(r -> r.getResults().join());
+
+        // Then
+        verify(api).deleteSubjectVersions(TEST_SUBJECT, false);
+        verify(api, never()).deleteSubjectVersions(eq(TEST_SUBJECT), eq(true));
+    }
+
+    @Test
+    void shouldPerformSoftDeleteThenHardDeleteWhenPermanentDeleteIsTrue() {
+        // Given
+        AsyncSchemaRegistryApi api = mock(AsyncSchemaRegistryApi.class);
+        when(api.deleteSubjectVersions(eq(TEST_SUBJECT), eq(false)))
+            .thenReturn(Mono.just(List.of(1, 2)));
+        when(api.deleteSubjectVersions(eq(TEST_SUBJECT), eq(true)))
+            .thenReturn(Mono.just(List.of(1, 2)));
+
+        DeleteSchemaSubjectChangeHandler handler = new DeleteSchemaSubjectChangeHandler(api);
+        ResourceChange change = createDeleteChange(true);
+
+        // When
+        List<ChangeResponse> responses = handler.handleChanges(List.of(change));
+        responses.forEach(r -> r.getResults().join());
+
+        // Then
+        InOrder inOrder = Mockito.inOrder(api);
+        inOrder.verify(api).deleteSubjectVersions(TEST_SUBJECT, false);
+        inOrder.verify(api).deleteSubjectVersions(TEST_SUBJECT, true);
+    }
+
+    private ResourceChange createDeleteChange(Boolean permanentDelete) {
+        Map<String, Object> delete = Map.of(
+            "normalizeSchema", false,
+            "schemaId", "",
+            "version", ""
+        );
+        if (permanentDelete != null) {
+            delete = new HashMap<>(delete);
+            delete.put("permanentDelete", permanentDelete);
+        }
+        return GenericResourceChange
+            .builder(V1SchemaRegistrySubject.class)
+            .withMetadata(ObjectMeta
+                .builder()
+                .withName(TEST_SUBJECT)
+                .build())
+            .withSpec(ResourceChangeSpec
+                .builder()
+                .withOperation(Operation.DELETE)
+                .withData(delete)
+                .build())
+            .build();
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes #674: Schema subjects cannot be permanently deleted because the Schema Registry API requires a soft delete before a hard delete
- The DeleteSchemaSubjectChangeHandler now always performs a soft delete first (permanent=false), then chains a hard delete (permanent=true) when the permanent-delete annotation is set
- This fixes permanent deletion for both the standard Schema Registry and Aiven providers

## Test plan
- [x] Added DeleteSchemaSubjectChangeHandlerTest verifying soft-only delete, soft+hard delete sequence, and null permanentDelete handling
- [x] Added DefaultAsyncSchemaRegistryApiTest verifying API delegation for both soft and hard deletes
- [x] Added AivenAsyncSchemaRegistryApiTest verifying Aiven API client is called correctly