### PR TITLE
docs(new-blog): add how we governed 78 clusters without breaking production

### DIFF
--- a/docs/content/en/docs/Resources/_index.md
+++ b/docs/content/en/docs/Resources/_index.md
@@ -9,6 +9,7 @@ menu:
 
 ## Blog 
 
+* [Gitops for Kafka in the real world: How we governed 78 clusters without breaking production](https://one2n.io/blog/gitops-for-kafka-in-the-real-world-governing-legacy-and-modern-clusters-without-breaking-production) (by Harshwardhan Mehrotra, One2N)
 * [GitOps & Kafka: Enabling smooth and seamless Data Schema management with Jikkou and GitHub Actions](https://medium.com/@fhussonnois/gitops-kafka-enabling-smooth-and-seamless-data-schema-management-with-jikkou-and-github-actions-d920a6a14bb) (by Florian Hussonnois)
 * [Jikkou: Declarative ACLs configuration for Apache Kafka® and Schema Registry on Aiven](https://medium.com/@fhussonnois/jikkou-declarative-acls-configuration-for-apache-kafka-and-schema-registry-on-aiven-a3a48b8fc950) (by Florian Hussonnois)
 * [Kafka Connect + Jikkou- Easily manage Kafka connectors](https://medium.com/@fhussonnois/kafka-connect-jikkou-easily-manage-kafka-connectors-d4dd2b8a560c) (by Florian Hussonnois)


### PR DESCRIPTION
## added a new blog 
add new blog post documenting the approach to governing 78 Kafka clusters without breaking production.

This blog post shares practical insights and lessons learned from managing multiple Kafka clusters at scale using Jikkou's declarative approach