### PR TITLE
fix(kafka): label selectors no longer break topic reconciliation

### DIFF
--- a/core/src/main/java/io/streamthoughts/jikkou/core/selector/Selectors.java
+++ b/core/src/main/java/io/streamthoughts/jikkou/core/selector/Selectors.java
@@ -52,4 +52,19 @@ public final class Selectors {
     public static Selector noneMatch(@NotNull List<Selector> selectors) {
         return new NoneMatchSelector(selectors);
     }
+
+    /**
+     * Checks whether the given selector contains a {@link LabelSelector},
+     * either directly or nested within an {@link AggregateSelector}.
+     *
+     * @param selector the selector to check.
+     * @return {@code true} if the selector contains a {@link LabelSelector}.
+     */
+    public static boolean containsLabelSelector(@NotNull Selector selector) {
+        if (selector instanceof LabelSelector) return true;
+        if (selector instanceof AggregateSelector agg) {
+            return agg.selectors.stream().anyMatch(Selectors::containsLabelSelector);
+        }
+        return false;
+    }
 }

--- a/core/src/test/java/io/streamthoughts/jikkou/core/selector/SelectorsTest.java
+++ b/core/src/test/java/io/streamthoughts/jikkou/core/selector/SelectorsTest.java
@@ -6,6 +6,9 @@
  */
 package io.streamthoughts.jikkou.core.selector;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import io.streamthoughts.jikkou.core.models.HasMetadata;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
@@ -38,6 +41,41 @@ class SelectorsTest {
         Selector selector = Selectors.noneMatch(EXPRESSIONS);
         Assertions.assertEquals(List.of("expr1", "expr2"), selector.getSelectorExpressions());
         Assertions.assertEquals(SelectorMatchingStrategy.NONE, selector.getSelectorMatchingStrategy());
+    }
+
+    @Test
+    void shouldReturnFalseForNoSelector() {
+        assertFalse(Selectors.containsLabelSelector(Selectors.NO_SELECTOR));
+    }
+
+    @Test
+    void shouldReturnTrueForLabelSelector() {
+        PreparedExpression expr = new PreparedExpression("env", ExpressionOperator.EXISTS, List.of());
+        LabelSelector labelSelector = new LabelSelector(expr);
+        assertTrue(Selectors.containsLabelSelector(labelSelector));
+    }
+
+    @Test
+    void shouldReturnFalseForFieldSelector() {
+        PreparedExpression expr = new PreparedExpression("metadata.name", ExpressionOperator.IN, List.of("test"));
+        FieldSelector fieldSelector = new FieldSelector(expr);
+        assertFalse(Selectors.containsLabelSelector(fieldSelector));
+    }
+
+    @Test
+    void shouldReturnTrueForAggregateSelectorWithNestedLabelSelector() {
+        PreparedExpression expr = new PreparedExpression("env", ExpressionOperator.EXISTS, List.of());
+        LabelSelector labelSelector = new LabelSelector(expr);
+        Selector aggregate = Selectors.allMatch(List.of(labelSelector));
+        assertTrue(Selectors.containsLabelSelector(aggregate));
+    }
+
+    @Test
+    void shouldReturnFalseForAggregateSelectorWithoutLabelSelector() {
+        PreparedExpression expr = new PreparedExpression("metadata.name", ExpressionOperator.IN, List.of("test"));
+        FieldSelector fieldSelector = new FieldSelector(expr);
+        Selector aggregate = Selectors.allMatch(List.of(fieldSelector));
+        assertFalse(Selectors.containsLabelSelector(aggregate));
     }
 
     @NotNull

--- a/providers/jikkou-provider-kafka/src/integration-test/resources/test-kafka-topics-with-labels.yaml
+++ b/providers/jikkou-provider-kafka/src/integration-test/resources/test-kafka-topics-with-labels.yaml
@@ -1,0 +1,25 @@
+apiVersion: "kafka.jikkou.io/v1"
+kind: KafkaTopicList
+metadata:
+  annotations: {}
+  labels: {}
+items:
+  - metadata:
+      name: "topic-test-A"
+      labels:
+        team: my-service
+    spec:
+      partitions: 1
+      replicas: 1
+      configs:
+        cleanup.policy: compact
+
+  - metadata:
+      name: "topic-test-B"
+      labels:
+        team: my-service
+    spec:
+      partitions: 1
+      replicas: 1
+      configs:
+        cleanup.policy: delete

--- a/providers/jikkou-provider-kafka/src/test/java/io/streamthoughts/jikkou/kafka/reconciler/AdminClientKafkaTopicControllerTest.java
+++ b/providers/jikkou-provider-kafka/src/test/java/io/streamthoughts/jikkou/kafka/reconciler/AdminClientKafkaTopicControllerTest.java
@@ -1,0 +1,114 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.jikkou.kafka.reconciler;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.streamthoughts.jikkou.core.models.ObjectMeta;
+import io.streamthoughts.jikkou.kafka.models.V1KafkaTopic;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class AdminClientKafkaTopicControllerTest {
+
+    @Test
+    void shouldEnrichActualTopicWithLabelsFromExpected() {
+        // GIVEN
+        V1KafkaTopic actual = V1KafkaTopic.builder()
+                .withMetadata(ObjectMeta.builder()
+                        .withName("my-topic")
+                        .build())
+                .build();
+
+        V1KafkaTopic expected = V1KafkaTopic.builder()
+                .withMetadata(ObjectMeta.builder()
+                        .withName("my-topic")
+                        .withLabel("my-label", "my-service")
+                        .build())
+                .build();
+
+        // WHEN
+        List<V1KafkaTopic> actualList = new ArrayList<>(List.of(actual));
+        AdminClientKafkaTopicController.enrichLabelsFromExpected(actualList, List.of(expected));
+
+        // THEN
+        assertEquals("my-service", actual.getMetadata().getLabels().get("my-label"));
+    }
+
+    @Test
+    void shouldLeaveActualUnchangedWhenNoMatchingExpected() {
+        // GIVEN
+        V1KafkaTopic actual = V1KafkaTopic.builder()
+                .withMetadata(ObjectMeta.builder()
+                        .withName("other-topic")
+                        .build())
+                .build();
+
+        V1KafkaTopic expected = V1KafkaTopic.builder()
+                .withMetadata(ObjectMeta.builder()
+                        .withName("my-topic")
+                        .withLabel("my-label", "my-service")
+                        .build())
+                .build();
+
+        // WHEN
+        List<V1KafkaTopic> actualList = new ArrayList<>(List.of(actual));
+        AdminClientKafkaTopicController.enrichLabelsFromExpected(actualList, List.of(expected));
+
+        // THEN
+        assertTrue(actual.getMetadata().getLabels().isEmpty());
+    }
+
+    @Test
+    void shouldPreserveSystemLabelsOnActualAfterEnrichment() {
+        // GIVEN
+        V1KafkaTopic actual = V1KafkaTopic.builder()
+                .withMetadata(ObjectMeta.builder()
+                        .withName("my-topic")
+                        .withLabel("jikkou.io/kafka.topic.id", "abc-123")
+                        .build())
+                .build();
+
+        V1KafkaTopic expected = V1KafkaTopic.builder()
+                .withMetadata(ObjectMeta.builder()
+                        .withName("my-topic")
+                        .withLabel("my-label", "my-service")
+                        .build())
+                .build();
+
+        // WHEN
+        List<V1KafkaTopic> actualList = new ArrayList<>(List.of(actual));
+        AdminClientKafkaTopicController.enrichLabelsFromExpected(actualList, List.of(expected));
+
+        // THEN
+        Map<String, Object> labels = actual.getMetadata().getLabels();
+        assertEquals("abc-123", labels.get("jikkou.io/kafka.topic.id"));
+        assertEquals("my-service", labels.get("my-label"));
+    }
+
+    @Test
+    void shouldLeaveActualUnchangedWhenExpectedListIsEmpty() {
+        // GIVEN
+        V1KafkaTopic actual = V1KafkaTopic.builder()
+                .withMetadata(ObjectMeta.builder()
+                        .withName("my-topic")
+                        .withLabel("jikkou.io/kafka.topic.id", "abc-123")
+                        .build())
+                .build();
+
+        // WHEN
+        List<V1KafkaTopic> actualList = new ArrayList<>(List.of(actual));
+        AdminClientKafkaTopicController.enrichLabelsFromExpected(actualList, List.of());
+
+        // THEN
+        assertEquals(Map.of("jikkou.io/kafka.topic.id", "abc-123"),
+                actual.getMetadata().getLabels());
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #698

- **Propagate labels from expected to actual resources**: Before applying the selector, labels from input (expected) topics are merged onto collected (actual) topics joined by `metadata.name`, using `ObjectMeta.addLabelIfAbsent` so system labels (e.g., `jikkou.io/kafka.topic.id`) are preserved
- **Reject `delete-orphans` + label selector**: Throws `JikkouRuntimeException` when both are active, since label selectors would cause all non-matching topics to be incorrectly deleted
- **Add `Selectors.containsLabelSelector()`**: Utility to recursively detect `LabelSelector` instances within `AggregateSelector` trees

## Test plan

- [x] Unit tests for `Selectors.containsLabelSelector()` (5 cases: NO_SELECTOR, LabelSelector, FieldSelector, nested in AggregateSelector)
- [x] Unit tests for `enrichLabelsFromExpected()` (4 cases: basic enrichment, no match, system label preservation, empty expected)
- [x] Existing `TopicChangeComputerTest` still passes (13 tests)
- [x] Integration test: reconcile pre-existing topics with label selector produces UPDATE/NONE, not CREATE
- [x] Integration test: label selector + delete-orphans throws `JikkouRuntimeException`
- [ ] Full integration test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)