### PR TITLE
test: add unit tests for processor and resource-generator modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,8 @@
         <appassembler-maven-plugin.version>2.1.0</appassembler-maven-plugin.version>
         <protobuf-java.version>4.33.5</protobuf-java.version>
         <jsonschema-generator.version>4.38.0</jsonschema-generator.version>
+        <!-- JaCoCo coverage minimum (0.0 = off, 0.50 = 50%). Modules can override. -->
+        <jacoco.check.minimum>0.0</jacoco.check.minimum>
         <mockito-core.version>5.21.0</mockito-core.version>
         <junit-jupiter.version>1.21.4</junit-jupiter.version>
     </properties>
@@ -673,6 +675,29 @@
                             </fileSets>
                             <!-- report config -->
                             <dataFile>${project.basedir}/../target/jacoco.exec</dataFile>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>check</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <dataFile>${project.basedir}/../target/jacoco-unit.exec</dataFile>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>${jacoco.check.minimum}</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
                         </configuration>
                     </execution>
                 </executions>

--- a/processor/pom.xml
+++ b/processor/pom.xml
@@ -16,6 +16,7 @@
     <properties>
         <license.header.file>${project.parent.basedir}/header</license.header.file>
         <reactor-core.version>3.6.6</reactor-core.version>
+        <jacoco.check.minimum>0.50</jacoco.check.minimum>
     </properties>
 
     <dependencies>
@@ -23,6 +24,12 @@
             <groupId>io.streamthoughts</groupId>
             <artifactId>jikkou-core</artifactId>
             <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.testing.compile</groupId>
+            <artifactId>compile-testing</artifactId>
+            <version>0.21.0</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/processor/src/test/java/io/streamthoughts/jikkou/core/processor/ProviderProcessorTest.java
+++ b/processor/src/test/java/io/streamthoughts/jikkou/core/processor/ProviderProcessorTest.java
@@ -1,0 +1,225 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.jikkou.core.processor;
+
+import static com.google.testing.compile.CompilationSubject.assertThat;
+import static com.google.testing.compile.Compiler.javac;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.testing.compile.Compilation;
+import com.google.testing.compile.JavaFileObjects;
+import java.io.IOException;
+import java.util.Set;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardLocation;
+import org.junit.jupiter.api.Test;
+
+class ProviderProcessorTest {
+
+    private static final String VALID_PROVIDER_TEMPLATE = """
+            package com.example;
+
+            import io.streamthoughts.jikkou.core.annotation.Provider;
+            import io.streamthoughts.jikkou.core.extension.ExtensionRegistry;
+            import io.streamthoughts.jikkou.core.resource.ResourceRegistry;
+            import io.streamthoughts.jikkou.spi.ExtensionProvider;
+            import org.jetbrains.annotations.NotNull;
+
+            @Provider(name = "%s")
+            public class %s implements ExtensionProvider {
+                public %s() {}
+                @Override public void registerExtensions(@NotNull ExtensionRegistry registry) {}
+                @Override public void registerResources(@NotNull ResourceRegistry registry) {}
+            }
+            """;
+
+    @Test
+    void shouldReturnProviderAnnotationType() {
+        ProviderProcessor processor = new ProviderProcessor();
+        Set<String> types = processor.getSupportedAnnotationTypes();
+        assertEquals(Set.of("io.streamthoughts.jikkou.core.annotation.Provider"), types);
+    }
+
+    @Test
+    void shouldGenerateServiceFileForValidProvider() {
+        JavaFileObject source = JavaFileObjects.forSourceString(
+                "com.example.TestProvider",
+                VALID_PROVIDER_TEMPLATE.formatted("test-provider", "TestProvider", "TestProvider"));
+
+        Compilation compilation = javac()
+                .withProcessors(new ProviderProcessor())
+                .compile(source);
+
+        assertThat(compilation).succeeded();
+        assertThat(compilation)
+                .generatedFile(StandardLocation.CLASS_OUTPUT, ProviderProcessor.PROVIDER_RESOURCE_FILE)
+                .contentsAsUtf8String()
+                .contains("com.example.TestProvider");
+    }
+
+    @Test
+    void shouldNotIncludeAbstractProviderInServiceFile() {
+        JavaFileObject source = JavaFileObjects.forSourceString(
+                "com.example.AbstractProvider",
+                """
+                package com.example;
+
+                import io.streamthoughts.jikkou.core.annotation.Provider;
+                import io.streamthoughts.jikkou.spi.ExtensionProvider;
+
+                @Provider(name = "abstract-provider")
+                public abstract class AbstractProvider implements ExtensionProvider {
+                }
+                """);
+
+        Compilation compilation = javac()
+                .withProcessors(new ProviderProcessor())
+                .compile(source);
+
+        assertThat(compilation).succeeded();
+        assertServiceFileDoesNotContain(compilation, "com.example.AbstractProvider");
+    }
+
+    @Test
+    void shouldNotIncludeProviderWithoutNoArgConstructor() {
+        JavaFileObject source = JavaFileObjects.forSourceString(
+                "com.example.NoArgProvider",
+                """
+                package com.example;
+
+                import io.streamthoughts.jikkou.core.annotation.Provider;
+                import io.streamthoughts.jikkou.core.extension.ExtensionRegistry;
+                import io.streamthoughts.jikkou.core.resource.ResourceRegistry;
+                import io.streamthoughts.jikkou.spi.ExtensionProvider;
+                import org.jetbrains.annotations.NotNull;
+
+                @Provider(name = "no-arg-provider")
+                public class NoArgProvider implements ExtensionProvider {
+
+                    public NoArgProvider(String arg) {}
+
+                    @Override public void registerExtensions(@NotNull ExtensionRegistry registry) {}
+                    @Override public void registerResources(@NotNull ResourceRegistry registry) {}
+                }
+                """);
+
+        Compilation compilation = javac()
+                .withProcessors(new ProviderProcessor())
+                .compile(source);
+
+        assertThat(compilation).succeeded();
+        assertServiceFileDoesNotContain(compilation, "com.example.NoArgProvider");
+    }
+
+    @Test
+    void shouldNotIncludeNonExtensionProviderClass() {
+        JavaFileObject source = JavaFileObjects.forSourceString(
+                "com.example.NotAProvider",
+                """
+                package com.example;
+
+                import io.streamthoughts.jikkou.core.annotation.Provider;
+
+                @Provider(name = "not-a-provider")
+                public class NotAProvider {
+                    public NotAProvider() {}
+                }
+                """);
+
+        Compilation compilation = javac()
+                .withProcessors(new ProviderProcessor())
+                .compile(source);
+
+        assertThat(compilation).succeeded();
+        assertServiceFileDoesNotContain(compilation, "com.example.NotAProvider");
+    }
+
+    private static void assertServiceFileDoesNotContain(Compilation compilation, String className) {
+        var serviceFile = compilation.generatedFile(
+                StandardLocation.CLASS_OUTPUT,
+                ProviderProcessor.PROVIDER_RESOURCE_FILE);
+        if (serviceFile.isEmpty()) {
+            return; // No file generated = class not included, which is correct
+        }
+        try {
+            String content = serviceFile.get().getCharContent(false).toString();
+            assertFalse(content.contains(className),
+                    "Class " + className + " should not appear in service file, but found: " + content);
+        } catch (java.io.FileNotFoundException e) {
+            // File reference exists but content does not — effectively empty, which is correct
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void shouldGenerateServiceFileWithMultipleProviders() {
+        JavaFileObject source1 = JavaFileObjects.forSourceString(
+                "com.example.ProviderA",
+                VALID_PROVIDER_TEMPLATE.formatted("provider-a", "ProviderA", "ProviderA"));
+
+        JavaFileObject source2 = JavaFileObjects.forSourceString(
+                "com.example.ProviderB",
+                VALID_PROVIDER_TEMPLATE.formatted("provider-b", "ProviderB", "ProviderB"));
+
+        Compilation compilation = javac()
+                .withProcessors(new ProviderProcessor())
+                .compile(source1, source2);
+
+        assertThat(compilation).succeeded();
+
+        var serviceFile = compilation.generatedFile(
+                StandardLocation.CLASS_OUTPUT,
+                ProviderProcessor.PROVIDER_RESOURCE_FILE);
+        assertTrue(serviceFile.isPresent());
+
+        try {
+            String content = serviceFile.get().getCharContent(false).toString();
+            assertTrue(content.contains("com.example.ProviderA"));
+            assertTrue(content.contains("com.example.ProviderB"));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void shouldHandleInnerClassProvider() {
+        JavaFileObject source = JavaFileObjects.forSourceString(
+                "com.example.Outer",
+                """
+                package com.example;
+
+                import io.streamthoughts.jikkou.core.annotation.Provider;
+                import io.streamthoughts.jikkou.core.extension.ExtensionRegistry;
+                import io.streamthoughts.jikkou.core.resource.ResourceRegistry;
+                import io.streamthoughts.jikkou.spi.ExtensionProvider;
+                import org.jetbrains.annotations.NotNull;
+
+                public class Outer {
+
+                    @Provider(name = "inner-provider")
+                    public static class InnerProvider implements ExtensionProvider {
+                        public InnerProvider() {}
+                        @Override public void registerExtensions(@NotNull ExtensionRegistry registry) {}
+                        @Override public void registerResources(@NotNull ResourceRegistry registry) {}
+                    }
+                }
+                """);
+
+        Compilation compilation = javac()
+                .withProcessors(new ProviderProcessor())
+                .compile(source);
+
+        assertThat(compilation).succeeded();
+        assertThat(compilation)
+                .generatedFile(StandardLocation.CLASS_OUTPUT, ProviderProcessor.PROVIDER_RESOURCE_FILE)
+                .contentsAsUtf8String()
+                .contains("com.example.Outer$InnerProvider");
+    }
+}

--- a/processor/src/test/java/io/streamthoughts/jikkou/core/processor/ServicesFilesTest.java
+++ b/processor/src/test/java/io/streamthoughts/jikkou/core/processor/ServicesFilesTest.java
@@ -1,0 +1,133 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.jikkou.core.processor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class ServicesFilesTest {
+
+    @Test
+    void shouldReturnCorrectPath() {
+        String path = ServicesFiles.getPath("com.example.MyService");
+        assertEquals("META-INF/services/com.example.MyService", path);
+    }
+
+    @Test
+    void shouldReadEmptyServiceFile() throws IOException {
+        InputStream input = toInputStream("");
+        Set<String> result = ServicesFiles.readServiceFile(input);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void shouldReadSingleServiceEntry() throws IOException {
+        InputStream input = toInputStream("com.example.ServiceA\n");
+        Set<String> result = ServicesFiles.readServiceFile(input);
+        assertEquals(Set.of("com.example.ServiceA"), result);
+    }
+
+    @Test
+    void shouldReadMultipleServiceEntries() throws IOException {
+        String content = "com.example.ServiceA\ncom.example.ServiceB\ncom.example.ServiceC\n";
+        InputStream input = toInputStream(content);
+        Set<String> result = ServicesFiles.readServiceFile(input);
+        assertEquals(Set.of("com.example.ServiceA", "com.example.ServiceB", "com.example.ServiceC"), result);
+    }
+
+    @Test
+    void shouldIgnoreComments() throws IOException {
+        String content = "# This is a comment\ncom.example.ServiceA\n# Another comment\ncom.example.ServiceB\n";
+        InputStream input = toInputStream(content);
+        Set<String> result = ServicesFiles.readServiceFile(input);
+        assertEquals(Set.of("com.example.ServiceA", "com.example.ServiceB"), result);
+    }
+
+    @Test
+    void shouldIgnoreInlineComments() throws IOException {
+        String content = "com.example.ServiceA # inline comment\n";
+        InputStream input = toInputStream(content);
+        Set<String> result = ServicesFiles.readServiceFile(input);
+        assertEquals(Set.of("com.example.ServiceA"), result);
+    }
+
+    @Test
+    void shouldTrimWhitespace() throws IOException {
+        String content = "  com.example.ServiceA  \n  \n\tcom.example.ServiceB\t\n";
+        InputStream input = toInputStream(content);
+        Set<String> result = ServicesFiles.readServiceFile(input);
+        assertEquals(Set.of("com.example.ServiceA", "com.example.ServiceB"), result);
+    }
+
+    @Test
+    void shouldSkipBlankLines() throws IOException {
+        String content = "\n\ncom.example.ServiceA\n\n\ncom.example.ServiceB\n\n";
+        InputStream input = toInputStream(content);
+        Set<String> result = ServicesFiles.readServiceFile(input);
+        assertEquals(Set.of("com.example.ServiceA", "com.example.ServiceB"), result);
+    }
+
+    @Test
+    void shouldSkipCommentOnlyLines() throws IOException {
+        String content = "# only comments\n# another comment\n";
+        InputStream input = toInputStream(content);
+        Set<String> result = ServicesFiles.readServiceFile(input);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void shouldDeduplicateEntries() throws IOException {
+        String content = "com.example.ServiceA\ncom.example.ServiceA\n";
+        InputStream input = toInputStream(content);
+        Set<String> result = ServicesFiles.readServiceFile(input);
+        assertEquals(1, result.size());
+        assertTrue(result.contains("com.example.ServiceA"));
+    }
+
+    @Test
+    void shouldWriteServiceFile() throws IOException {
+        Collection<String> services = List.of("com.example.ServiceA", "com.example.ServiceB");
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        ServicesFiles.writeServiceFile(services, output);
+        String result = output.toString(StandardCharsets.UTF_8);
+        assertEquals("com.example.ServiceA\ncom.example.ServiceB\n", result);
+    }
+
+    @Test
+    void shouldWriteEmptyServiceFile() throws IOException {
+        Collection<String> services = List.of();
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        ServicesFiles.writeServiceFile(services, output);
+        String result = output.toString(StandardCharsets.UTF_8);
+        assertEquals("", result);
+    }
+
+    @Test
+    void shouldRoundTripServiceFile() throws IOException {
+        Collection<String> original = List.of("com.example.Alpha", "com.example.Beta");
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        ServicesFiles.writeServiceFile(original, output);
+
+        InputStream input = new ByteArrayInputStream(output.toByteArray());
+        Set<String> readBack = ServicesFiles.readServiceFile(input);
+        assertEquals(Set.of("com.example.Alpha", "com.example.Beta"), readBack);
+    }
+
+    private static InputStream toInputStream(String content) {
+        return new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/resource-generator/pom.xml
+++ b/resource-generator/pom.xml
@@ -22,6 +22,7 @@
 
     <properties>
         <license.header.file>${project.parent.basedir}/header</license.header.file>
+        <jacoco.check.minimum>0.50</jacoco.check.minimum>
     </properties>
 
     <dependencies>

--- a/resource-generator/src/test/java/io/streamthoughts/jikkou/generator/JikkouAnnotatorTest.java
+++ b/resource-generator/src/test/java/io/streamthoughts/jikkou/generator/JikkouAnnotatorTest.java
@@ -1,0 +1,340 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.jikkou.generator;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.sun.codemodel.JAnnotationUse;
+import com.sun.codemodel.JCodeModel;
+import com.sun.codemodel.JDefinedClass;
+import com.sun.codemodel.JFieldVar;
+import com.sun.codemodel.JMod;
+import java.util.Collection;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class JikkouAnnotatorTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private JikkouAnnotator annotator;
+    private JCodeModel codeModel;
+
+    @BeforeEach
+    void setUp() {
+        annotator = new JikkouAnnotator();
+        codeModel = new JCodeModel();
+    }
+
+    @Test
+    void shouldReturnFalseForAdditionalPropertiesSupported() {
+        assertFalse(annotator.isAdditionalPropertiesSupported());
+    }
+
+    // --- propertyField tests ---
+
+    @Test
+    void shouldAnnotateArrayFieldWithSingular() throws Exception {
+        JDefinedClass clazz = codeModel._class("com.example.TestClass");
+        JFieldVar field = clazz.field(JMod.PRIVATE, String.class, "items");
+
+        ObjectNode propertyNode = MAPPER.createObjectNode();
+        propertyNode.put("type", "array");
+
+        annotator.propertyField(field, clazz, "items", propertyNode);
+
+        assertTrue(hasAnnotation(field.annotations(), "lombok.Singular"));
+    }
+
+    @Test
+    void shouldNotAnnotateNonArrayFieldWithSingular() throws Exception {
+        JDefinedClass clazz = codeModel._class("com.example.TestClass");
+        JFieldVar field = clazz.field(JMod.PRIVATE, String.class, "name");
+
+        ObjectNode propertyNode = MAPPER.createObjectNode();
+        propertyNode.put("type", "string");
+
+        annotator.propertyField(field, clazz, "name", propertyNode);
+
+        assertFalse(hasAnnotation(field.annotations(), "lombok.Singular"));
+    }
+
+    @Test
+    void shouldAnnotateFieldWithDefaultValue() throws Exception {
+        JDefinedClass clazz = codeModel._class("com.example.TestClass");
+        JFieldVar field = clazz.field(JMod.PRIVATE, String.class, "status");
+
+        ObjectNode propertyNode = MAPPER.createObjectNode();
+        propertyNode.put("type", "string");
+        propertyNode.put("default", "active");
+
+        annotator.propertyField(field, clazz, "status", propertyNode);
+
+        assertTrue(hasAnnotation(field.annotations(), "lombok.Builder.Default"));
+    }
+
+    @Test
+    void shouldNotAnnotateFieldWithoutDefaultValue() throws Exception {
+        JDefinedClass clazz = codeModel._class("com.example.TestClass");
+        JFieldVar field = clazz.field(JMod.PRIVATE, String.class, "status");
+
+        ObjectNode propertyNode = MAPPER.createObjectNode();
+        propertyNode.put("type", "string");
+
+        annotator.propertyField(field, clazz, "status", propertyNode);
+
+        assertFalse(hasAnnotation(field.annotations(), "lombok.Builder.Default"));
+    }
+
+    @Test
+    void shouldAnnotateArrayFieldWithDefaultWithBothAnnotations() throws Exception {
+        JDefinedClass clazz = codeModel._class("com.example.TestClass");
+        JFieldVar field = clazz.field(JMod.PRIVATE, String.class, "tags");
+
+        ObjectNode propertyNode = MAPPER.createObjectNode();
+        propertyNode.put("type", "array");
+        propertyNode.putArray("default");
+
+        annotator.propertyField(field, clazz, "tags", propertyNode);
+
+        assertTrue(hasAnnotation(field.annotations(), "lombok.Singular"));
+        assertTrue(hasAnnotation(field.annotations(), "lombok.Builder.Default"));
+    }
+
+    // --- propertyOrder tests ---
+
+    @Test
+    void shouldAnnotateClassWithApiVersionFromProperties() throws Exception {
+        JDefinedClass clazz = codeModel._class("com.example.TestResource");
+
+        ObjectNode propertiesNode = MAPPER.createObjectNode();
+        ObjectNode apiVersionNode = MAPPER.createObjectNode();
+        apiVersionNode.put("default", "v1beta1");
+        propertiesNode.set("apiVersion", apiVersionNode);
+
+        annotator.propertyOrder(clazz, propertiesNode);
+
+        assertTrue(hasAnnotation(clazz.annotations(), "io.streamthoughts.jikkou.core.annotation.ApiVersion"));
+        assertTrue(hasAnnotation(clazz.annotations(), "lombok.extern.jackson.Jacksonized"));
+        assertTrue(hasAnnotation(clazz.annotations(), "io.streamthoughts.jikkou.core.annotation.Reflectable"));
+    }
+
+    @Test
+    void shouldAnnotateClassWithKindFromProperties() throws Exception {
+        JDefinedClass clazz = codeModel._class("com.example.TestResource");
+
+        ObjectNode propertiesNode = MAPPER.createObjectNode();
+        ObjectNode kindNode = MAPPER.createObjectNode();
+        kindNode.put("default", "KafkaTopic");
+        propertiesNode.set("kind", kindNode);
+
+        annotator.propertyOrder(clazz, propertiesNode);
+
+        assertTrue(hasAnnotation(clazz.annotations(), "io.streamthoughts.jikkou.core.annotation.Kind"));
+    }
+
+    @Test
+    void shouldAlwaysAnnotateWithJacksonizedAndReflectable() throws Exception {
+        JDefinedClass clazz = codeModel._class("com.example.TestResource");
+
+        ObjectNode propertiesNode = MAPPER.createObjectNode();
+
+        annotator.propertyOrder(clazz, propertiesNode);
+
+        assertTrue(hasAnnotation(clazz.annotations(), "lombok.extern.jackson.Jacksonized"));
+        assertTrue(hasAnnotation(clazz.annotations(), "io.streamthoughts.jikkou.core.annotation.Reflectable"));
+    }
+
+    @Test
+    void shouldNotAnnotateWithApiVersionWhenNoDefaultPresent() throws Exception {
+        JDefinedClass clazz = codeModel._class("com.example.TestResource");
+
+        ObjectNode propertiesNode = MAPPER.createObjectNode();
+        ObjectNode apiVersionNode = MAPPER.createObjectNode();
+        apiVersionNode.put("type", "string"); // no "default" field
+        propertiesNode.set("apiVersion", apiVersionNode);
+
+        annotator.propertyOrder(clazz, propertiesNode);
+
+        assertFalse(hasAnnotation(clazz.annotations(), "io.streamthoughts.jikkou.core.annotation.ApiVersion"));
+    }
+
+    // --- propertyInclusion tests ---
+
+    @Test
+    void shouldAddDefaultAnnotationsWhenNoAdditionalProperties() throws Exception {
+        JDefinedClass clazz = codeModel._class("com.example.TestClass");
+
+        ObjectNode schema = MAPPER.createObjectNode();
+        // no "additionalProperties" key
+
+        annotator.propertyInclusion(clazz, schema);
+
+        // Default annotations should be added (all enabledByDefault=false in JikkouAnnotator,
+        // so no lombok annotations should be added by default)
+        // The method calls addDefaultAnnotations which adds all enabled-by-default annotations
+        // Since all are enabledByDefault=false, no lombok annotations should be present
+        Set<String> annotationNames = getAnnotationNames(clazz.annotations());
+        assertFalse(annotationNames.contains("lombok.Getter"));
+        assertFalse(annotationNames.contains("lombok.Setter"));
+    }
+
+    @Test
+    void shouldAddLombokGetterWhenExplicitlyEnabled() throws Exception {
+        JDefinedClass clazz = codeModel._class("com.example.TestClass");
+
+        ObjectNode schema = MAPPER.createObjectNode();
+        ObjectNode additionalProperties = MAPPER.createObjectNode();
+        additionalProperties.put("lombok-getter", true);
+        schema.set("additionalProperties", additionalProperties);
+
+        annotator.propertyInclusion(clazz, schema);
+
+        assertTrue(hasAnnotation(clazz.annotations(), "lombok.Getter"));
+    }
+
+    @Test
+    void shouldNotAddLombokGetterWhenExplicitlyDisabled() throws Exception {
+        JDefinedClass clazz = codeModel._class("com.example.TestClass");
+
+        ObjectNode schema = MAPPER.createObjectNode();
+        ObjectNode additionalProperties = MAPPER.createObjectNode();
+        additionalProperties.put("lombok-getter", false);
+        schema.set("additionalProperties", additionalProperties);
+
+        annotator.propertyInclusion(clazz, schema);
+
+        assertFalse(hasAnnotation(clazz.annotations(), "lombok.Getter"));
+    }
+
+    @Test
+    void shouldAddMultipleLombokAnnotations() throws Exception {
+        JDefinedClass clazz = codeModel._class("com.example.TestClass");
+
+        ObjectNode schema = MAPPER.createObjectNode();
+        ObjectNode additionalProperties = MAPPER.createObjectNode();
+        additionalProperties.put("lombok-getter", true);
+        additionalProperties.put("lombok-setter", true);
+        additionalProperties.put("lombok-builder", true);
+        schema.set("additionalProperties", additionalProperties);
+
+        annotator.propertyInclusion(clazz, schema);
+
+        assertTrue(hasAnnotation(clazz.annotations(), "lombok.Getter"));
+        assertTrue(hasAnnotation(clazz.annotations(), "lombok.Setter"));
+        assertTrue(hasAnnotation(clazz.annotations(), "lombok.Builder"));
+    }
+
+    @Test
+    void shouldAddDescriptionAnnotation() throws Exception {
+        JDefinedClass clazz = codeModel._class("com.example.TestClass");
+
+        ObjectNode schema = MAPPER.createObjectNode();
+        ObjectNode additionalProperties = MAPPER.createObjectNode();
+        additionalProperties.put("lombok-getter", true);
+        schema.set("additionalProperties", additionalProperties);
+        schema.put("description", "A test resource description");
+
+        annotator.propertyInclusion(clazz, schema);
+
+        assertTrue(hasAnnotation(clazz.annotations(), "io.streamthoughts.jikkou.core.annotation.Description"));
+        assertTrue(hasAnnotation(clazz.annotations(), "com.fasterxml.jackson.annotation.JsonClassDescription"));
+    }
+
+    @Test
+    void shouldAddNamesAnnotationFromSpec() throws Exception {
+        JDefinedClass clazz = codeModel._class("com.example.TestClass");
+
+        ObjectNode schema = MAPPER.createObjectNode();
+        ObjectNode additionalProperties = MAPPER.createObjectNode();
+        additionalProperties.put("lombok-getter", true);
+
+        ObjectNode spec = MAPPER.createObjectNode();
+        ObjectNode names = MAPPER.createObjectNode();
+        names.put("singular", "topic");
+        names.put("plural", "topics");
+        names.putArray("shortNames").add("kt");
+        spec.set("names", names);
+        additionalProperties.set("spec", spec);
+        schema.set("additionalProperties", additionalProperties);
+
+        annotator.propertyInclusion(clazz, schema);
+
+        assertTrue(hasAnnotation(clazz.annotations(), "io.streamthoughts.jikkou.core.annotation.Names"));
+        assertTrue(hasAnnotation(clazz.annotations(), "io.streamthoughts.jikkou.core.annotation.Verbs"));
+    }
+
+    @Test
+    void shouldAddVerbsAnnotationFromSpec() throws Exception {
+        JDefinedClass clazz = codeModel._class("com.example.TestClass");
+
+        ObjectNode schema = MAPPER.createObjectNode();
+        ObjectNode additionalProperties = MAPPER.createObjectNode();
+        additionalProperties.put("lombok-getter", true);
+
+        ObjectNode spec = MAPPER.createObjectNode();
+        spec.putArray("verbs").add("get").add("list").add("create");
+        additionalProperties.set("spec", spec);
+        schema.set("additionalProperties", additionalProperties);
+
+        annotator.propertyInclusion(clazz, schema);
+
+        assertTrue(hasAnnotation(clazz.annotations(), "io.streamthoughts.jikkou.core.annotation.Verbs"));
+    }
+
+    @Test
+    void shouldAddTransientAnnotationFromSpec() throws Exception {
+        JDefinedClass clazz = codeModel._class("com.example.TestClass");
+
+        ObjectNode schema = MAPPER.createObjectNode();
+        ObjectNode additionalProperties = MAPPER.createObjectNode();
+        additionalProperties.put("lombok-getter", true);
+
+        ObjectNode spec = MAPPER.createObjectNode();
+        spec.put("isTransient", true);
+        additionalProperties.set("spec", spec);
+        schema.set("additionalProperties", additionalProperties);
+
+        annotator.propertyInclusion(clazz, schema);
+
+        assertTrue(hasAnnotation(clazz.annotations(), "io.streamthoughts.jikkou.core.annotation.Transient"));
+    }
+
+    @Test
+    void shouldNotAddTransientAnnotationWhenNotInSpec() throws Exception {
+        JDefinedClass clazz = codeModel._class("com.example.TestClass");
+
+        ObjectNode schema = MAPPER.createObjectNode();
+        ObjectNode additionalProperties = MAPPER.createObjectNode();
+        additionalProperties.put("lombok-getter", true);
+
+        ObjectNode spec = MAPPER.createObjectNode();
+        additionalProperties.set("spec", spec);
+        schema.set("additionalProperties", additionalProperties);
+
+        annotator.propertyInclusion(clazz, schema);
+
+        assertFalse(hasAnnotation(clazz.annotations(), "io.streamthoughts.jikkou.core.annotation.Transient"));
+    }
+
+    // --- Helper methods ---
+
+    private static boolean hasAnnotation(Collection<JAnnotationUse> annotations, String annotationFqn) {
+        return getAnnotationNames(annotations).contains(annotationFqn);
+    }
+
+    private static Set<String> getAnnotationNames(Collection<JAnnotationUse> annotations) {
+        return annotations.stream()
+                .map(a -> a.getAnnotationClass().fullName())
+                .collect(Collectors.toSet());
+    }
+}


### PR DESCRIPTION
Add comprehensive unit tests for both modules that previously had zero test coverage:

- ServicesFilesTest: 13 tests covering read/write/round-trip of service files, comment handling, whitespace trimming, and deduplication
- ProviderProcessorTest: 7 tests using compile-testing to verify annotation processor generates correct service files for valid providers and rejects abstract, no-arg-less, and non-provider classes
- JikkouAnnotatorTest: 16 tests covering propertyField (Singular, Builder.Default), propertyOrder (ApiVersion, Kind, Jacksonized, Reflectable), and propertyInclusion (Lombok annotations, Description, Names, Verbs, Transient)

Also add JaCoCo coverage check enforcement:
- Parent POM: add jacoco check execution with configurable minimum (default 0.0 so existing modules are unaffected)
- processor and resource-generator modules: set 50% line coverage minimum