### PR TITLE
fix(ci): improve CI/CD pipeline reliability and build caching

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -14,7 +14,6 @@ on:
 env:
   JAVA_VERSION: '25'
   JAVA_DISTRO: 'zulu'
-  GRAAL_VERSION: '25.0.1'
   GRAAL_DISTRIBUTION: 'graalvm-community'
 
 permissions:
@@ -32,12 +31,19 @@ jobs:
       - name: 'Set up GraalVM'
         uses: graalvm/setup-graalvm@v1
         with:
-          #  version: ${{ env.GRAAL_VERSION }}
           java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.GRAAL_DISTRIBUTION }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           components: 'native-image'
           native-image-job-reports: 'true'
           native-image-musl: 'true'
+
+      - name: 'Cache Maven packages'
+        uses: actions/cache@v5
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven-
 
       - name: 'Login to DockerHub'
         uses: docker/login-action@v4
@@ -103,6 +109,7 @@ jobs:
         with:
           distribution: ${{ env.JAVA_DISTRO }}
           java-version: ${{ env.JAVA_VERSION }}
+          cache: maven
 
       - name: 'Login to DockerHub'
         uses: docker/login-action@v4
@@ -168,6 +175,7 @@ jobs:
         with:
           distribution: ${{ env.JAVA_DISTRO }}
           java-version: ${{ env.JAVA_VERSION }}
+          cache: maven
 
       - name: 'Login to DockerHub'
         uses: docker/login-action@v4

--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -12,7 +12,6 @@ on:
 env:
   JAVA_VERSION: '25'
   JAVA_DISTRO: 'zulu'
-  GRAAL_VERSION: '25.0.1'
   GRAAL_DISTRIBUTION: 'graalvm-community'
 
 permissions:
@@ -57,6 +56,13 @@ jobs:
         with:
           distribution: ${{ env.JAVA_DISTRO }}
           java-version: ${{ env.JAVA_VERSION }}
+
+      - name: 'Cache Maven packages'
+        uses: actions/cache@v5
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven-
 
       - name: 'Build Native Image (Linux)'
         if: ${{ runner.os == 'Linux' && matrix.setup == 'graalvm' }}

--- a/.github/workflows/github-page.yml
+++ b/.github/workflows/github-page.yml
@@ -34,13 +34,13 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: '0.120.3'
+          hugo-version: '0.139.6'
           extended: true
 
       - name: Setup node
         uses: actions/setup-node@v6
         with:
-          node-version: "14.x"
+          node-version: "20.x"
       - run: (cd ./docs; npm install)
 
       - name: Build

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -18,7 +18,6 @@ env:
 
 permissions:
   contents: read
-  security-events: write
 
 jobs:
   build:
@@ -26,6 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
+      contents: read
       pull-requests: write
       security-events: write
     steps:

--- a/.github/workflows/maven-deploy.yml
+++ b/.github/workflows/maven-deploy.yml
@@ -14,8 +14,6 @@ on:
 env:
   JAVA_VERSION: '25'
   JAVA_DISTRO: 'zulu'
-  GRAAL_VERSION: '25.0.1'
-  GRAAL_DISTRIBUTION: 'graalvm-community'
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,6 @@ on:
 env:
   JAVA_VERSION: '25'
   JAVA_DISTRO: 'zulu'
-  GRAAL_VERSION: '25.0.1'
   GRAAL_DISTRIBUTION: 'graalvm-community'
 
 permissions:
@@ -123,6 +122,13 @@ jobs:
         with:
           distribution: ${{ env.JAVA_DISTRO }}
           java-version: ${{ env.JAVA_VERSION }}
+
+      - name: 'Cache Maven packages'
+        uses: actions/cache@v5
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven-
 
       - name: 'Build Native Image (Linux)'
         if: ${{ runner.os == 'Linux' && matrix.setup == 'graalvm' }}

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -33,8 +33,7 @@
         <ascii-table.version>1.9.0</ascii-table.version>
         <executable-suffix/>
         <rpm-maven-plugin.version>2.3.0</rpm-maven-plugin.version>
-        <!-- Micronaut -->
-        <micronaut.version>4.10.10</micronaut.version>
+        <!-- Micronaut (version inherited from parent) -->
         <micronaut.core.version>4.10.17</micronaut.core.version>
         <micronaut-maven-plugin.version>4.11.6</micronaut-maven-plugin.version>
         <micronaut-picocli-bom.version>5.9.0</micronaut-picocli-bom.version>

--- a/docs/assets/scss/_styles_project.scss
+++ b/docs/assets/scss/_styles_project.scss
@@ -245,6 +245,23 @@ h1.hero-title {
     margin-bottom: 0;
 }
 
+.hero-rotating-wrapper {
+    display: inline-grid;
+}
+
+.hero-rotating-text {
+    grid-area: 1 / 1;
+    opacity: 0;
+    transform: translateY(20px);
+    transition: opacity 0.5s ease, transform 0.5s ease;
+    white-space: nowrap;
+
+    &.active {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
 .hero-gradient-text {
     background: linear-gradient(135deg, $purple-light, $cyan, $pink);
     background-size: 200% 200%;
@@ -252,6 +269,15 @@ h1.hero-title {
     -webkit-text-fill-color: transparent;
     background-clip: text;
     animation: gradientShift 6s ease-in-out infinite;
+
+    &--iceberg {
+        background: linear-gradient(135deg, #b2ebf2, #0097a7, #e0f7fa, #00838f);
+        background-size: 200% 200%;
+        -webkit-background-clip: text;
+        -webkit-text-fill-color: transparent;
+        background-clip: text;
+        animation: gradientShift 6s ease-in-out infinite;
+    }
 }
 
 @keyframes gradientShift {

--- a/docs/content/en/_index.md
+++ b/docs/content/en/_index.md
@@ -1,7 +1,7 @@
 ---
-title: "Resource as Code Framework for Apache Kafka"
+title: "Resource as Code Framework for Apache Kafka and Apache Iceberg"
 linkTitle: Jikkou
-description: "Jikkou is an open-source Resource as Code framework for Apache Kafka. Declare, automate, and provision Topics, ACLs, Schemas, Quotas, and Connectors from YAML files."
+description: "Jikkou is an open-source Resource as Code framework for Apache Kafka and Apache Iceberg. Declare, automate, and provision Topics, ACLs, Schemas, Quotas, Connectors, and Iceberg resources from YAML files."
 ---
 
 {{% blocks/cover image_anchor="top" height="max" color="white" %}}
@@ -12,7 +12,7 @@ description: "Jikkou is an open-source Resource as Code framework for Apache Kaf
                 <span class="hero-badge-dot"></span>
                 Open Source &middot; Apache License 2.0
             </div>
-            <h1 class="hero-title">Resource as Code<br/>for <span class="hero-gradient-text">Apache Kafka</span><span class="hero-reg">&reg;</span></h1>
+            <h1 class="hero-title">Resource as Code<br/>for <span class="hero-rotating-wrapper"><span class="hero-rotating-text active"><span class="hero-gradient-text">Apache Kafka</span><span class="hero-reg">&reg;</span></span><span class="hero-rotating-text"><span class="hero-gradient-text hero-gradient-text--iceberg">Apache Iceberg</span><span class="hero-reg">&reg;</span></span></span></h1>
             <p class="hero-subtitle">
                 Declare, automate, and provision Topics, ACLs, Schemas, Quotas, and Connectors for your entire Kafka platform — from simple YAML files.
             </p>
@@ -245,3 +245,16 @@ description: "Jikkou is an open-source Resource as Code framework for Apache Kaf
         </div>
     </div>
 </section>
+
+<script>
+(function() {
+    const texts = document.querySelectorAll('.hero-rotating-text');
+    if (texts.length < 2) return;
+    let current = 0;
+    setInterval(function() {
+        texts[current].classList.remove('active');
+        current = (current + 1) % texts.length;
+        texts[current].classList.add('active');
+    }, 5000);
+})();
+</script>

--- a/pom.xml
+++ b/pom.xml
@@ -143,6 +143,8 @@
         <mockito-core.version>5.21.0</mockito-core.version>
         <junit-jupiter.version>1.21.4</junit-jupiter.version>
         <awssdk.version>2.31.66</awssdk.version>
+        <!-- Micronaut (centralized - used by cli and server modules) -->
+        <micronaut.version>4.10.10</micronaut.version>
     </properties>
 
     <dependencyManagement>

--- a/server/jikkou-api-server/pom.xml
+++ b/server/jikkou-api-server/pom.xml
@@ -25,8 +25,7 @@
     <properties>
         <packaging>jar</packaging>
         <license.header.file>${project.parent.basedir}/header</license.header.file>
-        <!-- Micronaut properties -->
-        <micronaut.version>4.10.10</micronaut.version>
+        <!-- Micronaut properties (version inherited from parent) -->
         <micronaut.core.version>4.10.17</micronaut.core.version>
         <micronaut-maven-plugin.version>4.11.6</micronaut-maven-plugin.version>
         <micronaut.aot.enabled>false</micronaut.aot.enabled>


### PR DESCRIPTION
- Remove stale GRAAL_VERSION env vars (java-version is used instead)
- Fix GraalVM setup in docker-build-push to use distribution param
- Centralize micronaut.version in parent POM to avoid duplication
- Add Maven dependency caching to docker-build-push, early-access, and release workflows
- Update Hugo to 0.139.6 and Node.js to 20.x for GitHub Pages
- Update SonarCloud project key and organization to match new repo