### PR TITLE
fix(kafka-connect): call .get() on basicAuth Supplier fields in KafkaConnectApiFactory

### DIFF
--- a/providers/jikkou-provider-kafka-connect/pom.xml
+++ b/providers/jikkou-provider-kafka-connect/pom.xml
@@ -65,6 +65,12 @@
             <version>1.21.4</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <version>${mockwebserver.version}</version>
+            <scope>test</scope>
+        </dependency>
         <!-- END dependencies for test -->
     </dependencies>
 

--- a/providers/jikkou-provider-kafka-connect/src/main/java/io/streamthoughts/jikkou/kafka/connect/api/KafkaConnectApiFactory.java
+++ b/providers/jikkou-provider-kafka-connect/src/main/java/io/streamthoughts/jikkou/kafka/connect/api/KafkaConnectApiFactory.java
@@ -73,7 +73,7 @@ public final class KafkaConnectApiFactory {
 
     @NotNull
     private static String getAuthorizationHeader(KafkaConnectClientConfig config) {
-        String basicAuthInfo = config.basicAuthUser() + ":" + config.basicAuthPassword();
+        String basicAuthInfo = config.basicAuthUser().get() + ":" + config.basicAuthPassword().get();
         return "Basic " + Encoding.BASE64.encode(basicAuthInfo.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/providers/jikkou-provider-kafka-connect/src/test/java/io/streamthoughts/jikkou/kafka/connect/api/KafkaConnectApiFactoryTest.java
+++ b/providers/jikkou-provider-kafka-connect/src/test/java/io/streamthoughts/jikkou/kafka/connect/api/KafkaConnectApiFactoryTest.java
@@ -1,0 +1,69 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.jikkou.kafka.connect.api;
+
+import io.streamthoughts.jikkou.core.config.Configuration;
+import io.streamthoughts.jikkou.http.client.ssl.SSLConfig;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class KafkaConnectApiFactoryTest {
+
+    private static MockWebServer mockServer;
+
+    @BeforeAll
+    static void beforeAll() throws IOException {
+        mockServer = new MockWebServer();
+        mockServer.start();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        mockServer.close();
+    }
+
+    @Test
+    @DisplayName("Should build Authorization header from actual basicAuth credentials")
+    void shouldBuildBasicAuthHeaderFromActualCredentials() throws InterruptedException {
+        // Given
+        mockServer.enqueue(new MockResponse.Builder()
+                .code(200)
+                .addHeader("Content-Type", "application/json")
+                .body("[]")
+                .build());
+
+        KafkaConnectClientConfig config = new KafkaConnectClientConfig(
+                "test-cluster",
+                String.format("http://%s:%s", mockServer.getHostName(), mockServer.getPort()),
+                AuthMethod.BASICAUTH,
+                () -> "alice",
+                () -> "secret",
+                () -> SSLConfig.from(Configuration.empty()),
+                false
+        );
+
+        // When
+        try (KafkaConnectApi api = KafkaConnectApiFactory.create(config)) {
+            api.listConnectors();
+        }
+
+        // Then
+        String authorization = mockServer.takeRequest().getHeaders().get("Authorization");
+        String expectedCredentials = Base64.getEncoder()
+                .encodeToString("alice:secret".getBytes(StandardCharsets.UTF_8));
+        Assertions.assertEquals("Basic " + expectedCredentials, authorization,
+                "Authorization header must encode the actual credentials, not the Supplier toString()");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #758

`KafkaConnectClientConfig` is a Java record where `basicAuthUser` and `basicAuthPassword` are declared as `Supplier<String>`. The record accessor methods `config.basicAuthUser()` and `config.basicAuthPassword()` return the `Supplier` itself, **not** the resolved `String` value.

`KafkaConnectApiFactory.getAuthorizationHeader()` was concatenating these suppliers directly:

```java
// Before (buggy):
String basicAuthInfo = config.basicAuthUser() + ":" + config.basicAuthPassword();
```

Java's `+` operator calls `toString()` on non-String types, so `basicAuthInfo` became the concatenated lambda addresses (e.g. `KafkaConnectClientConfig$$Lambda/0x...@addr:KafkaConnectClientConfig$$Lambda/0x...@addr`). This garbage was base64-encoded and sent as the `Authorization: Basic` header, causing HTTP 401 Unauthorized on every request when `authMethod = "basicAuth"`.

## Fix

Call `.get()` on both suppliers:

```java
// After (fixed):
String basicAuthInfo = config.basicAuthUser().get() + ":" + config.basicAuthPassword().get();
```

## Test

Added `KafkaConnectApiFactoryTest` using `MockWebServer` (same pattern as `SchemaRegistryApiFactoryTest`) to verify that the `Authorization` header contains the correct base64-encoded credentials. The test was confirmed to **fail before the fix** and **pass after**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)