### PR TITLE
feat(confluent): add Confluent Cloud RBAC role bindings provider

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -125,6 +125,11 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>jikkou-provider-confluent</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>jikkou-provider-kafka-connect</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
         <module>providers/jikkou-provider-core</module>
         <module>providers/jikkou-provider-kafka-connect</module>
         <module>providers/jikkou-provider-aws</module>
+        <module>providers/jikkou-provider-confluent</module>
         <module>server/jikkou-api-client</module>
         <module>server/jikkou-api-server</module>
         <module>server/jikkou-api-data</module>

--- a/providers/jikkou-provider-confluent/pom.xml
+++ b/providers/jikkou-provider-confluent/pom.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) The original authors
+
+  Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.streamthoughts</groupId>
+        <artifactId>jikkou-parent</artifactId>
+        <version>0.38.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <name>Jikkou Extension :: Confluent Cloud</name>
+    <artifactId>jikkou-provider-confluent</artifactId>
+    <description>Integration between Confluent Cloud and Jikkou</description>
+
+    <properties>
+        <license.header.file>${project.parent.basedir}/header</license.header.file>
+        <okhttp.version>5.3.2</okhttp.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.streamthoughts</groupId>
+            <artifactId>jikkou-processor</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.streamthoughts</groupId>
+            <artifactId>jikkou-extension-rest-client</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.streamthoughts</groupId>
+            <artifactId>jikkou-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <!-- START dependencies for test -->
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>${okhttp.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <version>${okhttp.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- END dependencies for test -->
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven-compiler-plugin.version}</version>
+                <configuration>
+                    <parameters>${maven.compiler.parameters}</parameters>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.streamthoughts</groupId>
+                            <artifactId>jikkou-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/providers/jikkou-provider-confluent/src/main/java/io/streamthoughts/jikkou/extension/confluent/ApiVersions.java
+++ b/providers/jikkou-provider-confluent/src/main/java/io/streamthoughts/jikkou/extension/confluent/ApiVersions.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.jikkou.extension.confluent;
+
+public final class ApiVersions {
+
+    public static final String IAM_CONFLUENT_CLOUD_V1 = "iam.confluent.cloud/v1";
+}

--- a/providers/jikkou-provider-confluent/src/main/java/io/streamthoughts/jikkou/extension/confluent/ConfluentCloudExtensionProvider.java
+++ b/providers/jikkou-provider-confluent/src/main/java/io/streamthoughts/jikkou/extension/confluent/ConfluentCloudExtensionProvider.java
@@ -1,0 +1,107 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.jikkou.extension.confluent;
+
+import io.streamthoughts.jikkou.core.annotation.Named;
+import io.streamthoughts.jikkou.core.annotation.Provider;
+import io.streamthoughts.jikkou.core.config.ConfigProperty;
+import io.streamthoughts.jikkou.core.config.Configuration;
+import io.streamthoughts.jikkou.core.exceptions.ConfigException;
+import io.streamthoughts.jikkou.core.extension.ExtensionRegistry;
+import io.streamthoughts.jikkou.core.resource.ResourceRegistry;
+import io.streamthoughts.jikkou.extension.confluent.api.ConfluentCloudApiClientConfig;
+import io.streamthoughts.jikkou.extension.confluent.collections.V1RoleBindingList;
+import io.streamthoughts.jikkou.extension.confluent.models.V1RoleBinding;
+import io.streamthoughts.jikkou.extension.confluent.reconciler.ConfluentCloudRoleBindingCollector;
+import io.streamthoughts.jikkou.extension.confluent.reconciler.ConfluentCloudRoleBindingController;
+import io.streamthoughts.jikkou.spi.BaseExtensionProvider;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+
+@Named("confluent-cloud")
+@Provider(
+    name = "confluent-cloud",
+    description = "Extension provider for Confluent Cloud",
+    tags = {"Confluent Cloud", "Apache Kafka", "Cloud", "RBAC"}
+)
+public final class ConfluentCloudExtensionProvider extends BaseExtensionProvider {
+
+    interface Config {
+        ConfigProperty<String> API_URL = ConfigProperty
+            .ofString("apiUrl")
+            .defaultValue("https://api.confluent.cloud")
+            .description("URL to the Confluent Cloud REST API.");
+
+        ConfigProperty<String> API_KEY = ConfigProperty
+            .ofString("apiKey")
+            .description("Confluent Cloud API Key.");
+
+        ConfigProperty<String> API_SECRET = ConfigProperty
+            .ofString("apiSecret")
+            .description("Confluent Cloud API Secret.");
+
+        ConfigProperty<String> CRN_PATTERN = ConfigProperty
+            .ofString("crnPattern")
+            .description("CRN pattern used to scope role binding list operations.");
+
+        ConfigProperty<Boolean> DEBUG_LOGGING_ENABLED = ConfigProperty
+            .ofBoolean("debugLoggingEnabled")
+            .description("Enable debug logging.")
+            .defaultValue(false);
+    }
+
+    private ConfluentCloudApiClientConfig apiClientConfig;
+
+    /** {@inheritDoc} **/
+    @Override
+    public void configure(@NotNull Configuration configuration) throws ConfigException {
+        super.configure(configuration);
+        apiClientConfig = new ConfluentCloudApiClientConfig(
+            Config.API_URL.get(configuration),
+            Config.API_KEY.get(configuration),
+            Config.API_SECRET.get(configuration),
+            Config.CRN_PATTERN.get(configuration),
+            Config.DEBUG_LOGGING_ENABLED.get(configuration)
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<ConfigProperty<?>> configProperties() {
+        return List.of(
+            Config.API_URL,
+            Config.API_KEY,
+            Config.API_SECRET,
+            Config.CRN_PATTERN,
+            Config.DEBUG_LOGGING_ENABLED
+        );
+    }
+
+    public ConfluentCloudApiClientConfig apiClientConfig() {
+        return apiClientConfig;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void registerExtensions(@NotNull ExtensionRegistry registry) {
+        registry.register(ConfluentCloudRoleBindingCollector.class, ConfluentCloudRoleBindingCollector::new);
+        registry.register(ConfluentCloudRoleBindingController.class, ConfluentCloudRoleBindingController::new);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void registerResources(@NotNull ResourceRegistry registry) {
+        registry.register(V1RoleBinding.class);
+        registry.register(V1RoleBindingList.class);
+    }
+}

--- a/providers/jikkou-provider-confluent/src/main/java/io/streamthoughts/jikkou/extension/confluent/MetadataAnnotations.java
+++ b/providers/jikkou-provider-confluent/src/main/java/io/streamthoughts/jikkou/extension/confluent/MetadataAnnotations.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.jikkou.extension.confluent;
+
+public class MetadataAnnotations {
+
+    public static String CONFLUENT_CLOUD_ROLE_BINDING_ID = "confluent.cloud/role-binding-id";
+}

--- a/providers/jikkou-provider-confluent/src/main/java/io/streamthoughts/jikkou/extension/confluent/adapter/RoleBindingAdapter.java
+++ b/providers/jikkou-provider-confluent/src/main/java/io/streamthoughts/jikkou/extension/confluent/adapter/RoleBindingAdapter.java
@@ -1,0 +1,68 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.jikkou.extension.confluent.adapter;
+
+import static io.streamthoughts.jikkou.extension.confluent.MetadataAnnotations.CONFLUENT_CLOUD_ROLE_BINDING_ID;
+
+import io.streamthoughts.jikkou.core.models.ObjectMeta;
+import io.streamthoughts.jikkou.extension.confluent.api.data.RoleBindingData;
+import io.streamthoughts.jikkou.extension.confluent.models.V1RoleBinding;
+import io.streamthoughts.jikkou.extension.confluent.models.V1RoleBindingSpec;
+import java.util.List;
+
+public final class RoleBindingAdapter {
+
+    /**
+     * Maps a {@link V1RoleBinding} resource to a {@link RoleBindingData} DTO.
+     * The ID is extracted from the metadata annotation if present.
+     */
+    public static RoleBindingData map(final V1RoleBinding resource) {
+        if (resource == null) return null;
+        V1RoleBindingSpec spec = resource.getSpec();
+        String id = resource.optionalMetadata()
+            .flatMap(meta -> meta.findAnnotationByKey(CONFLUENT_CLOUD_ROLE_BINDING_ID))
+            .map(Object::toString)
+            .orElse(null);
+        return new RoleBindingData(
+            id,
+            spec.getPrincipal(),
+            spec.getRoleName(),
+            spec.getCrnPattern()
+        );
+    }
+
+    /**
+     * Maps a list of {@link RoleBindingData} DTOs to a list of {@link V1RoleBinding} resources.
+     */
+    public static List<V1RoleBinding> map(final List<RoleBindingData> entries) {
+        return entries.stream()
+            .map(RoleBindingAdapter::map)
+            .toList();
+    }
+
+    /**
+     * Maps a {@link RoleBindingData} DTO to a {@link V1RoleBinding} resource.
+     * The ID is stored in a metadata annotation.
+     */
+    public static V1RoleBinding map(final RoleBindingData data) {
+        if (data == null) return null;
+        ObjectMeta.ObjectMetaBuilder objectMetaBuilder = ObjectMeta.builder();
+        if (data.id() != null) {
+            objectMetaBuilder = objectMetaBuilder
+                .withAnnotation(CONFLUENT_CLOUD_ROLE_BINDING_ID, data.id());
+        }
+        return V1RoleBinding.builder()
+            .withMetadata(objectMetaBuilder.build())
+            .withSpec(V1RoleBindingSpec.builder()
+                .withPrincipal(data.principal())
+                .withRoleName(data.roleName())
+                .withCrnPattern(data.crnPattern())
+                .build()
+            )
+            .build();
+    }
+}

--- a/providers/jikkou-provider-confluent/src/main/java/io/streamthoughts/jikkou/extension/confluent/api/ConfluentCloudApi.java
+++ b/providers/jikkou-provider-confluent/src/main/java/io/streamthoughts/jikkou/extension/confluent/api/ConfluentCloudApi.java
@@ -1,0 +1,120 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.jikkou.extension.confluent.api;
+
+import io.streamthoughts.jikkou.extension.confluent.api.data.RoleBindingData;
+import io.streamthoughts.jikkou.extension.confluent.api.data.RoleBindingListResponse;
+import io.streamthoughts.jikkou.extension.confluent.api.data.ServiceAccountListResponse;
+import io.streamthoughts.jikkou.extension.confluent.api.data.UserListResponse;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+
+/**
+ * REST API for Confluent Cloud IAM v2.
+ *
+ * @see <a href="https://docs.confluent.io/cloud/current/api.html#tag/Role-Bindings-(iam/v2)">API docs</a>
+ */
+@Path("/iam/v2")
+@Produces("application/json")
+public interface ConfluentCloudApi extends AutoCloseable {
+
+    /**
+     * List role bindings.
+     *
+     * @param crnPattern CRN pattern to filter role bindings.
+     * @param pageSize   Maximum number of results per page (max 100).
+     * @param pageToken  Token for the next page.
+     * @return the list response with pagination metadata.
+     */
+    @GET
+    @Path("/role-bindings")
+    RoleBindingListResponse listRoleBindings(
+        @QueryParam("crn_pattern") String crnPattern,
+        @QueryParam("page_size") Integer pageSize,
+        @QueryParam("page_token") String pageToken);
+
+    /**
+     * Create a role binding.
+     *
+     * @param data the role binding to create.
+     * @return the created role binding.
+     */
+    @POST
+    @Path("/role-bindings")
+    @Consumes("application/json")
+    RoleBindingData createRoleBinding(RoleBindingData data);
+
+    /**
+     * Get a role binding by ID.
+     *
+     * @param id the role binding ID.
+     * @return the role binding.
+     */
+    @GET
+    @Path("/role-bindings/{id}")
+    RoleBindingData getRoleBinding(@PathParam("id") String id);
+
+    /**
+     * Delete a role binding by ID.
+     *
+     * @param id the role binding ID.
+     */
+    @DELETE
+    @Path("/role-bindings/{id}")
+    void deleteRoleBinding(@PathParam("id") String id);
+
+    /*
+     * ----------------------------------------------------------------------------------------------------------------
+     * USERS
+     * ----------------------------------------------------------------------------------------------------------------
+     */
+
+    /**
+     * List users.
+     *
+     * @param pageSize  Maximum number of results per page (max 100).
+     * @param pageToken Token for the next page.
+     * @return the list response with pagination metadata.
+     */
+    @GET
+    @Path("/users")
+    UserListResponse listUsers(
+        @QueryParam("page_size") Integer pageSize,
+        @QueryParam("page_token") String pageToken);
+
+    /*
+     * ----------------------------------------------------------------------------------------------------------------
+     * SERVICE ACCOUNTS
+     * ----------------------------------------------------------------------------------------------------------------
+     */
+
+    /**
+     * List service accounts.
+     *
+     * @param pageSize  Maximum number of results per page (max 100).
+     * @param pageToken Token for the next page.
+     * @return the list response with pagination metadata.
+     */
+    @GET
+    @Path("/service-accounts")
+    ServiceAccountListResponse listServiceAccounts(
+        @QueryParam("page_size") Integer pageSize,
+        @QueryParam("page_token") String pageToken);
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    default void close() {
+    }
+}

--- a/providers/jikkou-provider-confluent/src/main/java/io/streamthoughts/jikkou/extension/confluent/api/ConfluentCloudApiClient.java
+++ b/providers/jikkou-provider-confluent/src/main/java/io/streamthoughts/jikkou/extension/confluent/api/ConfluentCloudApiClient.java
@@ -1,0 +1,132 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.jikkou.extension.confluent.api;
+
+import io.streamthoughts.jikkou.extension.confluent.api.data.RoleBindingData;
+import io.streamthoughts.jikkou.extension.confluent.api.data.RoleBindingListResponse;
+import io.streamthoughts.jikkou.extension.confluent.api.data.ServiceAccountData;
+import io.streamthoughts.jikkou.extension.confluent.api.data.ServiceAccountListResponse;
+import io.streamthoughts.jikkou.extension.confluent.api.data.UserData;
+import io.streamthoughts.jikkou.extension.confluent.api.data.UserListResponse;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Confluent Cloud API client wrapper that handles pagination and pre-fills CRN pattern.
+ */
+public final class ConfluentCloudApiClient implements AutoCloseable {
+
+    private static final int DEFAULT_PAGE_SIZE = 100;
+
+    private final ConfluentCloudApi api;
+    private final String crnPattern;
+
+    /**
+     * Creates a new {@link ConfluentCloudApiClient} instance.
+     *
+     * @param api        the REST API proxy.
+     * @param crnPattern the CRN pattern for scoping list operations.
+     */
+    public ConfluentCloudApiClient(@NotNull final ConfluentCloudApi api,
+                                   @NotNull final String crnPattern) {
+        this.api = Objects.requireNonNull(api, "api must not be null");
+        this.crnPattern = Objects.requireNonNull(crnPattern, "crnPattern must not be null");
+    }
+
+    /**
+     * Lists all role bindings matching the configured CRN pattern, handling pagination.
+     *
+     * @return all role bindings.
+     */
+    public List<RoleBindingData> listRoleBindings() {
+        List<RoleBindingData> allBindings = new ArrayList<>();
+        String pageToken = null;
+        do {
+            RoleBindingListResponse response = api.listRoleBindings(crnPattern, DEFAULT_PAGE_SIZE, pageToken);
+            if (response.data() != null) {
+                allBindings.addAll(response.data());
+            }
+            pageToken = response.metadata() != null ? response.metadata().pageToken() : null;
+        } while (pageToken != null);
+        return allBindings;
+    }
+
+    /**
+     * Creates a role binding.
+     *
+     * @param data the role binding to create.
+     * @return the created role binding.
+     */
+    public RoleBindingData createRoleBinding(@NotNull RoleBindingData data) {
+        return api.createRoleBinding(data);
+    }
+
+    /**
+     * Gets a role binding by ID.
+     *
+     * @param id the role binding ID.
+     * @return the role binding.
+     */
+    public RoleBindingData getRoleBinding(@NotNull String id) {
+        return api.getRoleBinding(id);
+    }
+
+    /**
+     * Deletes a role binding by ID.
+     *
+     * @param id the role binding ID.
+     */
+    public void deleteRoleBinding(@NotNull String id) {
+        api.deleteRoleBinding(id);
+    }
+
+    /**
+     * Lists all users, handling pagination.
+     *
+     * @return all users.
+     */
+    public List<UserData> listUsers() {
+        List<UserData> allUsers = new ArrayList<>();
+        String pageToken = null;
+        do {
+            UserListResponse response = api.listUsers(DEFAULT_PAGE_SIZE, pageToken);
+            if (response.data() != null) {
+                allUsers.addAll(response.data());
+            }
+            pageToken = response.metadata() != null ? response.metadata().pageToken() : null;
+        } while (pageToken != null);
+        return allUsers;
+    }
+
+    /**
+     * Lists all service accounts, handling pagination.
+     *
+     * @return all service accounts.
+     */
+    public List<ServiceAccountData> listServiceAccounts() {
+        List<ServiceAccountData> allAccounts = new ArrayList<>();
+        String pageToken = null;
+        do {
+            ServiceAccountListResponse response = api.listServiceAccounts(DEFAULT_PAGE_SIZE, pageToken);
+            if (response.data() != null) {
+                allAccounts.addAll(response.data());
+            }
+            pageToken = response.metadata() != null ? response.metadata().pageToken() : null;
+        } while (pageToken != null);
+        return allAccounts;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void close() {
+        api.close();
+    }
+}

--- a/providers/jikkou-provider-confluent/src/main/java/io/streamthoughts/jikkou/extension/confluent/api/ConfluentCloudApiClientConfig.java
+++ b/providers/jikkou-provider-confluent/src/main/java/io/streamthoughts/jikkou/extension/confluent/api/ConfluentCloudApiClientConfig.java
@@ -1,0 +1,25 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.jikkou.extension.confluent.api;
+
+/**
+ * Configuration for the Confluent Cloud API client.
+ *
+ * @param apiUrl               Base URL for the Confluent Cloud API.
+ * @param apiKey               Cloud API key (used as HTTP Basic username).
+ * @param apiSecret            Cloud API secret (used as HTTP Basic password).
+ * @param crnPattern           CRN pattern used to scope role binding list operations.
+ * @param debugLoggingEnabled  Whether to enable debug logging.
+ */
+public record ConfluentCloudApiClientConfig(
+    String apiUrl,
+    String apiKey,
+    String apiSecret,
+    String crnPattern,
+    boolean debugLoggingEnabled
+) {
+}

--- a/providers/jikkou-provider-confluent/src/main/java/io/streamthoughts/jikkou/extension/confluent/api/ConfluentCloudApiClientException.java
+++ b/providers/jikkou-provider-confluent/src/main/java/io/streamthoughts/jikkou/extension/confluent/api/ConfluentCloudApiClientException.java
@@ -1,0 +1,20 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.jikkou.extension.confluent.api;
+
+import io.streamthoughts.jikkou.core.exceptions.JikkouRuntimeException;
+
+public class ConfluentCloudApiClientException extends JikkouRuntimeException {
+
+    public ConfluentCloudApiClientException(final String message) {
+        super(message);
+    }
+
+    public ConfluentCloudApiClientException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/providers/jikkou-provider-confluent/src/main/java/io/streamthoughts/jikkou/extension/confluent/api/ConfluentCloudApiClientFactory.java
+++ b/providers/jikkou-provider-confluent/src/main/java/io/streamthoughts/jikkou/extension/confluent/api/ConfluentCloudApiClientFactory.java
@@ -1,0 +1,49 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.jikkou.extension.confluent.api;
+
+import io.streamthoughts.jikkou.http.client.RestClientBuilder;
+import java.net.URI;
+import java.util.Base64;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Factory for creating {@link ConfluentCloudApiClient} instances.
+ */
+public class ConfluentCloudApiClientFactory {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ConfluentCloudApiClientFactory.class);
+
+    /**
+     * Creates a new {@link ConfluentCloudApiClient} for the given configuration.
+     *
+     * @param config the configuration.
+     * @return a new {@link ConfluentCloudApiClient} instance.
+     */
+    public static ConfluentCloudApiClient create(ConfluentCloudApiClientConfig config) {
+        URI baseUri = URI.create(config.apiUrl());
+        LOG.info(
+            "Create new REST client for Confluent Cloud API: {} (debugLoggingEnabled: {})",
+            baseUri,
+            config.debugLoggingEnabled()
+        );
+        String credentials = Base64.getEncoder().encodeToString(
+            (config.apiKey() + ":" + config.apiSecret()).getBytes()
+        );
+        RestClientBuilder builder = RestClientBuilder
+            .newBuilder()
+            .enableClientDebugging(config.debugLoggingEnabled())
+            .baseUri(baseUri);
+
+        builder.header("Authorization", "Basic " + credentials);
+        return new ConfluentCloudApiClient(
+            builder.build(ConfluentCloudApi.class),
+            config.crnPattern()
+        );
+    }
+}

--- a/providers/jikkou-provider-confluent/src/main/java/io/streamthoughts/jikkou/extension/confluent/api/data/ListMetadata.java
+++ b/providers/jikkou-provider-confluent/src/main/java/io/streamthoughts/jikkou/extension/confluent/api/data/ListMetadata.java
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.jikkou.extension.confluent.api.data;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.streamthoughts.jikkou.core.annotation.Reflectable;
+
+/**
+ * Pagination metadata from Confluent Cloud list responses.
+ *
+ * @param totalSize  Total number of results.
+ * @param pageToken  Token for the next page, or {@code null} if no more pages.
+ */
+@Reflectable
+public record ListMetadata(
+    @JsonProperty("total_size") Integer totalSize,
+    @JsonProperty("next") String pageToken
+) {
+}

--- a/providers/jikkou-provider-confluent/src/main/java/io/streamthoughts/jikkou/extension/confluent/api/data/RoleBindingData.java
+++ b/providers/jikkou-provider-confluent/src/main/java/io/streamthoughts/jikkou/extension/confluent/api/data/RoleBindingData.java
@@ -1,0 +1,64 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.jikkou.extension.confluent.api.data;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.streamthoughts.jikkou.core.annotation.Reflectable;
+import java.util.Objects;
+
+/**
+ * Confluent Cloud IAM v2 Role Binding.
+ *
+ * @param id         Role binding ID (read-only, e.g. {@code rb-f3a90de}).
+ * @param principal  Principal (pattern: {@code User:*} or {@code Group:*}).
+ * @param roleName   Role name (e.g. {@code CloudClusterAdmin}).
+ * @param crnPattern CRN pattern (pattern: {@code crn://*}).
+ */
+@Reflectable
+@JsonPropertyOrder({
+    "id",
+    "principal",
+    "role_name",
+    "crn_pattern"
+})
+public record RoleBindingData(
+    @JsonProperty("id") String id,
+    @JsonProperty("principal") String principal,
+    @JsonProperty("role_name") String roleName,
+    @JsonProperty("crn_pattern") String crnPattern
+) {
+
+    /**
+     * Creates a new {@link RoleBindingData} without an ID (for create requests).
+     */
+    public RoleBindingData(String principal, String roleName, String crnPattern) {
+        this(null, principal, roleName, crnPattern);
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>Equality is based on the triple (principal, roleName, crnPattern), not the id.</p>
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        RoleBindingData that = (RoleBindingData) o;
+        return Objects.equals(principal, that.principal) &&
+            Objects.equals(roleName, that.roleName) &&
+            Objects.equals(crnPattern, that.crnPattern);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hash(principal, roleName, crnPattern);
+    }
+}

--- a/providers/jikkou-provider-confluent/src/main/java/io/streamthoughts/jikkou/extension/confluent/api/data/RoleBindingListResponse.java
+++ b/providers/jikkou-provider-confluent/src/main/java/io/streamthoughts/jikkou/extension/confluent/api/data/RoleBindingListResponse.java
@@ -1,0 +1,24 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.jikkou.extension.confluent.api.data;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.streamthoughts.jikkou.core.annotation.Reflectable;
+import java.util.List;
+
+/**
+ * Response from {@code GET /iam/v2/role-bindings}.
+ *
+ * @param metadata Pagination metadata.
+ * @param data     List of role binding entries.
+ */
+@Reflectable
+public record RoleBindingListResponse(
+    @JsonProperty("metadata") ListMetadata metadata,
+    @JsonProperty("data") List<RoleBindingData> data
+) {
+}

--- a/providers/jikkou-provider-confluent/src/main/java/io/streamthoughts/jikkou/extension/confluent/api/data/ServiceAccountData.java
+++ b/providers/jikkou-provider-confluent/src/main/java/io/streamthoughts/jikkou/extension/confluent/api/data/ServiceAccountData.java
@@ -1,0 +1,25 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.jikkou.extension.confluent.api.data;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.streamthoughts.jikkou.core.annotation.Reflectable;
+
+/**
+ * Confluent Cloud IAM v2 Service Account.
+ *
+ * @param id          Service account ID (e.g. {@code sa-12345}).
+ * @param displayName Service account display name.
+ * @param description Service account description.
+ */
+@Reflectable
+public record ServiceAccountData(
+    @JsonProperty("id") String id,
+    @JsonProperty("display_name") String displayName,
+    @JsonProperty("description") String description
+) {
+}

--- a/providers/jikkou-provider-confluent/src/main/java/io/streamthoughts/jikkou/extension/confluent/api/data/ServiceAccountListResponse.java
+++ b/providers/jikkou-provider-confluent/src/main/java/io/streamthoughts/jikkou/extension/confluent/api/data/ServiceAccountListResponse.java
@@ -1,0 +1,24 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.jikkou.extension.confluent.api.data;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.streamthoughts.jikkou.core.annotation.Reflectable;
+import java.util.List;
+
+/**
+ * Response from {@code GET /iam/v2/service-accounts}.
+ *
+ * @param metadata Pagination metadata.
+ * @param data     List of service accounts.
+ */
+@Reflectable
+public record ServiceAccountListResponse(
+    @JsonProperty("metadata") ListMetadata metadata,
+    @JsonProperty("data") List<ServiceAccountData> data
+) {
+}

--- a/providers/jikkou-provider-confluent/src/main/java/io/streamthoughts/jikkou/extension/confluent/api/data/UserData.java
+++ b/providers/jikkou-provider-confluent/src/main/java/io/streamthoughts/jikkou/extension/confluent/api/data/UserData.java
@@ -1,0 +1,25 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.jikkou.extension.confluent.api.data;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.streamthoughts.jikkou.core.annotation.Reflectable;
+
+/**
+ * Confluent Cloud IAM v2 User.
+ *
+ * @param id       User ID (e.g. {@code u-12345}).
+ * @param email    User email.
+ * @param fullName User full name.
+ */
+@Reflectable
+public record UserData(
+    @JsonProperty("id") String id,
+    @JsonProperty("email") String email,
+    @JsonProperty("full_name") String fullName
+) {
+}

--- a/providers/jikkou-provider-confluent/src/main/java/io/streamthoughts/jikkou/extension/confluent/api/data/UserListResponse.java
+++ b/providers/jikkou-provider-confluent/src/main/java/io/streamthoughts/jikkou/extension/confluent/api/data/UserListResponse.java
@@ -1,0 +1,24 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.jikkou.extension.confluent.api.data;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.streamthoughts.jikkou.core.annotation.Reflectable;
+import java.util.List;
+
+/**
+ * Response from {@code GET /iam/v2/users}.
+ *
+ * @param metadata Pagination metadata.
+ * @param data     List of users.
+ */
+@Reflectable
+public record UserListResponse(
+    @JsonProperty("metadata") ListMetadata metadata,
+    @JsonProperty("data") List<UserData> data
+) {
+}

--- a/providers/jikkou-provider-confluent/src/main/java/io/streamthoughts/jikkou/extension/confluent/change/RoleBindingChangeComputer.java
+++ b/providers/jikkou-provider-confluent/src/main/java/io/streamthoughts/jikkou/extension/confluent/change/RoleBindingChangeComputer.java
@@ -1,0 +1,67 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.jikkou.extension.confluent.change;
+
+import io.streamthoughts.jikkou.core.models.change.GenericResourceChange;
+import io.streamthoughts.jikkou.core.models.change.ResourceChange;
+import io.streamthoughts.jikkou.core.models.change.ResourceChangeSpec;
+import io.streamthoughts.jikkou.core.models.change.StateChange;
+import io.streamthoughts.jikkou.core.reconciler.Change;
+import io.streamthoughts.jikkou.core.reconciler.change.ResourceChangeComputer;
+import io.streamthoughts.jikkou.core.reconciler.change.ResourceChangeFactory;
+import io.streamthoughts.jikkou.extension.confluent.adapter.RoleBindingAdapter;
+import io.streamthoughts.jikkou.extension.confluent.api.data.RoleBindingData;
+import io.streamthoughts.jikkou.extension.confluent.models.V1RoleBinding;
+import java.util.ArrayList;
+import java.util.List;
+
+public final class RoleBindingChangeComputer extends ResourceChangeComputer<RoleBindingData, V1RoleBinding> {
+
+    /**
+     * Creates a new {@link RoleBindingChangeComputer} instance.
+     *
+     * @param deleteOrphans flag to indicate if orphan entries must be deleted.
+     */
+    public RoleBindingChangeComputer(boolean deleteOrphans) {
+        super(RoleBindingAdapter::map, new RoleBindingChangeFactory(), deleteOrphans);
+    }
+
+    static class RoleBindingChangeFactory extends ResourceChangeFactory<RoleBindingData, V1RoleBinding> {
+
+        public static final String ENTRY = "entry";
+
+        @Override
+        public ResourceChange createChangeForCreate(RoleBindingData key, V1RoleBinding after) {
+            return createChangeForUpdate(key, null, after);
+        }
+
+        @Override
+        public ResourceChange createChangeForDelete(RoleBindingData key, V1RoleBinding before) {
+            return createChangeForUpdate(key, before, null);
+        }
+
+        @Override
+        public ResourceChange createChangeForUpdate(RoleBindingData key,
+                                                    V1RoleBinding before,
+                                                    V1RoleBinding after) {
+            List<StateChange> changes = new ArrayList<>();
+            changes.add(StateChange.with(ENTRY,
+                RoleBindingAdapter.map(before),
+                RoleBindingAdapter.map(after))
+            );
+            return GenericResourceChange
+                .builder(V1RoleBinding.class)
+                .withSpec(ResourceChangeSpec
+                    .builder()
+                    .withOperation(Change.computeOperation(changes))
+                    .withChanges(changes)
+                    .build()
+                )
+                .build();
+        }
+    }
+}

--- a/providers/jikkou-provider-confluent/src/main/java/io/streamthoughts/jikkou/extension/confluent/change/RoleBindingChangeDescription.java
+++ b/providers/jikkou-provider-confluent/src/main/java/io/streamthoughts/jikkou/extension/confluent/change/RoleBindingChangeDescription.java
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.jikkou.extension.confluent.change;
+
+import io.streamthoughts.jikkou.core.reconciler.Operation;
+import io.streamthoughts.jikkou.core.reconciler.TextDescription;
+import io.streamthoughts.jikkou.extension.confluent.api.data.RoleBindingData;
+
+public final class RoleBindingChangeDescription {
+
+    public static TextDescription of(Operation type, RoleBindingData entry) {
+        return () -> String.format("%s Confluent Cloud Role Binding for principal '%s' (role=%s, crnPattern=%s)",
+            type.humanize(),
+            entry.principal(),
+            entry.roleName(),
+            entry.crnPattern()
+        );
+    }
+}

--- a/providers/jikkou-provider-confluent/src/main/java/io/streamthoughts/jikkou/extension/confluent/change/RoleBindingChangeHandler.java
+++ b/providers/jikkou-provider-confluent/src/main/java/io/streamthoughts/jikkou/extension/confluent/change/RoleBindingChangeHandler.java
@@ -1,0 +1,109 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.jikkou.extension.confluent.change;
+
+import io.streamthoughts.jikkou.core.data.TypeConverter;
+import io.streamthoughts.jikkou.core.models.change.ResourceChange;
+import io.streamthoughts.jikkou.core.models.change.SpecificStateChange;
+import io.streamthoughts.jikkou.core.reconciler.ChangeHandler;
+import io.streamthoughts.jikkou.core.reconciler.ChangeMetadata;
+import io.streamthoughts.jikkou.core.reconciler.ChangeResponse;
+import io.streamthoughts.jikkou.core.reconciler.Operation;
+import io.streamthoughts.jikkou.core.reconciler.TextDescription;
+import io.streamthoughts.jikkou.core.reconciler.change.BaseChangeHandler;
+import io.streamthoughts.jikkou.extension.confluent.api.ConfluentCloudApiClient;
+import io.streamthoughts.jikkou.extension.confluent.api.data.RoleBindingData;
+import jakarta.ws.rs.WebApplicationException;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import org.jetbrains.annotations.NotNull;
+
+public abstract class RoleBindingChangeHandler extends BaseChangeHandler {
+
+    protected final ConfluentCloudApiClient api;
+
+    public RoleBindingChangeHandler(@NotNull final ConfluentCloudApiClient api,
+                                    @NotNull final Operation supportedOperation) {
+        super(Set.of(supportedOperation));
+        this.api = Objects.requireNonNull(api, "api must not be null");
+    }
+
+    protected static RoleBindingData getEntry(ResourceChange change) {
+        SpecificStateChange<RoleBindingData> entry = change.getSpec()
+            .getChanges()
+            .getLast("entry", TypeConverter.of(RoleBindingData.class));
+        return change.getOp() == Operation.DELETE ? entry.getBefore() : entry.getAfter();
+    }
+
+    protected <R> ChangeResponse executeAsync(final ResourceChange change,
+                                              final java.util.function.Supplier<R> supplier) {
+        CompletableFuture<ChangeMetadata> future = CompletableFuture
+            .supplyAsync(() -> {
+                try {
+                    supplier.get();
+                    return ChangeMetadata.empty();
+                } catch (WebApplicationException e) {
+                    return ChangeMetadata.of(e);
+                }
+            });
+        return new ChangeResponse(change, future);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public TextDescription describe(@NotNull ResourceChange change) {
+        return RoleBindingChangeDescription.of(change.getSpec().getOp(), getEntry(change));
+    }
+
+    public static class Create extends RoleBindingChangeHandler {
+
+        public Create(@NotNull final ConfluentCloudApiClient api) {
+            super(api, Operation.CREATE);
+        }
+
+        @Override
+        public List<ChangeResponse> handleChanges(@NotNull List<ResourceChange> changes) {
+            return changes.stream()
+                .map(change -> executeAsync(
+                    change,
+                    () -> api.createRoleBinding(getEntry(change)))
+                )
+                .collect(Collectors.toList());
+        }
+    }
+
+    public static class Delete extends RoleBindingChangeHandler {
+
+        public Delete(@NotNull final ConfluentCloudApiClient api) {
+            super(api, Operation.DELETE);
+        }
+
+        @Override
+        public List<ChangeResponse> handleChanges(@NotNull List<ResourceChange> changes) {
+            return changes.stream()
+                .map(change -> {
+                    RoleBindingData entry = getEntry(change);
+                    return executeAsync(change, () -> {
+                        api.deleteRoleBinding(entry.id());
+                        return null;
+                    });
+                })
+                .collect(Collectors.toList());
+        }
+    }
+
+    public static class None extends ChangeHandler.None {
+        public None() {
+            super(change -> RoleBindingChangeDescription.of(change.getSpec().getOp(), getEntry(change)));
+        }
+    }
+}

--- a/providers/jikkou-provider-confluent/src/main/java/io/streamthoughts/jikkou/extension/confluent/collections/V1RoleBindingList.java
+++ b/providers/jikkou-provider-confluent/src/main/java/io/streamthoughts/jikkou/extension/confluent/collections/V1RoleBindingList.java
@@ -1,0 +1,57 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.jikkou.extension.confluent.collections;
+
+import io.streamthoughts.jikkou.core.annotation.ApiVersion;
+import io.streamthoughts.jikkou.core.annotation.Kind;
+import io.streamthoughts.jikkou.core.models.ObjectMeta;
+import io.streamthoughts.jikkou.core.models.SpecificResourceList;
+import io.streamthoughts.jikkou.extension.confluent.models.V1RoleBinding;
+import java.beans.ConstructorProperties;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+@ApiVersion("iam.confluent.cloud/v1")
+@Kind("RoleBindingList")
+public class V1RoleBindingList extends SpecificResourceList<V1RoleBindingList, V1RoleBinding> {
+
+    @ConstructorProperties({
+        "apiVersion",
+        "kind",
+        "metadata",
+        "items"
+    })
+    public V1RoleBindingList(@Nullable String apiVersion,
+                             @Nullable String kind,
+                             @Nullable ObjectMeta metadata,
+                             @NotNull List<V1RoleBinding> items) {
+        super(apiVersion, kind, metadata, items);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Builder toBuilder() {
+        return new Builder()
+            .withApiVersion(apiVersion)
+            .withKind(kind)
+            .withMetadata(metadata)
+            .withItems(items);
+    }
+
+    public static final class Builder extends SpecificResourceList.Builder<V1RoleBindingList.Builder, V1RoleBindingList, V1RoleBinding> {
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public V1RoleBindingList build() {
+            return new V1RoleBindingList(apiVersion, kind, metadata, items);
+        }
+    }
+}

--- a/providers/jikkou-provider-confluent/src/main/java/io/streamthoughts/jikkou/extension/confluent/models/V1RoleBinding.java
+++ b/providers/jikkou-provider-confluent/src/main/java/io/streamthoughts/jikkou/extension/confluent/models/V1RoleBinding.java
@@ -1,0 +1,128 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.jikkou.extension.confluent.models;
+
+import com.fasterxml.jackson.annotation.JsonClassDescription;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.streamthoughts.jikkou.core.annotation.ApiVersion;
+import io.streamthoughts.jikkou.core.annotation.Description;
+import io.streamthoughts.jikkou.core.annotation.Kind;
+import io.streamthoughts.jikkou.core.annotation.Names;
+import io.streamthoughts.jikkou.core.annotation.Reflectable;
+import io.streamthoughts.jikkou.core.annotation.Verbs;
+import io.streamthoughts.jikkou.core.models.HasMetadata;
+import io.streamthoughts.jikkou.core.models.HasSpec;
+import io.streamthoughts.jikkou.core.models.ObjectMeta;
+import io.streamthoughts.jikkou.core.models.Resource;
+import io.streamthoughts.jikkou.core.models.Verb;
+import java.beans.ConstructorProperties;
+import java.util.Objects;
+import lombok.Builder;
+import lombok.With;
+import lombok.extern.jackson.Jacksonized;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Builder(builderMethodName = "builder", toBuilder = true, setterPrefix = "with")
+@With
+@Description("The RoleBinding resource allows managing RBAC role bindings on Confluent Cloud.")
+@JsonClassDescription("The RoleBinding resource allows managing RBAC role bindings on Confluent Cloud.")
+@Names(singular = "ccloud-rb", plural = "ccloud-rbs", shortNames = {"ccrb"})
+@Verbs({
+    Verb.APPLY,
+    Verb.CREATE,
+    Verb.DELETE,
+    Verb.LIST
+})
+@JsonPropertyOrder({
+    "apiVersion",
+    "kind",
+    "metadata",
+    "spec"
+})
+@ApiVersion("iam.confluent.cloud/v1")
+@Kind("RoleBinding")
+@Jacksonized
+@Reflectable
+public class V1RoleBinding implements HasMetadata, HasSpec<V1RoleBindingSpec>, Resource {
+
+    @JsonProperty("apiVersion")
+    @Builder.Default
+    private String apiVersion = "iam.confluent.cloud/v1";
+
+    @JsonProperty("kind")
+    @Builder.Default
+    private String kind = "RoleBinding";
+
+    @JsonProperty("metadata")
+    private ObjectMeta metadata;
+
+    @JsonProperty("spec")
+    private V1RoleBindingSpec spec;
+
+    public V1RoleBinding() {
+    }
+
+    @ConstructorProperties({
+        "apiVersion",
+        "kind",
+        "metadata",
+        "spec"
+    })
+    public V1RoleBinding(String apiVersion, String kind, ObjectMeta metadata, V1RoleBindingSpec spec) {
+        this.apiVersion = apiVersion;
+        this.kind = kind;
+        this.metadata = metadata;
+        this.spec = spec;
+    }
+
+    @JsonProperty("apiVersion")
+    public String getApiVersion() {
+        return apiVersion;
+    }
+
+    @JsonProperty("kind")
+    public String getKind() {
+        return kind;
+    }
+
+    @JsonProperty("metadata")
+    public ObjectMeta getMetadata() {
+        return metadata;
+    }
+
+    @JsonProperty("spec")
+    public V1RoleBindingSpec getSpec() {
+        return spec;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof V1RoleBinding rhs)) return false;
+        return Objects.equals(apiVersion, rhs.apiVersion) &&
+            Objects.equals(kind, rhs.kind) &&
+            Objects.equals(metadata, rhs.metadata) &&
+            Objects.equals(spec, rhs.spec);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(apiVersion, kind, metadata, spec);
+    }
+
+    @Override
+    public String toString() {
+        return "V1RoleBinding[" +
+            "apiVersion=" + apiVersion +
+            ", kind=" + kind +
+            ", metadata=" + metadata +
+            ", spec=" + spec +
+            ']';
+    }
+}

--- a/providers/jikkou-provider-confluent/src/main/java/io/streamthoughts/jikkou/extension/confluent/models/V1RoleBindingSpec.java
+++ b/providers/jikkou-provider-confluent/src/main/java/io/streamthoughts/jikkou/extension/confluent/models/V1RoleBindingSpec.java
@@ -1,0 +1,107 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.jikkou.extension.confluent.models;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.streamthoughts.jikkou.core.annotation.Reflectable;
+import java.beans.ConstructorProperties;
+import java.util.Objects;
+import lombok.Builder;
+import lombok.With;
+import lombok.extern.jackson.Jacksonized;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Builder(builderMethodName = "builder", toBuilder = true, setterPrefix = "with")
+@With
+@JsonPropertyOrder({
+    "principal",
+    "roleName",
+    "crnPattern"
+})
+@Jacksonized
+@Reflectable
+public class V1RoleBindingSpec {
+
+    /**
+     * The principal (pattern: {@code ^(User|Group):.+$}).
+     * (Required)
+     */
+    @JsonProperty("principal")
+    @JsonPropertyDescription("The principal (e.g. User:sa-abc123 or Group:my-group)")
+    private String principal;
+
+    /**
+     * The role name (e.g. CloudClusterAdmin).
+     * (Required)
+     */
+    @JsonProperty("roleName")
+    @JsonPropertyDescription("The role name")
+    private String roleName;
+
+    /**
+     * The CRN pattern (pattern: {@code ^crn://.+$}).
+     * (Required)
+     */
+    @JsonProperty("crnPattern")
+    @JsonPropertyDescription("The Confluent Resource Name pattern")
+    private String crnPattern;
+
+    public V1RoleBindingSpec() {
+    }
+
+    @ConstructorProperties({
+        "principal",
+        "roleName",
+        "crnPattern"
+    })
+    public V1RoleBindingSpec(String principal, String roleName, String crnPattern) {
+        this.principal = principal;
+        this.roleName = roleName;
+        this.crnPattern = crnPattern;
+    }
+
+    @JsonProperty("principal")
+    public String getPrincipal() {
+        return principal;
+    }
+
+    @JsonProperty("roleName")
+    public String getRoleName() {
+        return roleName;
+    }
+
+    @JsonProperty("crnPattern")
+    public String getCrnPattern() {
+        return crnPattern;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof V1RoleBindingSpec rhs)) return false;
+        return Objects.equals(principal, rhs.principal) &&
+            Objects.equals(roleName, rhs.roleName) &&
+            Objects.equals(crnPattern, rhs.crnPattern);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(principal, roleName, crnPattern);
+    }
+
+    @Override
+    public String toString() {
+        return "V1RoleBindingSpec[" +
+            "principal=" + principal +
+            ", roleName=" + roleName +
+            ", crnPattern=" + crnPattern +
+            ']';
+    }
+}

--- a/providers/jikkou-provider-confluent/src/main/java/io/streamthoughts/jikkou/extension/confluent/reconciler/ConfluentCloudRoleBindingCollector.java
+++ b/providers/jikkou-provider-confluent/src/main/java/io/streamthoughts/jikkou/extension/confluent/reconciler/ConfluentCloudRoleBindingCollector.java
@@ -1,0 +1,144 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.jikkou.extension.confluent.reconciler;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import io.streamthoughts.jikkou.core.annotation.SupportedResource;
+import io.streamthoughts.jikkou.core.config.Configuration;
+import io.streamthoughts.jikkou.core.exceptions.ConfigException;
+import io.streamthoughts.jikkou.core.extension.ExtensionContext;
+import io.streamthoughts.jikkou.core.io.Jackson;
+import io.streamthoughts.jikkou.core.models.ObjectMeta;
+import io.streamthoughts.jikkou.core.models.ResourceList;
+import io.streamthoughts.jikkou.core.reconciler.Collector;
+import io.streamthoughts.jikkou.core.selector.Selector;
+import io.streamthoughts.jikkou.extension.confluent.ConfluentCloudExtensionProvider;
+import io.streamthoughts.jikkou.extension.confluent.adapter.RoleBindingAdapter;
+import io.streamthoughts.jikkou.extension.confluent.api.ConfluentCloudApiClient;
+import io.streamthoughts.jikkou.extension.confluent.api.ConfluentCloudApiClientConfig;
+import io.streamthoughts.jikkou.extension.confluent.api.ConfluentCloudApiClientException;
+import io.streamthoughts.jikkou.extension.confluent.api.ConfluentCloudApiClientFactory;
+import io.streamthoughts.jikkou.extension.confluent.api.data.RoleBindingData;
+import io.streamthoughts.jikkou.extension.confluent.collections.V1RoleBindingList;
+import io.streamthoughts.jikkou.extension.confluent.models.V1RoleBinding;
+import jakarta.ws.rs.WebApplicationException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@SupportedResource(type = V1RoleBinding.class)
+public class ConfluentCloudRoleBindingCollector implements Collector<V1RoleBinding> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ConfluentCloudRoleBindingCollector.class);
+
+    public static final String LABEL_PRINCIPAL_NAME = "confluent.cloud/principal-name";
+    public static final String LABEL_PRINCIPAL_EMAIL = "confluent.cloud/principal-email";
+
+    private ConfluentCloudApiClientConfig apiClientConfig;
+
+    public ConfluentCloudRoleBindingCollector() {
+    }
+
+    public ConfluentCloudRoleBindingCollector(ConfluentCloudApiClientConfig apiClientConfig) {
+        init(apiClientConfig);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void init(@NotNull final ExtensionContext context) {
+        init(context.<ConfluentCloudExtensionProvider>provider().apiClientConfig());
+    }
+
+    private void init(@NotNull ConfluentCloudApiClientConfig config) throws ConfigException {
+        this.apiClientConfig = config;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ResourceList<V1RoleBinding> listAll(@NotNull Configuration configuration,
+                                               @NotNull Selector selector) {
+        ConfluentCloudApiClient api = ConfluentCloudApiClientFactory.create(apiClientConfig);
+        try {
+            List<RoleBindingData> response = api.listRoleBindings();
+            Map<String, PrincipalInfo> principalLookup = buildPrincipalLookup(api);
+
+            List<V1RoleBinding> items = RoleBindingAdapter.map(response)
+                .stream()
+                .map(rb -> enrichWithPrincipalInfo(rb, principalLookup))
+                .filter(selector::apply)
+                .collect(Collectors.toList());
+
+            return new V1RoleBindingList.Builder().withItems(items).build();
+
+        } catch (WebApplicationException e) {
+            String response;
+            try {
+                response = Jackson.JSON_OBJECT_MAPPER.writerWithDefaultPrettyPrinter()
+                    .writeValueAsString(e.getResponse().readEntity(JsonNode.class));
+            } catch (JsonProcessingException ex) {
+                response = e.getResponse().readEntity(String.class);
+            }
+            throw new ConfluentCloudApiClientException(String.format(
+                "failed to list Confluent Cloud role bindings. %s:%n%s",
+                e.getLocalizedMessage(),
+                response
+            ), e);
+        } finally {
+            api.close();
+        }
+    }
+
+    private Map<String, PrincipalInfo> buildPrincipalLookup(ConfluentCloudApiClient api) {
+        Map<String, PrincipalInfo> lookup = new HashMap<>();
+        try {
+            api.listUsers().forEach(user ->
+                lookup.put("User:" + user.id(), new PrincipalInfo(user.fullName(), user.email()))
+            );
+        } catch (Exception e) {
+            LOG.warn("Failed to fetch users for principal name resolution: {}", e.getMessage());
+        }
+        try {
+            api.listServiceAccounts().forEach(sa ->
+                lookup.put("User:" + sa.id(), new PrincipalInfo(sa.displayName(), null))
+            );
+        } catch (Exception e) {
+            LOG.warn("Failed to fetch service accounts for principal name resolution: {}", e.getMessage());
+        }
+        return lookup;
+    }
+
+    private V1RoleBinding enrichWithPrincipalInfo(V1RoleBinding rb, Map<String, PrincipalInfo> lookup) {
+        String principal = rb.getSpec().getPrincipal();
+        PrincipalInfo info = lookup.get(principal);
+        if (info == null) {
+            return rb;
+        }
+
+        ObjectMeta meta = rb.getMetadata() != null ? rb.getMetadata() : ObjectMeta.builder().build();
+        ObjectMeta.ObjectMetaBuilder builder = meta.toBuilder();
+
+        if (info.name() != null) {
+            builder = builder.withLabel(LABEL_PRINCIPAL_NAME, info.name());
+        }
+        if (info.email() != null) {
+            builder = builder.withLabel(LABEL_PRINCIPAL_EMAIL, info.email());
+        }
+        return rb.withMetadata(builder.build());
+    }
+
+    private record PrincipalInfo(String name, String email) {
+    }
+}

--- a/providers/jikkou-provider-confluent/src/main/java/io/streamthoughts/jikkou/extension/confluent/reconciler/ConfluentCloudRoleBindingController.java
+++ b/providers/jikkou-provider-confluent/src/main/java/io/streamthoughts/jikkou/extension/confluent/reconciler/ConfluentCloudRoleBindingController.java
@@ -1,0 +1,123 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.jikkou.extension.confluent.reconciler;
+
+import static io.streamthoughts.jikkou.core.ReconciliationMode.CREATE;
+import static io.streamthoughts.jikkou.core.ReconciliationMode.DELETE;
+import static io.streamthoughts.jikkou.core.ReconciliationMode.FULL;
+
+import io.streamthoughts.jikkou.core.ReconciliationContext;
+import io.streamthoughts.jikkou.core.annotation.SupportedResource;
+import io.streamthoughts.jikkou.core.config.ConfigProperty;
+import io.streamthoughts.jikkou.core.exceptions.ConfigException;
+import io.streamthoughts.jikkou.core.extension.ExtensionContext;
+import io.streamthoughts.jikkou.core.models.change.ResourceChange;
+import io.streamthoughts.jikkou.core.reconciler.ChangeExecutor;
+import io.streamthoughts.jikkou.core.reconciler.ChangeHandler;
+import io.streamthoughts.jikkou.core.reconciler.ChangeResult;
+import io.streamthoughts.jikkou.core.reconciler.Controller;
+import io.streamthoughts.jikkou.core.reconciler.annotations.ControllerConfiguration;
+import io.streamthoughts.jikkou.core.selector.Selectors;
+import io.streamthoughts.jikkou.extension.confluent.ApiVersions;
+import io.streamthoughts.jikkou.extension.confluent.ConfluentCloudExtensionProvider;
+import io.streamthoughts.jikkou.extension.confluent.api.ConfluentCloudApiClient;
+import io.streamthoughts.jikkou.extension.confluent.api.ConfluentCloudApiClientConfig;
+import io.streamthoughts.jikkou.extension.confluent.api.ConfluentCloudApiClientFactory;
+import io.streamthoughts.jikkou.extension.confluent.change.RoleBindingChangeComputer;
+import io.streamthoughts.jikkou.extension.confluent.change.RoleBindingChangeHandler;
+import io.streamthoughts.jikkou.extension.confluent.models.V1RoleBinding;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.jetbrains.annotations.NotNull;
+
+@ControllerConfiguration(
+    supportedModes = {CREATE, DELETE, FULL}
+)
+@SupportedResource(type = V1RoleBinding.class)
+@SupportedResource(
+    apiVersion = ApiVersions.IAM_CONFLUENT_CLOUD_V1,
+    kind = "RoleBindingChange"
+)
+public class ConfluentCloudRoleBindingController implements Controller<V1RoleBinding> {
+
+    interface Config {
+        ConfigProperty<Boolean> DELETE_ORPHANS_OPTIONS = ConfigProperty
+            .ofBoolean("delete-orphans")
+            .defaultValue(false);
+    }
+
+    private final AtomicBoolean initialized = new AtomicBoolean(false);
+    private ConfluentCloudApiClientConfig apiClientConfig;
+    private ConfluentCloudRoleBindingCollector collector;
+
+    public ConfluentCloudRoleBindingController() {
+    }
+
+    public ConfluentCloudRoleBindingController(@NotNull ConfluentCloudApiClientConfig apiClientConfig) {
+        init(apiClientConfig);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void init(@NotNull final ExtensionContext context) {
+        init(context.<ConfluentCloudExtensionProvider>provider().apiClientConfig());
+    }
+
+    private void init(@NotNull ConfluentCloudApiClientConfig config) throws ConfigException {
+        if (initialized.compareAndSet(false, true)) {
+            this.apiClientConfig = config;
+            this.collector = new ConfluentCloudRoleBindingCollector(config);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<ChangeResult> execute(@NotNull final ChangeExecutor executor,
+                                      @NotNull ReconciliationContext context) {
+
+        ConfluentCloudApiClient api = ConfluentCloudApiClientFactory.create(apiClientConfig);
+        try {
+            List<ChangeHandler> handlers = List.of(
+                new RoleBindingChangeHandler.Create(api),
+                new RoleBindingChangeHandler.Delete(api),
+                new RoleBindingChangeHandler.None()
+            );
+            return executor.applyChanges(handlers);
+        } finally {
+            api.close();
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<ResourceChange> plan(
+        @NotNull Collection<V1RoleBinding> resources,
+        @NotNull ReconciliationContext context) {
+
+        // Get existing resources from the environment.
+        List<V1RoleBinding> actualResources = collector.listAll(context.configuration(), Selectors.NO_SELECTOR).stream()
+            .filter(context.selector()::apply)
+            .toList();
+
+        // Get expected resources which are candidates for this reconciliation.
+        List<V1RoleBinding> expectedResources = resources.stream()
+            .filter(context.selector()::apply)
+            .toList();
+
+        Boolean deleteOrphans = Config.DELETE_ORPHANS_OPTIONS.get(context.configuration());
+        RoleBindingChangeComputer computer = new RoleBindingChangeComputer(deleteOrphans);
+
+        return computer.computeChanges(actualResources, expectedResources);
+    }
+}

--- a/providers/jikkou-provider-confluent/src/main/resources/META-INF/native-image/io.streamthoughts/jikkou-provider-confluent/reachability-metadata.json
+++ b/providers/jikkou-provider-confluent/src/main/resources/META-INF/native-image/io.streamthoughts/jikkou-provider-confluent/reachability-metadata.json
@@ -1,0 +1,24 @@
+{
+  "reflection": [
+    {
+      "type": "io.streamthoughts.jikkou.extension.confluent.api.ConfluentCloudApi",
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "java.lang.AutoCloseable",
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "java.io.Closeable",
+      "allDeclaredMethods": true
+    },
+    {
+      "type": {
+        "proxy": [
+          "io.streamthoughts.jikkou.extension.confluent.api.ConfluentCloudApi",
+          "org.jboss.resteasy.client.jaxrs.internal.proxy.ResteasyClientProxy"
+        ]
+      }
+    }
+  ]
+}

--- a/providers/jikkou-provider-confluent/src/main/resources/META-INF/services/io.streamthoughts.jikkou.spi.ExtensionProvider
+++ b/providers/jikkou-provider-confluent/src/main/resources/META-INF/services/io.streamthoughts.jikkou.spi.ExtensionProvider
@@ -1,0 +1,1 @@
+io.streamthoughts.jikkou.extension.confluent.ConfluentCloudExtensionProvider

--- a/providers/jikkou-provider-confluent/src/test/java/io/streamthoughts/jikkou/extension/confluent/adapter/RoleBindingAdapterTest.java
+++ b/providers/jikkou-provider-confluent/src/test/java/io/streamthoughts/jikkou/extension/confluent/adapter/RoleBindingAdapterTest.java
@@ -1,0 +1,105 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.jikkou.extension.confluent.adapter;
+
+import io.streamthoughts.jikkou.core.models.ObjectMeta;
+import io.streamthoughts.jikkou.extension.confluent.MetadataAnnotations;
+import io.streamthoughts.jikkou.extension.confluent.api.data.RoleBindingData;
+import io.streamthoughts.jikkou.extension.confluent.models.V1RoleBinding;
+import io.streamthoughts.jikkou.extension.confluent.models.V1RoleBindingSpec;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class RoleBindingAdapterTest {
+
+    static final String TEST_ID = "rb-abc123";
+    static final String TEST_PRINCIPAL = "User:sa-test";
+    static final String TEST_ROLE = "CloudClusterAdmin";
+    static final String TEST_CRN = "crn://confluent.cloud/organization=org-123/environment=env-456";
+
+    @Test
+    void shouldMapResourceToData() {
+        V1RoleBinding resource = V1RoleBinding.builder()
+            .withMetadata(ObjectMeta.builder()
+                .withAnnotation(MetadataAnnotations.CONFLUENT_CLOUD_ROLE_BINDING_ID, TEST_ID)
+                .build())
+            .withSpec(V1RoleBindingSpec.builder()
+                .withPrincipal(TEST_PRINCIPAL)
+                .withRoleName(TEST_ROLE)
+                .withCrnPattern(TEST_CRN)
+                .build())
+            .build();
+
+        RoleBindingData result = RoleBindingAdapter.map(resource);
+
+        Assertions.assertEquals(TEST_ID, result.id());
+        Assertions.assertEquals(TEST_PRINCIPAL, result.principal());
+        Assertions.assertEquals(TEST_ROLE, result.roleName());
+        Assertions.assertEquals(TEST_CRN, result.crnPattern());
+    }
+
+    @Test
+    void shouldMapResourceToDataWithoutId() {
+        V1RoleBinding resource = V1RoleBinding.builder()
+            .withSpec(V1RoleBindingSpec.builder()
+                .withPrincipal(TEST_PRINCIPAL)
+                .withRoleName(TEST_ROLE)
+                .withCrnPattern(TEST_CRN)
+                .build())
+            .build();
+
+        RoleBindingData result = RoleBindingAdapter.map(resource);
+
+        Assertions.assertNull(result.id());
+        Assertions.assertEquals(TEST_PRINCIPAL, result.principal());
+    }
+
+    @Test
+    void shouldMapDataToResource() {
+        RoleBindingData data = new RoleBindingData(TEST_ID, TEST_PRINCIPAL, TEST_ROLE, TEST_CRN);
+
+        V1RoleBinding result = RoleBindingAdapter.map(data);
+
+        Assertions.assertEquals(TEST_PRINCIPAL, result.getSpec().getPrincipal());
+        Assertions.assertEquals(TEST_ROLE, result.getSpec().getRoleName());
+        Assertions.assertEquals(TEST_CRN, result.getSpec().getCrnPattern());
+        Assertions.assertEquals(TEST_ID,
+            result.getMetadata().findAnnotationByKey(MetadataAnnotations.CONFLUENT_CLOUD_ROLE_BINDING_ID).orElse(null));
+    }
+
+    @Test
+    void shouldMapDataWithoutIdToResource() {
+        RoleBindingData data = new RoleBindingData(TEST_PRINCIPAL, TEST_ROLE, TEST_CRN);
+
+        V1RoleBinding result = RoleBindingAdapter.map(data);
+
+        Assertions.assertEquals(TEST_PRINCIPAL, result.getSpec().getPrincipal());
+        Assertions.assertTrue(
+            result.getMetadata().findAnnotationByKey(MetadataAnnotations.CONFLUENT_CLOUD_ROLE_BINDING_ID).isEmpty());
+    }
+
+    @Test
+    void shouldMapListOfDataToResources() {
+        List<RoleBindingData> entries = List.of(
+            new RoleBindingData(TEST_ID, TEST_PRINCIPAL, TEST_ROLE, TEST_CRN),
+            new RoleBindingData("rb-xyz789", "User:sa-other", "DeveloperRead", TEST_CRN)
+        );
+
+        List<V1RoleBinding> result = RoleBindingAdapter.map(entries);
+
+        Assertions.assertEquals(2, result.size());
+        Assertions.assertEquals(TEST_PRINCIPAL, result.get(0).getSpec().getPrincipal());
+        Assertions.assertEquals("User:sa-other", result.get(1).getSpec().getPrincipal());
+    }
+
+    @Test
+    void shouldMapNullToNull() {
+        Assertions.assertNull(RoleBindingAdapter.map((V1RoleBinding) null));
+        Assertions.assertNull(RoleBindingAdapter.map((RoleBindingData) null));
+    }
+}

--- a/providers/jikkou-provider-confluent/src/test/java/io/streamthoughts/jikkou/extension/confluent/api/ConfluentCloudApiClientTest.java
+++ b/providers/jikkou-provider-confluent/src/test/java/io/streamthoughts/jikkou/extension/confluent/api/ConfluentCloudApiClientTest.java
@@ -1,0 +1,98 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.jikkou.extension.confluent.api;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.streamthoughts.jikkou.extension.confluent.api.data.ListMetadata;
+import io.streamthoughts.jikkou.extension.confluent.api.data.RoleBindingData;
+import io.streamthoughts.jikkou.extension.confluent.api.data.RoleBindingListResponse;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class ConfluentCloudApiClientTest {
+
+    static final String TEST_CRN = "crn://confluent.cloud/organization=org-123";
+
+    @Test
+    void shouldListAllRoleBindingsWithPagination() {
+        ConfluentCloudApi api = mock(ConfluentCloudApi.class);
+
+        // First page returns data with a next page token
+        RoleBindingData rb1 = new RoleBindingData("rb-1", "User:sa-1", "CloudClusterAdmin", TEST_CRN);
+        when(api.listRoleBindings(eq(TEST_CRN), anyInt(), eq(null)))
+            .thenReturn(new RoleBindingListResponse(
+                new ListMetadata(2, "next-token"),
+                List.of(rb1)
+            ));
+
+        // Second page returns data with no next page token
+        RoleBindingData rb2 = new RoleBindingData("rb-2", "User:sa-2", "DeveloperRead", TEST_CRN);
+        when(api.listRoleBindings(eq(TEST_CRN), anyInt(), eq("next-token")))
+            .thenReturn(new RoleBindingListResponse(
+                new ListMetadata(2, null),
+                List.of(rb2)
+            ));
+
+        ConfluentCloudApiClient client = new ConfluentCloudApiClient(api, TEST_CRN);
+        List<RoleBindingData> results = client.listRoleBindings();
+
+        Assertions.assertEquals(2, results.size());
+        Assertions.assertEquals("rb-1", results.get(0).id());
+        Assertions.assertEquals("rb-2", results.get(1).id());
+        verify(api, times(2)).listRoleBindings(eq(TEST_CRN), anyInt(), any());
+    }
+
+    @Test
+    void shouldListRoleBindingsWithSinglePage() {
+        ConfluentCloudApi api = mock(ConfluentCloudApi.class);
+
+        RoleBindingData rb1 = new RoleBindingData("rb-1", "User:sa-1", "CloudClusterAdmin", TEST_CRN);
+        when(api.listRoleBindings(eq(TEST_CRN), anyInt(), eq(null)))
+            .thenReturn(new RoleBindingListResponse(
+                new ListMetadata(1, null),
+                List.of(rb1)
+            ));
+
+        ConfluentCloudApiClient client = new ConfluentCloudApiClient(api, TEST_CRN);
+        List<RoleBindingData> results = client.listRoleBindings();
+
+        Assertions.assertEquals(1, results.size());
+        verify(api, times(1)).listRoleBindings(eq(TEST_CRN), anyInt(), any());
+    }
+
+    @Test
+    void shouldDelegateCreateRoleBinding() {
+        ConfluentCloudApi api = mock(ConfluentCloudApi.class);
+        RoleBindingData input = new RoleBindingData("User:sa-1", "CloudClusterAdmin", TEST_CRN);
+        RoleBindingData created = new RoleBindingData("rb-1", "User:sa-1", "CloudClusterAdmin", TEST_CRN);
+        when(api.createRoleBinding(input)).thenReturn(created);
+
+        ConfluentCloudApiClient client = new ConfluentCloudApiClient(api, TEST_CRN);
+        RoleBindingData result = client.createRoleBinding(input);
+
+        Assertions.assertEquals("rb-1", result.id());
+        verify(api, times(1)).createRoleBinding(input);
+    }
+
+    @Test
+    void shouldDelegateDeleteRoleBinding() {
+        ConfluentCloudApi api = mock(ConfluentCloudApi.class);
+
+        ConfluentCloudApiClient client = new ConfluentCloudApiClient(api, TEST_CRN);
+        client.deleteRoleBinding("rb-1");
+
+        verify(api, times(1)).deleteRoleBinding("rb-1");
+    }
+}

--- a/providers/jikkou-provider-confluent/src/test/java/io/streamthoughts/jikkou/extension/confluent/change/RoleBindingChangeComputerTest.java
+++ b/providers/jikkou-provider-confluent/src/test/java/io/streamthoughts/jikkou/extension/confluent/change/RoleBindingChangeComputerTest.java
@@ -1,0 +1,162 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.jikkou.extension.confluent.change;
+
+import io.streamthoughts.jikkou.core.models.ObjectMeta;
+import io.streamthoughts.jikkou.core.models.change.GenericResourceChange;
+import io.streamthoughts.jikkou.core.models.change.ResourceChange;
+import io.streamthoughts.jikkou.core.models.change.ResourceChangeSpec;
+import io.streamthoughts.jikkou.core.models.change.StateChange;
+import io.streamthoughts.jikkou.core.reconciler.Operation;
+import io.streamthoughts.jikkou.extension.confluent.MetadataAnnotations;
+import io.streamthoughts.jikkou.extension.confluent.api.data.RoleBindingData;
+import io.streamthoughts.jikkou.extension.confluent.models.V1RoleBinding;
+import io.streamthoughts.jikkou.extension.confluent.models.V1RoleBindingSpec;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class RoleBindingChangeComputerTest {
+
+    static final String TEST_PRINCIPAL = "User:sa-test";
+    static final String TEST_ROLE = "CloudClusterAdmin";
+    static final String TEST_CRN = "crn://confluent.cloud/organization=org-123";
+
+    @Test
+    void shouldReturnCreateChangeForNewRoleBinding() {
+        RoleBindingChangeComputer computer = new RoleBindingChangeComputer(false);
+
+        V1RoleBinding after = V1RoleBinding.builder()
+            .withSpec(V1RoleBindingSpec.builder()
+                .withPrincipal(TEST_PRINCIPAL)
+                .withRoleName(TEST_ROLE)
+                .withCrnPattern(TEST_CRN)
+                .build())
+            .build();
+
+        List<ResourceChange> changes = computer.computeChanges(
+            Collections.emptyList(),
+            List.of(after)
+        );
+
+        Assertions.assertEquals(1, changes.size());
+        Assertions.assertEquals(Operation.CREATE, changes.getFirst().getSpec().getOp());
+    }
+
+    @Test
+    void shouldReturnNoneChangeForExistingRoleBinding() {
+        RoleBindingChangeComputer computer = new RoleBindingChangeComputer(false);
+
+        V1RoleBinding existing = V1RoleBinding.builder()
+            .withMetadata(ObjectMeta.builder()
+                .withAnnotation(MetadataAnnotations.CONFLUENT_CLOUD_ROLE_BINDING_ID, "rb-123")
+                .build())
+            .withSpec(V1RoleBindingSpec.builder()
+                .withPrincipal(TEST_PRINCIPAL)
+                .withRoleName(TEST_ROLE)
+                .withCrnPattern(TEST_CRN)
+                .build())
+            .build();
+
+        V1RoleBinding expected = V1RoleBinding.builder()
+            .withSpec(V1RoleBindingSpec.builder()
+                .withPrincipal(TEST_PRINCIPAL)
+                .withRoleName(TEST_ROLE)
+                .withCrnPattern(TEST_CRN)
+                .build())
+            .build();
+
+        List<ResourceChange> changes = computer.computeChanges(
+            List.of(existing),
+            List.of(expected)
+        );
+
+        Assertions.assertEquals(1, changes.size());
+        Assertions.assertEquals(Operation.NONE, changes.getFirst().getSpec().getOp());
+    }
+
+    @Test
+    void shouldReturnDeleteChangeWhenOrphansDeleteEnabled() {
+        RoleBindingChangeComputer computer = new RoleBindingChangeComputer(true);
+
+        V1RoleBinding existing = V1RoleBinding.builder()
+            .withMetadata(ObjectMeta.builder()
+                .withAnnotation(MetadataAnnotations.CONFLUENT_CLOUD_ROLE_BINDING_ID, "rb-123")
+                .build())
+            .withSpec(V1RoleBindingSpec.builder()
+                .withPrincipal(TEST_PRINCIPAL)
+                .withRoleName(TEST_ROLE)
+                .withCrnPattern(TEST_CRN)
+                .build())
+            .build();
+
+        List<ResourceChange> changes = computer.computeChanges(
+            List.of(existing),
+            Collections.emptyList()
+        );
+
+        Assertions.assertEquals(1, changes.size());
+        Assertions.assertEquals(Operation.DELETE, changes.getFirst().getSpec().getOp());
+    }
+
+    @Test
+    void shouldNotReturnDeleteChangeWhenOrphansDeleteDisabled() {
+        RoleBindingChangeComputer computer = new RoleBindingChangeComputer(false);
+
+        V1RoleBinding existing = V1RoleBinding.builder()
+            .withMetadata(ObjectMeta.builder()
+                .withAnnotation(MetadataAnnotations.CONFLUENT_CLOUD_ROLE_BINDING_ID, "rb-123")
+                .build())
+            .withSpec(V1RoleBindingSpec.builder()
+                .withPrincipal(TEST_PRINCIPAL)
+                .withRoleName(TEST_ROLE)
+                .withCrnPattern(TEST_CRN)
+                .build())
+            .build();
+
+        List<ResourceChange> changes = computer.computeChanges(
+            List.of(existing),
+            Collections.emptyList()
+        );
+
+        Assertions.assertTrue(changes.isEmpty());
+    }
+
+    @Test
+    void shouldReturnCorrectCreateChangeSpec() {
+        RoleBindingChangeComputer computer = new RoleBindingChangeComputer(false);
+
+        V1RoleBinding after = V1RoleBinding.builder()
+            .withSpec(V1RoleBindingSpec.builder()
+                .withPrincipal(TEST_PRINCIPAL)
+                .withRoleName(TEST_ROLE)
+                .withCrnPattern(TEST_CRN)
+                .build())
+            .build();
+
+        List<ResourceChange> changes = computer.computeChanges(
+            Collections.emptyList(),
+            List.of(after)
+        );
+
+        ResourceChange expected = GenericResourceChange
+            .builder(V1RoleBinding.class)
+            .withSpec(ResourceChangeSpec
+                .builder()
+                .withOperation(Operation.CREATE)
+                .withChange(StateChange.create(
+                    "entry",
+                    new RoleBindingData(TEST_PRINCIPAL, TEST_ROLE, TEST_CRN))
+                )
+                .build()
+            )
+            .build();
+
+        Assertions.assertEquals(List.of(expected), changes);
+    }
+}

--- a/providers/jikkou-provider-confluent/src/test/java/io/streamthoughts/jikkou/extension/confluent/change/RoleBindingChangeHandlerTest.java
+++ b/providers/jikkou-provider-confluent/src/test/java/io/streamthoughts/jikkou/extension/confluent/change/RoleBindingChangeHandlerTest.java
@@ -1,0 +1,81 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.jikkou.extension.confluent.change;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.streamthoughts.jikkou.core.models.change.GenericResourceChange;
+import io.streamthoughts.jikkou.core.models.change.ResourceChange;
+import io.streamthoughts.jikkou.core.models.change.ResourceChangeSpec;
+import io.streamthoughts.jikkou.core.models.change.StateChange;
+import io.streamthoughts.jikkou.core.reconciler.ChangeResponse;
+import io.streamthoughts.jikkou.core.reconciler.Operation;
+import io.streamthoughts.jikkou.extension.confluent.api.ConfluentCloudApiClient;
+import io.streamthoughts.jikkou.extension.confluent.api.data.RoleBindingData;
+import io.streamthoughts.jikkou.extension.confluent.models.V1RoleBinding;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class RoleBindingChangeHandlerTest {
+
+    static final String TEST_PRINCIPAL = "User:sa-test";
+    static final String TEST_ROLE = "CloudClusterAdmin";
+    static final String TEST_CRN = "crn://confluent.cloud/organization=org-123";
+    static final String TEST_ID = "rb-abc123";
+
+    @Test
+    void shouldCallCreateRoleBinding() {
+        ConfluentCloudApiClient api = mock(ConfluentCloudApiClient.class);
+        RoleBindingData data = new RoleBindingData(TEST_PRINCIPAL, TEST_ROLE, TEST_CRN);
+        when(api.createRoleBinding(any())).thenReturn(
+            new RoleBindingData(TEST_ID, TEST_PRINCIPAL, TEST_ROLE, TEST_CRN));
+
+        RoleBindingChangeHandler.Create handler = new RoleBindingChangeHandler.Create(api);
+
+        ResourceChange change = GenericResourceChange
+            .builder(V1RoleBinding.class)
+            .withSpec(ResourceChangeSpec.builder()
+                .withOperation(Operation.CREATE)
+                .withChange(StateChange.create("entry", data))
+                .build())
+            .build();
+
+        List<ChangeResponse> responses = handler.handleChanges(List.of(change));
+
+        Assertions.assertEquals(1, responses.size());
+        // Wait for async completion
+        responses.getFirst().getResults().join();
+        verify(api, times(1)).createRoleBinding(any());
+    }
+
+    @Test
+    void shouldCallDeleteRoleBinding() {
+        ConfluentCloudApiClient api = mock(ConfluentCloudApiClient.class);
+        RoleBindingData data = new RoleBindingData(TEST_ID, TEST_PRINCIPAL, TEST_ROLE, TEST_CRN);
+
+        RoleBindingChangeHandler.Delete handler = new RoleBindingChangeHandler.Delete(api);
+
+        ResourceChange change = GenericResourceChange
+            .builder(V1RoleBinding.class)
+            .withSpec(ResourceChangeSpec.builder()
+                .withOperation(Operation.DELETE)
+                .withChange(StateChange.delete("entry", data))
+                .build())
+            .build();
+
+        List<ChangeResponse> responses = handler.handleChanges(List.of(change));
+
+        Assertions.assertEquals(1, responses.size());
+        responses.getFirst().getResults().join();
+        verify(api, times(1)).deleteRoleBinding(TEST_ID);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #491

- Add new `jikkou-provider-confluent` module for managing Confluent Cloud RBAC role bindings as code via the IAM v2 REST API
- Support `LIST`, `CREATE`, `DELETE` operations (no `UPDATE` — role bindings are immutable in the Confluent Cloud API)
- Change detection uses the `(principal, roleName, crnPattern)` triple as identifier
- Collector enriches role bindings with principal display names and emails (resolved from `/iam/v2/users` and `/iam/v2/service-accounts`) as metadata labels for better identification

### Resource spec

```yaml
apiVersion: "iam.confluent.cloud/v1"
kind: "RoleBinding"
metadata: {}
spec:
  principal: "User:u-abc123"
  roleName: "CloudClusterAdmin"
  crnPattern: "crn://confluent.cloud/organization=org-123/environment=env-456"
```

### Provider configuration

```hocon
provider.confluent-cloud {
  enabled = true
  type = io.streamthoughts.jikkou.extension.confluent.ConfluentCloudExtensionProvider
  config = {
    apiUrl = "https://api.confluent.cloud"  # default
    apiKey = ${CONFLUENT_CLOUD_API_KEY}      # Cloud API Key (not Cluster)
    apiSecret = ${CONFLUENT_CLOUD_API_SECRET}
    crnPattern = ${CONFLUENT_CLOUD_CRN_PATTERN}
    debugLoggingEnabled = false
  }
}
```

### Resource names

| Singular | Plural | Short |
|----------|--------|-------|
| `ccloud-rb` | `ccloud-rbs` | `ccrb` |

### Module structure

Follows the same pattern as the Aiven provider:
- `api/` — JAX-RS interface, client wrapper with pagination, factory with HTTP Basic auth
- `models/` — `V1RoleBinding`, `V1RoleBindingSpec` (hand-written, Lombok builders)
- `adapter/` — Bidirectional mapping between API DTOs and resource models
- `change/` — Change computer and handlers (CREATE/DELETE/NONE)
- `reconciler/` — Collector and controller
- GraalVM native-image reachability metadata included

## Test plan

- [x] `RoleBindingAdapterTest` — bidirectional mapping, null handling (6 tests)
- [x] `RoleBindingChangeComputerTest` — CREATE, NONE, DELETE with/without orphan deletion (5 tests)
- [x] `RoleBindingChangeHandlerTest` — mocked API create/delete calls (2 tests)
- [x] `ConfluentCloudApiClientTest` — pagination, delegation (4 tests)
- [x] Manual smoke test against Confluent Cloud — `jikkou get ccloud-rbs` returns role bindings with principal name labels