### PR TITLE
fix(core): add missing provider type for CoreExtensionProvider in reference.conf (#693)

### DIFF
--- a/cli/src/main/resources/reference.conf
+++ b/cli/src/main/resources/reference.conf
@@ -18,6 +18,7 @@ jikkou {
   # Core
   provider.core {
     enabled = true
+    type = io.streamthoughts.jikkou.core.CoreExtensionProvider
   }
   # Apache Kafka Provider
   provider.kafka {

--- a/e2e/resources/kafka-topic-list.yaml
+++ b/e2e/resources/kafka-topic-list.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: "kafka.jikkou.io/v1"
+kind: "KafkaTopicList"
+items:
+  - metadata:
+      name: 'e2e-topic-list-1'
+      labels:
+        environment: e2e
+    spec:
+      partitions: 1
+      replicas: 1
+  - metadata:
+      name: 'e2e-topic-list-2'
+      labels:
+        environment: e2e
+    spec:
+      partitions: 2
+      replicas: 1

--- a/providers/jikkou-provider-kafka/src/test/java/io/streamthoughts/jikkou/kafka/KafkaTopicListExpansionTest.java
+++ b/providers/jikkou-provider-kafka/src/test/java/io/streamthoughts/jikkou/kafka/KafkaTopicListExpansionTest.java
@@ -1,0 +1,117 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.jikkou.kafka;
+
+import io.streamthoughts.jikkou.core.CoreExtensionProvider;
+import io.streamthoughts.jikkou.core.JikkouApi;
+import io.streamthoughts.jikkou.core.ReconciliationContext;
+import io.streamthoughts.jikkou.core.models.HasItems;
+import io.streamthoughts.jikkou.core.models.HasMetadata;
+import io.streamthoughts.jikkou.core.models.ObjectMeta;
+import io.streamthoughts.jikkou.core.models.ResourceList;
+import io.streamthoughts.jikkou.kafka.collections.V1KafkaTopicList;
+import io.streamthoughts.jikkou.kafka.models.V1KafkaTopic;
+import io.streamthoughts.jikkou.kafka.models.V1KafkaTopicSpec;
+import io.streamthoughts.jikkou.runtime.JikkouContext;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class KafkaTopicListExpansionTest {
+
+    @Test
+    void shouldExpandKafkaTopicListIntoIndividualTopics() {
+        // Given
+        JikkouApi api = JikkouContext.defaultContext()
+                .newApiBuilder()
+                .register(new CoreExtensionProvider())
+                .register(new KafkaExtensionProvider())
+                .build()
+                .enableBuiltInAnnotations(false);
+
+        V1KafkaTopicList topicList = new V1KafkaTopicList.Builder()
+                .withItems(List.of(
+                        V1KafkaTopic.builder()
+                                .withMetadata(ObjectMeta.builder()
+                                        .withName("topic-1")
+                                        .build())
+                                .withSpec(V1KafkaTopicSpec.builder()
+                                        .withPartitions(1)
+                                        .withReplicas((short) 1)
+                                        .build())
+                                .build(),
+                        V1KafkaTopic.builder()
+                                .withMetadata(ObjectMeta.builder()
+                                        .withName("topic-2")
+                                        .build())
+                                .withSpec(V1KafkaTopicSpec.builder()
+                                        .withPartitions(2)
+                                        .withReplicas((short) 1)
+                                        .build())
+                                .build()))
+                .build();
+
+        ReconciliationContext context = ReconciliationContext.builder()
+                .dryRun(true)
+                .build();
+
+        // When
+        HasItems result = api.prepare(ResourceList.of(topicList), context);
+
+        // Then
+        List<? extends HasMetadata> items = result.getItems();
+        Assertions.assertEquals(2, items.size());
+        Assertions.assertTrue(items.stream().allMatch(item -> "KafkaTopic".equals(item.getKind())));
+        Assertions.assertTrue(items.stream().noneMatch(item -> "KafkaTopicList".equals(item.getKind())));
+        Assertions.assertTrue(result.findByName("topic-1").isPresent());
+        Assertions.assertTrue(result.findByName("topic-2").isPresent());
+    }
+
+    @Test
+    void shouldNotExpandKafkaTopicListWhenCoreProviderNotRegistered() {
+        // Given
+        JikkouApi api = JikkouContext.defaultContext()
+                .newApiBuilder()
+                .register(new KafkaExtensionProvider())
+                .build()
+                .enableBuiltInAnnotations(false);
+
+        V1KafkaTopicList topicList = new V1KafkaTopicList.Builder()
+                .withItems(List.of(
+                        V1KafkaTopic.builder()
+                                .withMetadata(ObjectMeta.builder()
+                                        .withName("topic-1")
+                                        .build())
+                                .withSpec(V1KafkaTopicSpec.builder()
+                                        .withPartitions(1)
+                                        .withReplicas((short) 1)
+                                        .build())
+                                .build(),
+                        V1KafkaTopic.builder()
+                                .withMetadata(ObjectMeta.builder()
+                                        .withName("topic-2")
+                                        .build())
+                                .withSpec(V1KafkaTopicSpec.builder()
+                                        .withPartitions(2)
+                                        .withReplicas((short) 1)
+                                        .build())
+                                .build()))
+                .build();
+
+        ReconciliationContext context = ReconciliationContext.builder()
+                .dryRun(true)
+                .build();
+
+        // When
+        HasItems result = api.prepare(ResourceList.of(topicList), context);
+
+        // Then - without CoreExtensionProvider, the list is not expanded
+        List<? extends HasMetadata> items = result.getItems();
+        Assertions.assertEquals(1, items.size());
+        Assertions.assertEquals("KafkaTopicList", items.getFirst().getKind());
+    }
+}


### PR DESCRIPTION
The provider.core section in reference.conf was missing the type field. Since v0.37.0's ProviderApiConfigurator matches providers by type (not name).

CoreExtensionProvider was never registered, making ResourceListConverter unavailable and causing KafkaTopicList resources to fail with "Cannot find controller for resource type".

Add unit and e2e tests to cover KafkaTopicList expansion.

Fixes: #693