### PR TITLE
fix(docs): fix CERATE typo in ACLs documentation

### DIFF
--- a/docs/content/en/docs/Providers/Kafka/Resources/acls.md
+++ b/docs/content/en/docs/Providers/Kafka/Resources/acls.md
@@ -46,7 +46,7 @@ The list below describes the valid values for the `spec.acls.[].operations` prop
 
 * `READ`
 * `WRITE`
-* `CERATE`
+* `CREATE`
 * `DELETE`
 * `ALTER`
 * `DESCRIBE`


### PR DESCRIPTION
## Summary
- Fix typo `CERATE` → `CREATE` in ACLs documentation

Closes #518