### PR TITLE
fix(kafka-connect): call .get() on basicAuth Supplier fields in KafkaConnectApiFactory

### DIFF
--- a/providers/jikkou-provider-kafka-connect/pom.xml
+++ b/providers/jikkou-provider-kafka-connect/pom.xml
@@ -65,6 +65,12 @@
             <version>1.21.4</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <version>${mockwebserver.version}</version>
+            <scope>test</scope>
+        </dependency>
         <!-- END dependencies for test -->
     </dependencies>
 

--- a/providers/jikkou-provider-kafka-connect/src/main/java/io/jikkou/kafka/connect/api/KafkaConnectApiFactory.java
+++ b/providers/jikkou-provider-kafka-connect/src/main/java/io/jikkou/kafka/connect/api/KafkaConnectApiFactory.java
@@ -73,7 +73,7 @@ public final class KafkaConnectApiFactory {
 
     @NotNull
     private static String getAuthorizationHeader(KafkaConnectClientConfig config) {
-        String basicAuthInfo = config.basicAuthUser() + ":" + config.basicAuthPassword();
+        String basicAuthInfo = config.basicAuthUser().get() + ":" + config.basicAuthPassword().get();
         return "Basic " + Encoding.BASE64.encode(basicAuthInfo.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/providers/jikkou-provider-kafka-connect/src/test/java/io/jikkou/kafka/connect/api/KafkaConnectApiFactoryTest.java
+++ b/providers/jikkou-provider-kafka-connect/src/test/java/io/jikkou/kafka/connect/api/KafkaConnectApiFactoryTest.java
@@ -64,6 +64,6 @@ class KafkaConnectApiFactoryTest {
                 .encodeToString("alice:secret".getBytes(StandardCharsets.UTF_8));
         // result should correspond to base64 encoded string "alice:secret" prefixed with "Basic"
         Assertions.assertEquals("Basic " + expectedCredentials, authorization,
-                "Authorization header must encode the actual credentials, not the Supplier toString()");
+                "Authorization header must contain the base64-encoded credentials");
     }
 }

--- a/providers/jikkou-provider-kafka-connect/src/test/java/io/jikkou/kafka/connect/api/KafkaConnectApiFactoryTest.java
+++ b/providers/jikkou-provider-kafka-connect/src/test/java/io/jikkou/kafka/connect/api/KafkaConnectApiFactoryTest.java
@@ -1,0 +1,69 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.jikkou.kafka.connect.api;
+
+import io.jikkou.core.config.Configuration;
+import io.jikkou.http.client.ssl.SSLConfig;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class KafkaConnectApiFactoryTest {
+
+    private static MockWebServer mockServer = new MockWebServer();
+
+    @BeforeAll
+    static void beforeAll() throws IOException {
+        mockServer = new MockWebServer();
+        mockServer.start();
+    }
+
+    @AfterAll
+    static void afterAll() throws IOException {
+        mockServer.close();
+    }
+
+    @Test
+    @DisplayName("Should build Authorization header from actual basicAuth credentials")
+    void shouldBuildBasicAuthHeaderFromActualCredentials() throws InterruptedException {
+        // Given
+        mockServer.enqueue(new MockResponse.Builder()
+                .code(200)
+                .addHeader("Content-Type", "application/json")
+                .body("[]")
+                .build());
+        KafkaConnectClientConfig config = new KafkaConnectClientConfig(
+                "test-cluster",
+                String.format("http://%s:%s", mockServer.getHostName(), mockServer.getPort()),
+                AuthMethod.BASICAUTH,
+                () -> "alice",
+                () -> "secret",
+                () -> SSLConfig.from(Configuration.empty()),
+                false
+        );
+
+        // When
+        try (KafkaConnectApi api = KafkaConnectApiFactory.create(config)) {
+            api.listConnectors();
+        }
+
+        // Then
+        String authorization = mockServer.takeRequest().getHeaders().get("Authorization");
+        String expectedCredentials = Base64.getEncoder()
+                .encodeToString("alice:secret".getBytes(StandardCharsets.UTF_8));
+        // result should correspond to base64 encoded string "alice:secret" prefixed with "Basic"
+        Assertions.assertEquals("Basic " + expectedCredentials, authorization,
+                "Authorization header must encode the actual credentials, not the Supplier toString()");
+    }
+}


### PR DESCRIPTION
## Summary

`KafkaConnectClientConfig.basicAuthUser()` and `basicAuthPassword()` return `Supplier<String>` — the record accessor returns the supplier object, not the resolved string. Concatenating them without `.get()` embeds the lambda `toString()` into the `Authorization` header:

```
Authorization: Basic aW8uamlra291LmthZmthLmNvbm5lY3QuYXBpLkthZmthQ29ubmVjdENsaWVudENvbmZpZyQkTGFtYmRh...
```

Decoded, that's something like:
```
io.jikkou.kafka.connect.api.KafkaConnectClientConfig$$Lambda/0x0000...@...:io.jikkou...$$Lambda/...@...
```

The Connect REST API rejects this with `HTTP 401 Unauthorized`.

**Fix**: call `.get()` on both suppliers in `getAuthorizationHeader()`.

This is the same class of bug fixed for the Schema Registry provider in 0b5c7753.

## Changes

- `KafkaConnectApiFactory.java`: add `.get()` on `config.basicAuthUser()` and `config.basicAuthPassword()`
- `KafkaConnectApiFactoryTest.java`: new test that starts a `MockWebServer`, makes a real HTTP request, and asserts the `Authorization` header encodes the actual credentials
- `pom.xml`: add `mockwebserver` test dependency (same pattern as `jikkou-provider-schema-registry`)

## Test plan

- [ ] `KafkaConnectApiFactoryTest#shouldBuildBasicAuthHeaderFromActualCredentials` passes with the fix
- [ ] Reverting the fix causes the test to fail with a header containing the lambda `toString()` rather than `alice:secret`

Fixes #758.

🤖 Generated with [Claude Code](https://claude.com/claude-code)