### PR TITLE
docs(confluent): add examples, documentation, and README for Confluent Cloud provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ ok: 0, created: 1, altered: 0, deleted: 0, failed: 0
 | Apache Kafka | Schema Registry | Kafka Connect | Cloud Providers |
 |:---:|:---:|:---:|:---:|
 | Topics & Configs | Avro Schemas | Connectors | Aiven (ACLs, Quotas) |
-| ACLs | JSON Schemas | | AWS Glue Schemas |
-| Quotas | Protobuf Schemas | | |
+| ACLs | JSON Schemas | | Confluent Cloud (RBAC) |
+| Quotas | Protobuf Schemas | | AWS Glue Schemas |
 | Consumer Groups | | | |
 | Brokers & Users | | | |
 | KTable Records | | | |

--- a/docs/content/en/docs/Providers/Confluent Cloud/Annotations/_index.md
+++ b/docs/content/en/docs/Providers/Confluent Cloud/Annotations/_index.md
@@ -1,0 +1,20 @@
+---
+title: "Annotations"
+linkTitle: "Annotations"
+weight: 60
+description: >
+  Learn how to use the metadata annotations provided by the extensions for Confluent Cloud.
+---
+
+{{% pageinfo %}}
+Here, you will find information about the annotations provided by the Confluent Cloud extension for Jikkou.
+{{% /pageinfo %}}
+
+### List of built-in annotations
+
+#### `confluent.cloud/role-binding-id`
+
+Used by Jikkou.
+
+The annotation is automatically added by Jikkou to store the Confluent Cloud role binding ID (e.g., `rb-NBl9kE`).
+This ID is used internally when deleting role bindings.

--- a/docs/content/en/docs/Providers/Confluent Cloud/Configuration/_index.md
+++ b/docs/content/en/docs/Providers/Confluent Cloud/Configuration/_index.md
@@ -1,0 +1,69 @@
+---
+title: "Configuration"
+linkTitle: "Configuration"
+weight: 2
+description: >
+  Learn how to configure the extensions for Confluent Cloud.
+---
+
+{{% pageinfo %}}
+Here, you will find the configuration for the Confluent Cloud extension.
+{{% /pageinfo %}}
+
+## Configuration
+
+You can configure the properties to connect to Confluent Cloud
+through the Jikkou client configuration property `jikkou.provider.confluent-cloud`.
+
+**Example:**
+
+```hocon
+jikkou {
+  provider.confluent-cloud {
+    enabled = true
+    type = io.streamthoughts.jikkou.extension.confluent.ConfluentCloudExtensionProvider
+    config = {
+      # URL to the Confluent Cloud REST API (default: https://api.confluent.cloud)
+      apiUrl = "https://api.confluent.cloud"
+      # Confluent Cloud API Key (must be a Cloud API Key, not a Cluster API Key)
+      apiKey = ${CONFLUENT_CLOUD_API_KEY}
+      # Confluent Cloud API Secret
+      apiSecret = ${CONFLUENT_CLOUD_API_SECRET}
+      # CRN pattern used to scope role binding list operations
+      crnPattern = ${CONFLUENT_CLOUD_CRN_PATTERN}
+      # Enable debug logging (default: false)
+      debugLoggingEnabled = false
+    }
+  }
+}
+```
+
+### Configuration Properties
+
+| Property             | Type    | Required | Default                        | Description                                                      |
+|----------------------|---------|----------|--------------------------------|------------------------------------------------------------------|
+| `apiUrl`             | String  | No       | `https://api.confluent.cloud`  | URL to the Confluent Cloud REST API.                             |
+| `apiKey`             | String  | Yes      |                                | Cloud API Key. Must be a **Cloud API Key**, not a Cluster API Key. |
+| `apiSecret`          | String  | Yes      |                                | Cloud API Secret.                                                |
+| `crnPattern`         | String  | Yes      |                                | CRN pattern to scope role binding list operations.               |
+| `debugLoggingEnabled`| Boolean | No       | `false`                        | Enable debug logging for REST API calls.                         |
+
+### Creating a Cloud API Key
+
+Cloud API Keys can be created using the Confluent Cloud CLI:
+
+```bash
+confluent api-key create --resource cloud --description "Jikkou role binding management"
+```
+
+> **Important:** You must use a **Cloud API Key** (organization-level), not a Cluster API Key. Cluster API Keys will result in a `401 Unauthorized` error.
+
+### CRN Pattern
+
+The `crnPattern` property is required and scopes all list operations to a specific part of your organization hierarchy. Examples:
+
+| Scope             | CRN Pattern                                                                      |
+|-------------------|----------------------------------------------------------------------------------|
+| Organization      | `crn://confluent.cloud/organization=org-abc123`                                  |
+| Environment       | `crn://confluent.cloud/organization=org-abc123/environment=env-def456`           |
+| Kafka Cluster     | `crn://confluent.cloud/organization=org-abc123/environment=env-def456/cloud-cluster=lkc-789` |

--- a/docs/content/en/docs/Providers/Confluent Cloud/Resources/_index.md
+++ b/docs/content/en/docs/Providers/Confluent Cloud/Resources/_index.md
@@ -1,0 +1,11 @@
+---
+title: "Resources"
+linkTitle: "Resources"
+weight: 3
+description: >
+  Learn about the resources supported by the Confluent Cloud extension.
+---
+
+{{% pageinfo %}}
+Here, you will find the list of resources supported by the extension for Confluent Cloud.
+{{% /pageinfo %}}

--- a/docs/content/en/docs/Providers/Confluent Cloud/Resources/role-binding.md
+++ b/docs/content/en/docs/Providers/Confluent Cloud/Resources/role-binding.md
@@ -1,0 +1,157 @@
+---
+categories: [ ]
+tags: [ "feature", "resources" ]
+title: "Role Bindings for Confluent Cloud"
+linkTitle: "Role Bindings for Confluent Cloud"
+weight: 10
+description: >
+  Learn how to manage RBAC Role Bindings in Confluent Cloud.
+---
+
+{{% pageinfo color="info" %}}
+The `RoleBinding` resources are used to manage RBAC role bindings in Confluent Cloud. A
+`RoleBinding` resource defines which role is granted to a principal for a specific scope (identified by a CRN pattern).
+{{% /pageinfo %}}
+
+## `RoleBinding`
+
+### Specification
+
+Here is the _resource definition file_ for defining a `RoleBinding`.
+
+```yaml
+---
+apiVersion: "iam.confluent.cloud/v1"    # The api version (required)
+kind: "RoleBinding"                     # The resource kind (required)
+metadata:
+  labels: { }
+  annotations: { }
+spec:
+  principal: <>              # The principal (e.g., User:sa-abc123 or User:u-xyz789)
+  roleName: <>               # The role name (e.g., CloudClusterAdmin, DeveloperRead)
+  crnPattern: <>             # The Confluent Resource Name pattern (e.g., crn://confluent.cloud/...)
+```
+
+### Fields
+
+| Field         | Type   | Required | Description                                                                 |
+|---------------|--------|----------|-----------------------------------------------------------------------------|
+| `principal`   | String | Yes      | The principal. Pattern: `User:<user-id>` or `Group:<group-name>`.           |
+| `roleName`    | String | Yes      | The role to bind. See [Confluent Cloud RBAC roles](https://docs.confluent.io/cloud/current/security/access-control/rbac/predefined-rbac-roles.html). |
+| `crnPattern`  | String | Yes      | The Confluent Resource Name (CRN) pattern defining the scope of the binding. |
+
+### Common Role Names
+
+| Role                     | Description                                    |
+|--------------------------|------------------------------------------------|
+| `OrganizationAdmin`      | Full access to the organization.               |
+| `EnvironmentAdmin`       | Full access to an environment.                 |
+| `CloudClusterAdmin`      | Full access to a Kafka cluster.                |
+| `DeveloperManage`        | Manage topics and schemas.                     |
+| `DeveloperRead`          | Read from topics and view schemas.             |
+| `DeveloperWrite`         | Write to topics and manage schemas.            |
+| `ResourceOwner`          | Full access to a specific resource.            |
+
+### Example
+
+Here is a simple example that shows how to define a single role binding using
+the `RoleBinding` resource type.
+
+_`file: role-binding.yaml`_
+
+```yaml
+---
+apiVersion: "iam.confluent.cloud/v1"
+kind: "RoleBinding"
+metadata:
+  labels: { }
+  annotations: { }
+spec:
+  principal: "User:sa-abc123"
+  roleName: "CloudClusterAdmin"
+  crnPattern: "crn://confluent.cloud/organization=org-123/environment=env-456/cloud-cluster=lkc-789"
+```
+
+### Usage
+
+```bash
+# List all role bindings
+jikkou get ccloud-rbs
+
+# Apply role bindings from a file
+jikkou apply --files ./role-binding.yaml
+
+# Delete orphan role bindings not defined in the file
+jikkou apply --files ./role-binding.yaml -o delete-orphans=true
+
+# Dry-run to preview changes without applying
+jikkou diff --files ./role-binding.yaml
+```
+
+### Metadata Labels
+
+When listing role bindings, Jikkou automatically enriches each resource with metadata labels
+to help identify principals:
+
+| Label                              | Description                                          |
+|------------------------------------|------------------------------------------------------|
+| `confluent.cloud/principal-name`   | The display name of the user or service account.     |
+| `confluent.cloud/principal-email`  | The email of the user (not set for service accounts). |
+
+**Example output:**
+
+```yaml
+apiVersion: "iam.confluent.cloud/v1"
+kind: "RoleBinding"
+metadata:
+  labels:
+    confluent.cloud/principal-name: "Florian Hussonnois"
+    confluent.cloud/principal-email: "florian@example.com"
+  annotations:
+    confluent.cloud/role-binding-id: "rb-NBl9kE"
+spec:
+  principal: "User:u-rrnm2g9"
+  roleName: "OrganizationAdmin"
+  crnPattern: "crn://confluent.cloud/organization=d497af93-23f5-434a-a008-0547797be410"
+```
+
+## `RoleBindingList`
+
+If you need to define multiple role bindings (e.g., using a template), it may be easier to use a `RoleBindingList` resource.
+
+### Specification
+
+Here is the _resource definition file_ for defining a `RoleBindingList`.
+
+```yaml
+---
+apiVersion: "iam.confluent.cloud/v1"    # The api version (required)
+kind: "RoleBindingList"                 # The resource kind (required)
+metadata: # (optional)
+  labels: { }
+  annotations: { }
+items: [ ]                             # An array of RoleBinding
+```
+
+### Example
+
+```yaml
+---
+apiVersion: "iam.confluent.cloud/v1"
+kind: "RoleBindingList"
+items:
+  - spec:
+      principal: "User:sa-abc123"
+      roleName: "CloudClusterAdmin"
+      crnPattern: "crn://confluent.cloud/organization=org-123/environment=env-456/cloud-cluster=lkc-789"
+  - spec:
+      principal: "User:sa-abc123"
+      roleName: "DeveloperRead"
+      crnPattern: "crn://confluent.cloud/organization=org-123/environment=env-456/cloud-cluster=lkc-789/kafka=lkc-789/topic=my-topic"
+  - spec:
+      principal: "User:u-xyz789"
+      roleName: "OrganizationAdmin"
+      crnPattern: "crn://confluent.cloud/organization=org-123"
+```
+
+> **Note:** Role bindings are immutable in the Confluent Cloud API. If you need to change a role binding, delete the old one and create a new one. Jikkou only supports `CREATE` and `DELETE` operations (no `UPDATE`).

--- a/docs/content/en/docs/Providers/Confluent Cloud/_index.md
+++ b/docs/content/en/docs/Providers/Confluent Cloud/_index.md
@@ -1,0 +1,13 @@
+---
+title: "Confluent Cloud"
+linkTitle: "Confluent Cloud"
+weight: 55
+description: >
+  Learn how to use the Jikkou Extensions Provider for Confluent Cloud.
+---
+
+{{% pageinfo %}}
+Here, you will find information to use the [Confluent Cloud](https://confluent.cloud/) extensions.
+{{% /pageinfo %}}
+
+More information:

--- a/examples/confluent-cloud/role-binding-list.yaml
+++ b/examples/confluent-cloud/role-binding-list.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: "iam.confluent.cloud/v1"
+kind: "RoleBindingList"
+items:
+  - spec:
+      principal: "User:sa-abc123"
+      roleName: "CloudClusterAdmin"
+      crnPattern: "crn://confluent.cloud/organization=org-123/environment=env-456/cloud-cluster=lkc-789"
+  - spec:
+      principal: "User:sa-abc123"
+      roleName: "DeveloperRead"
+      crnPattern: "crn://confluent.cloud/organization=org-123/environment=env-456/cloud-cluster=lkc-789/kafka=lkc-789/topic=my-topic"
+  - spec:
+      principal: "User:u-xyz789"
+      roleName: "OrganizationAdmin"
+      crnPattern: "crn://confluent.cloud/organization=org-123"

--- a/examples/confluent-cloud/role-binding.yaml
+++ b/examples/confluent-cloud/role-binding.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: "iam.confluent.cloud/v1"
+kind: "RoleBinding"
+metadata:
+  labels: {}
+  annotations: {}
+spec:
+  principal: "User:sa-abc123"
+  roleName: "CloudClusterAdmin"
+  crnPattern: "crn://confluent.cloud/organization=org-123/environment=env-456/cloud-cluster=lkc-789"

--- a/providers/jikkou-provider-confluent/README.md
+++ b/providers/jikkou-provider-confluent/README.md
@@ -1,0 +1,3 @@
+# Confluent Cloud Extension Provider for Jikkou
+
+This module provides integration between Jikkou and Confluent Cloud for managing RBAC role bindings via the IAM v2 REST API.


### PR DESCRIPTION
## Summary

Follow-up to #737 — adds documentation, examples, and README for the new Confluent Cloud provider.

- Add example YAML files for `RoleBinding` and `RoleBindingList` resources in `examples/confluent-cloud/`
- Add provider documentation (configuration, resources, annotations) in `docs/content/en/docs/Providers/Confluent Cloud/`
- Add `providers/jikkou-provider-confluent/README.md`
- Update main `README.md` to include Confluent Cloud (RBAC) in supported resources table

## Test plan

- [x] Verify examples are valid YAML matching the resource spec
- [x] Verify documentation follows existing provider doc patterns (Aiven, AWS)