### PR TITLE
fix(kafka): use ScramCredentialDeletion for KafkaUser DELETE operations

### DIFF
--- a/providers/jikkou-provider-kafka/src/main/java/io/streamthoughts/jikkou/kafka/change/user/UserChangeHandler.java
+++ b/providers/jikkou-provider-kafka/src/main/java/io/streamthoughts/jikkou/kafka/change/user/UserChangeHandler.java
@@ -76,10 +76,10 @@ public class UserChangeHandler extends BaseChangeHandler {
                                 yield switch (authentication) {
                                     // SCRAM_SHA_256
                                     case V1KafkaUserAuthentication.ScramSha256 auth ->
-                                        KafkaUserService.handleScramSha256(userName, auth);
+                                        KafkaUserService.deleteScramSha256(userName, auth);
                                     // SCRAM_SHA_512
                                     case V1KafkaUserAuthentication.ScramSha512 auth ->
-                                        KafkaUserService.handleScramSha512(userName, auth);
+                                        KafkaUserService.deleteScramSha512(userName, auth);
                                 };
                             }
                         };

--- a/providers/jikkou-provider-kafka/src/main/java/io/streamthoughts/jikkou/kafka/reconciler/service/KafkaUserService.java
+++ b/providers/jikkou-provider-kafka/src/main/java/io/streamthoughts/jikkou/kafka/reconciler/service/KafkaUserService.java
@@ -24,6 +24,7 @@ import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.ScramCredentialInfo;
 import org.apache.kafka.clients.admin.ScramMechanism;
 import org.apache.kafka.clients.admin.UserScramCredentialAlteration;
+import org.apache.kafka.clients.admin.UserScramCredentialDeletion;
 import org.apache.kafka.clients.admin.UserScramCredentialUpsertion;
 import org.apache.kafka.clients.admin.UserScramCredentialsDescription;
 import org.jetbrains.annotations.NotNull;
@@ -127,6 +128,18 @@ public class KafkaUserService {
                 .build(),
             alteration
         );
+    }
+
+    public static Pair<V1KafkaUserAuthentication, UserScramCredentialAlteration> deleteScramSha512(String userName,
+                                                                                                   V1KafkaUserAuthentication.ScramSha512 auth) {
+        var alteration = new UserScramCredentialDeletion(userName, ScramMechanism.SCRAM_SHA_512);
+        return Pair.of(auth, alteration);
+    }
+
+    public static Pair<V1KafkaUserAuthentication, UserScramCredentialAlteration> deleteScramSha256(String userName,
+                                                                                                   V1KafkaUserAuthentication.ScramSha256 auth) {
+        var alteration = new UserScramCredentialDeletion(userName, ScramMechanism.SCRAM_SHA_256);
+        return Pair.of(auth, alteration);
     }
 
     private V1KafkaUserAuthentication map(final ScramCredentialInfo info) {

--- a/providers/jikkou-provider-kafka/src/test/java/io/streamthoughts/jikkou/kafka/change/user/UserChangeComputerTest.java
+++ b/providers/jikkou-provider-kafka/src/test/java/io/streamthoughts/jikkou/kafka/change/user/UserChangeComputerTest.java
@@ -1,0 +1,157 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.jikkou.kafka.change.user;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import io.streamthoughts.jikkou.core.models.ObjectMeta;
+import io.streamthoughts.jikkou.core.models.change.ResourceChange;
+import io.streamthoughts.jikkou.core.reconciler.Operation;
+import io.streamthoughts.jikkou.kafka.model.user.V1KafkaUser;
+import io.streamthoughts.jikkou.kafka.model.user.V1KafkaUserAuthentication;
+import io.streamthoughts.jikkou.kafka.model.user.V1KafkaUserSpec;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class UserChangeComputerTest {
+
+    private final UserChangeComputer computer = new UserChangeComputer();
+    private final UserChangeComputer.UserChangeFactory factory = new UserChangeComputer.UserChangeFactory();
+
+    @Test
+    void shouldComputeCreateChangeForNewUser() {
+        // Given
+        V1KafkaUser after = buildUser("testuser", List.of(
+            new V1KafkaUserAuthentication.ScramSha512("password", 8192, null)
+        ));
+
+        // When
+        List<ResourceChange> changes = computer.computeChanges(List.of(), List.of(after));
+
+        // Then
+        assertEquals(1, changes.size());
+        ResourceChange change = changes.getFirst();
+        assertEquals(Operation.CREATE, change.getSpec().getOp());
+        assertEquals("testuser", change.getMetadata().getName());
+
+        var stateChanges = change.getSpec().getChanges().all();
+        assertEquals(1, stateChanges.size());
+        assertEquals(Operation.CREATE, stateChanges.getFirst().getOp());
+        assertNotNull(stateChanges.getFirst().getAfter());
+    }
+
+    @Test
+    void shouldCreateDeleteChangeForScramSha512User() {
+        // Given
+        V1KafkaUser before = buildUser("testuser", List.of(
+            new V1KafkaUserAuthentication.ScramSha512(null, 8192, null)
+        ));
+
+        // When
+        ResourceChange change = factory.createChangeForDelete("testuser", before);
+
+        // Then
+        assertEquals(Operation.DELETE, change.getSpec().getOp());
+        assertEquals("testuser", change.getMetadata().getName());
+
+        var stateChanges = change.getSpec().getChanges().all();
+        assertEquals(1, stateChanges.size());
+        assertEquals(Operation.DELETE, stateChanges.getFirst().getOp());
+        assertNotNull(stateChanges.getFirst().getBefore());
+
+        V1KafkaUserAuthentication.ScramSha512 beforeAuth =
+            (V1KafkaUserAuthentication.ScramSha512) stateChanges.getFirst().getBefore();
+        assertEquals(8192, beforeAuth.iterations());
+    }
+
+    @Test
+    void shouldCreateDeleteChangeForScramSha256User() {
+        // Given
+        V1KafkaUser before = buildUser("testuser", List.of(
+            new V1KafkaUserAuthentication.ScramSha256(null, 4096, null)
+        ));
+
+        // When
+        ResourceChange change = factory.createChangeForDelete("testuser", before);
+
+        // Then
+        assertEquals(Operation.DELETE, change.getSpec().getOp());
+
+        var stateChanges = change.getSpec().getChanges().all();
+        assertEquals(1, stateChanges.size());
+        assertEquals(Operation.DELETE, stateChanges.getFirst().getOp());
+
+        V1KafkaUserAuthentication.ScramSha256 beforeAuth =
+            (V1KafkaUserAuthentication.ScramSha256) stateChanges.getFirst().getBefore();
+        assertEquals(4096, beforeAuth.iterations());
+    }
+
+    @Test
+    void shouldCreateDeleteChangeWithMultipleAuthentications() {
+        // Given
+        V1KafkaUser before = buildUser("testuser", List.of(
+            new V1KafkaUserAuthentication.ScramSha512(null, 8192, null),
+            new V1KafkaUserAuthentication.ScramSha256(null, 4096, null)
+        ));
+
+        // When
+        ResourceChange change = factory.createChangeForDelete("testuser", before);
+
+        // Then
+        assertEquals(Operation.DELETE, change.getSpec().getOp());
+
+        var stateChanges = change.getSpec().getChanges().all();
+        assertEquals(2, stateChanges.size());
+        stateChanges.forEach(sc -> assertEquals(Operation.DELETE, sc.getOp()));
+    }
+
+    @Test
+    void shouldComputeUpdateChangeForExistingUser() {
+        // Given
+        V1KafkaUser before = buildUser("testuser", List.of(
+            new V1KafkaUserAuthentication.ScramSha512(null, 8192, null)
+        ));
+        V1KafkaUser after = buildUser("testuser", List.of(
+            new V1KafkaUserAuthentication.ScramSha256("newpassword", 4096, null)
+        ));
+
+        // When
+        List<ResourceChange> changes = computer.computeChanges(List.of(before), List.of(after));
+
+        // Then
+        assertEquals(1, changes.size());
+        assertEquals("testuser", changes.getFirst().getMetadata().getName());
+    }
+
+    @Test
+    void shouldComputeNoChangeForIdenticalUser() {
+        // Given
+        V1KafkaUser before = buildUser("testuser", List.of(
+            new V1KafkaUserAuthentication.ScramSha512(null, 8192, null)
+        ));
+        V1KafkaUser after = buildUser("testuser", List.of(
+            new V1KafkaUserAuthentication.ScramSha512(null, 8192, null)
+        ));
+
+        // When
+        List<ResourceChange> changes = computer.computeChanges(List.of(before), List.of(after));
+
+        // Then
+        assertEquals(1, changes.size());
+        assertEquals(Operation.NONE, changes.getFirst().getSpec().getOp());
+    }
+
+    private static V1KafkaUser buildUser(String name, List<V1KafkaUserAuthentication> authentications) {
+        return V1KafkaUser.builder()
+            .withMetadata(new ObjectMeta(name))
+            .withSpec(V1KafkaUserSpec.builder()
+                .withAuthentications(authentications)
+                .build())
+            .build();
+    }
+}

--- a/providers/jikkou-provider-kafka/src/test/java/io/streamthoughts/jikkou/kafka/change/user/UserChangeHandlerTest.java
+++ b/providers/jikkou-provider-kafka/src/test/java/io/streamthoughts/jikkou/kafka/change/user/UserChangeHandlerTest.java
@@ -1,0 +1,246 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.jikkou.kafka.change.user;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.streamthoughts.jikkou.core.models.ObjectMeta;
+import io.streamthoughts.jikkou.core.models.change.GenericResourceChange;
+import io.streamthoughts.jikkou.core.models.change.ResourceChange;
+import io.streamthoughts.jikkou.core.models.change.ResourceChangeSpec;
+import io.streamthoughts.jikkou.core.models.change.StateChange;
+import io.streamthoughts.jikkou.core.reconciler.ChangeResponse;
+import io.streamthoughts.jikkou.core.reconciler.Operation;
+import io.streamthoughts.jikkou.kafka.model.user.V1KafkaUser;
+import io.streamthoughts.jikkou.kafka.model.user.V1KafkaUserAuthentication;
+import java.util.List;
+import java.util.Map;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AlterUserScramCredentialsResult;
+import org.apache.kafka.clients.admin.ScramMechanism;
+import org.apache.kafka.clients.admin.UserScramCredentialAlteration;
+import org.apache.kafka.clients.admin.UserScramCredentialDeletion;
+import org.apache.kafka.clients.admin.UserScramCredentialUpsertion;
+import org.apache.kafka.common.KafkaFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class UserChangeHandlerTest {
+
+    private AdminClient adminClient;
+    private UserChangeHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        adminClient = mock(AdminClient.class);
+        handler = new UserChangeHandler(adminClient);
+    }
+
+    @Test
+    void shouldSendUpsertionForCreateScramSha512() {
+        // Given
+        ResourceChange change = createUserChange(
+            "testuser",
+            Operation.CREATE,
+            StateChange.create(
+                "authentications.scram-sha-512",
+                new V1KafkaUserAuthentication.ScramSha512("password123", 8192, null)
+            )
+        );
+
+        mockAlterUserScramCredentials("testuser");
+
+        // When
+        List<ChangeResponse> responses = handler.handleChanges(List.of(change));
+
+        // Then
+        var captor = ArgumentCaptor.forClass(List.class);
+        verify(adminClient).alterUserScramCredentials(captor.capture());
+
+        List<UserScramCredentialAlteration> alterations = captor.getValue();
+        assertEquals(1, alterations.size());
+        assertInstanceOf(UserScramCredentialUpsertion.class, alterations.getFirst());
+
+        UserScramCredentialUpsertion upsertion = (UserScramCredentialUpsertion) alterations.getFirst();
+        assertEquals("testuser", upsertion.user());
+        assertEquals(ScramMechanism.SCRAM_SHA_512, upsertion.credentialInfo().mechanism());
+    }
+
+    @Test
+    void shouldSendUpsertionForCreateScramSha256() {
+        // Given
+        ResourceChange change = createUserChange(
+            "testuser",
+            Operation.CREATE,
+            StateChange.create(
+                "authentications.scram-sha-256",
+                new V1KafkaUserAuthentication.ScramSha256("password123", 8192, null)
+            )
+        );
+
+        mockAlterUserScramCredentials("testuser");
+
+        // When
+        List<ChangeResponse> responses = handler.handleChanges(List.of(change));
+
+        // Then
+        var captor = ArgumentCaptor.forClass(List.class);
+        verify(adminClient).alterUserScramCredentials(captor.capture());
+
+        List<UserScramCredentialAlteration> alterations = captor.getValue();
+        assertEquals(1, alterations.size());
+        assertInstanceOf(UserScramCredentialUpsertion.class, alterations.getFirst());
+
+        UserScramCredentialUpsertion upsertion = (UserScramCredentialUpsertion) alterations.getFirst();
+        assertEquals("testuser", upsertion.user());
+        assertEquals(ScramMechanism.SCRAM_SHA_256, upsertion.credentialInfo().mechanism());
+    }
+
+    @Test
+    void shouldSendDeletionForDeleteScramSha512() {
+        // Given
+        ResourceChange change = createUserChange(
+            "testuser",
+            Operation.DELETE,
+            StateChange.delete(
+                "authentications.scram-sha-512",
+                new V1KafkaUserAuthentication.ScramSha512(null, 8192, null)
+            )
+        );
+
+        mockAlterUserScramCredentials("testuser");
+
+        // When
+        List<ChangeResponse> responses = handler.handleChanges(List.of(change));
+
+        // Then
+        var captor = ArgumentCaptor.forClass(List.class);
+        verify(adminClient).alterUserScramCredentials(captor.capture());
+
+        List<UserScramCredentialAlteration> alterations = captor.getValue();
+        assertEquals(1, alterations.size());
+        assertInstanceOf(
+            UserScramCredentialDeletion.class,
+            alterations.getFirst(),
+            "DELETE operation should produce a UserScramCredentialDeletion, not an upsertion"
+        );
+
+        UserScramCredentialDeletion deletion = (UserScramCredentialDeletion) alterations.getFirst();
+        assertEquals("testuser", deletion.user());
+        assertEquals(ScramMechanism.SCRAM_SHA_512, deletion.mechanism());
+    }
+
+    @Test
+    void shouldSendDeletionForDeleteScramSha256() {
+        // Given
+        ResourceChange change = createUserChange(
+            "testuser",
+            Operation.DELETE,
+            StateChange.delete(
+                "authentications.scram-sha-256",
+                new V1KafkaUserAuthentication.ScramSha256(null, 8192, null)
+            )
+        );
+
+        mockAlterUserScramCredentials("testuser");
+
+        // When
+        List<ChangeResponse> responses = handler.handleChanges(List.of(change));
+
+        // Then
+        var captor = ArgumentCaptor.forClass(List.class);
+        verify(adminClient).alterUserScramCredentials(captor.capture());
+
+        List<UserScramCredentialAlteration> alterations = captor.getValue();
+        assertEquals(1, alterations.size());
+        assertInstanceOf(
+            UserScramCredentialDeletion.class,
+            alterations.getFirst(),
+            "DELETE operation should produce a UserScramCredentialDeletion, not an upsertion"
+        );
+
+        UserScramCredentialDeletion deletion = (UserScramCredentialDeletion) alterations.getFirst();
+        assertEquals("testuser", deletion.user());
+        assertEquals(ScramMechanism.SCRAM_SHA_256, deletion.mechanism());
+    }
+
+    @Test
+    void shouldSendUpsertionForUpdateScramSha512() {
+        // Given
+        ResourceChange change = createUserChange(
+            "testuser",
+            Operation.UPDATE,
+            StateChange.update(
+                "authentications.scram-sha-512",
+                new V1KafkaUserAuthentication.ScramSha512(null, 8192, null),
+                new V1KafkaUserAuthentication.ScramSha512("newpassword", 8192, null)
+            )
+        );
+
+        mockAlterUserScramCredentials("testuser");
+
+        // When
+        List<ChangeResponse> responses = handler.handleChanges(List.of(change));
+
+        // Then
+        var captor = ArgumentCaptor.forClass(List.class);
+        verify(adminClient).alterUserScramCredentials(captor.capture());
+
+        List<UserScramCredentialAlteration> alterations = captor.getValue();
+        assertEquals(1, alterations.size());
+        assertInstanceOf(UserScramCredentialUpsertion.class, alterations.getFirst());
+    }
+
+    @Test
+    void shouldReturnChangeResponsesForEachChange() {
+        // Given
+        ResourceChange change = createUserChange(
+            "testuser",
+            Operation.CREATE,
+            StateChange.create(
+                "authentications.scram-sha-512",
+                new V1KafkaUserAuthentication.ScramSha512("password123", 8192, null)
+            )
+        );
+
+        mockAlterUserScramCredentials("testuser");
+
+        // When
+        List<ChangeResponse> responses = handler.handleChanges(List.of(change));
+
+        // Then
+        assertEquals(1, responses.size());
+        assertTrue(responses.getFirst().getChange() == change);
+    }
+
+    private ResourceChange createUserChange(String userName, Operation operation, StateChange stateChange) {
+        return GenericResourceChange
+            .builder(V1KafkaUser.class)
+            .withMetadata(new ObjectMeta(userName))
+            .withSpec(ResourceChangeSpec
+                .builder()
+                .withOperation(operation)
+                .withChange(stateChange)
+                .build()
+            )
+            .build();
+    }
+
+    @SuppressWarnings("unchecked")
+    private void mockAlterUserScramCredentials(String userName) {
+        AlterUserScramCredentialsResult result = mock(AlterUserScramCredentialsResult.class);
+        KafkaFuture<Void> future = KafkaFuture.completedFuture(null);
+        when(result.values()).thenReturn(Map.of(userName, future));
+        when(adminClient.alterUserScramCredentials(org.mockito.ArgumentMatchers.anyList())).thenReturn(result);
+    }
+}


### PR DESCRIPTION
## Summary
- Fix KafkaUser deletion sending `AlterUserScramCredentials` with upsertions instead of deletions, silently re-creating the user with a random password (#733)
- Add `deleteScramSha256`/`deleteScramSha512` methods to `KafkaUserService` that construct `UserScramCredentialDeletion` instead of `UserScramCredentialUpsertion`
- Wire the new methods into the `DELETE` case of `UserChangeHandler`

## Test plan
- [x] Added `UserChangeHandlerTest` (6 tests) covering CREATE, UPDATE, and DELETE for both SCRAM-SHA-256 and SCRAM-SHA-512
- [x] Added `UserChangeComputerTest` (6 tests) covering change computation for CREATE, DELETE, UPDATE, and NONE operations
- [x] All 142 tests in `jikkou-provider-kafka` pass

Closes #733