### PR TITLE
fix: apply sslTrustStoreLocation to Kafka Connect / Schema Registry REST clients regardless of authMethod

### DIFF
--- a/extension-rest-client/src/main/java/io/jikkou/http/client/RestClientBuilder.java
+++ b/extension-rest-client/src/main/java/io/jikkou/http/client/RestClientBuilder.java
@@ -200,38 +200,49 @@ public class RestClientBuilder {
     }
 
     public RestClientBuilder sslConfig(final SSLConfig sslConfig) {
-        TrustManager[] trustManagers;
-        try {
-            trustManagers = SSLUtils.createTrustManagers(
-                sslConfig.trustStoreLocation(),
-                sslConfig.trustStorePassword().toCharArray(),
-                sslConfig.trustStoreType(),
-                KeyManagerFactory.getDefaultAlgorithm());
-        } catch (CertificateException | NoSuchAlgorithmException | KeyStoreException | IOException e) {
-            LOG.error("Could not create trust managers for Client Certificate authentication.", e);
-            throw new JikkouRuntimeException(e);
-        }
+        boolean hasTrustStore = sslConfig.trustStoreLocation() != null;
+        boolean hasKeyStore = sslConfig.keyStoreLocation() != null;
 
-        KeyManager[] keyManagers;
-        try {
-            keyManagers = SSLUtils.createKeyManagers(
-                sslConfig.keyStoreLocation(),
-                sslConfig.keyStorePassword().toCharArray(),
-                sslConfig.keyStoreType(),
-                KeyManagerFactory.getDefaultAlgorithm());
-        } catch (CertificateException
-                 | NoSuchAlgorithmException
-                 | UnrecoverableKeyException
-                 | KeyStoreException
-                 | IOException e) {
-            LOG.error("Could not create key managers for Client Certificate authentication.", e);
-            throw new JikkouRuntimeException(e);
-        }
+        if (hasTrustStore || hasKeyStore) {
+            TrustManager[] trustManagers;
+            try {
+                trustManagers = SSLUtils.createTrustManagers(
+                    sslConfig.trustStoreLocation(),
+                    toCharArrayOrNull(sslConfig.trustStorePassword()),
+                    sslConfig.trustStoreType(),
+                    KeyManagerFactory.getDefaultAlgorithm());
+            } catch (CertificateException | NoSuchAlgorithmException | KeyStoreException | IOException e) {
+                LOG.error("Could not create trust managers for Client Certificate authentication.", e);
+                throw new JikkouRuntimeException(e);
+            }
 
-        SSLContextFactory sslContextFactory = new SSLContextFactory();
-        clientBuilder.sslContext(sslContextFactory.getSSLContext(keyManagers, trustManagers));
+            KeyManager[] keyManagers = null;
+            if (hasKeyStore) {
+                try {
+                    keyManagers = SSLUtils.createKeyManagers(
+                        sslConfig.keyStoreLocation(),
+                        toCharArrayOrNull(sslConfig.keyStorePassword()),
+                        sslConfig.keyStoreType(),
+                        KeyManagerFactory.getDefaultAlgorithm());
+                } catch (CertificateException
+                         | NoSuchAlgorithmException
+                         | UnrecoverableKeyException
+                         | KeyStoreException
+                         | IOException e) {
+                    LOG.error("Could not create key managers for Client Certificate authentication.", e);
+                    throw new JikkouRuntimeException(e);
+                }
+            }
+
+            SSLContextFactory sslContextFactory = new SSLContextFactory();
+            clientBuilder.sslContext(sslContextFactory.getSSLContext(keyManagers, trustManagers));
+        }
 
         return sslConfig.ignoreHostnameVerification() ? sslIgnoreHostnameVerification() : this;
+    }
+
+    private static char[] toCharArrayOrNull(String value) {
+        return value != null ? value.toCharArray() : null;
     }
 
     /**

--- a/extension-rest-client/src/test/java/io/jikkou/http/client/RestClientBuilderTest.java
+++ b/extension-rest-client/src/test/java/io/jikkou/http/client/RestClientBuilderTest.java
@@ -11,6 +11,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.jikkou.core.config.Configuration;
+import io.jikkou.http.client.ssl.SSLConfig;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.DefaultValue;
@@ -24,6 +26,9 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.security.KeyStore;
 import java.util.List;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -31,6 +36,7 @@ import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 class RestClientBuilderTest {
 
@@ -268,6 +274,79 @@ class RestClientBuilderTest {
         // Then
         RecordedRequest request = server.takeRequest();
         assertEquals("/project/my-project/service/my-service/status", request.getPath());
+    }
+
+    @Test
+    void shouldAcceptEmptySslConfigWithoutThrowing() {
+        // Given
+        server.enqueue(new MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setResponseCode(200)
+                .setBody("pong"));
+        SSLConfig sslConfig = SSLConfig.from(Configuration.empty());
+
+        // When
+        TestResource resource = RestClientBuilder.newBuilder()
+                .baseUri(server.url("/").toString())
+                .sslConfig(sslConfig)
+                .build(TestResource.class);
+        String response = resource.ping();
+
+        // Then
+        assertEquals("pong", response);
+    }
+
+    @Test
+    void shouldAcceptSslConfigWithOnlyHostnameVerificationDisabledWithoutThrowing() {
+        // Given
+        server.enqueue(new MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setResponseCode(200)
+                .setBody("pong"));
+        SSLConfig sslConfig = new SSLConfig(
+                null, null, "PKCS12", null,
+                null, null, "PKCS12",
+                true);
+
+        // When
+        TestResource resource = RestClientBuilder.newBuilder()
+                .baseUri(server.url("/").toString())
+                .sslConfig(sslConfig)
+                .build(TestResource.class);
+        String response = resource.ping();
+
+        // Then
+        assertEquals("pong", response);
+    }
+
+    @Test
+    void shouldAcceptSslConfigWithOnlyTrustStoreWithoutThrowing(@TempDir java.nio.file.Path tempDir) throws Exception {
+        // Given
+        java.nio.file.Path truststorePath = tempDir.resolve("truststore.jks");
+        char[] password = "changeit".toCharArray();
+        KeyStore truststore = KeyStore.getInstance("JKS");
+        truststore.load(null, password);
+        try (OutputStream os = Files.newOutputStream(truststorePath)) {
+            truststore.store(os, password);
+        }
+        server.enqueue(new MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setResponseCode(200)
+                .setBody("pong"));
+        SSLConfig sslConfig = new SSLConfig(
+                null, null, "PKCS12", null,
+                truststorePath.toString(), "changeit", "JKS",
+                false);
+
+        // When
+        TestResource resource = RestClientBuilder.newBuilder()
+                .baseUri(server.url("/").toString())
+                .sslConfig(sslConfig)
+                .build(TestResource.class);
+        String response = resource.ping();
+
+        // Then
+        assertEquals("pong", response);
     }
 
     private <T> T newClient(Class<T> resourceInterface) {

--- a/providers/jikkou-provider-kafka-connect/src/main/java/io/jikkou/kafka/connect/api/KafkaConnectApiFactory.java
+++ b/providers/jikkou-provider-kafka-connect/src/main/java/io/jikkou/kafka/connect/api/KafkaConnectApiFactory.java
@@ -54,17 +54,17 @@ public final class KafkaConnectApiFactory {
                     .readTimeout(timeout);
         }
 
+        // Apply SSL config (truststore, keystore, hostname verification) regardless of
+        // auth method, so HTTPS endpoints with private CAs work for basicAuth/none too.
+        builder.sslConfig(config.sslConfig().get());
+
         builder = switch (config.authMethod()) {
             case BASICAUTH -> {
                 String buildAuthorizationHeader = getAuthorizationHeader(config);
                 builder.header("Authorization", buildAuthorizationHeader);
                 yield builder;
             }
-            case SSL -> {
-                builder.sslConfig(config.sslConfig().get());
-                yield builder;
-            }
-            case NONE -> builder;
+            case SSL, NONE -> builder;
 
             case INVALID -> throw new IllegalStateException("Unexpected value: " + config.authMethod());
         };

--- a/providers/jikkou-provider-schema-registry/pom.xml
+++ b/providers/jikkou-provider-schema-registry/pom.xml
@@ -73,6 +73,12 @@
             <version>${mockwebserver.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp-tls</artifactId>
+            <version>${mockwebserver.version}</version>
+            <scope>test</scope>
+        </dependency>
         <!-- END dependencies for test -->
     </dependencies>
 

--- a/providers/jikkou-provider-schema-registry/src/main/java/io/jikkou/schema/registry/api/SchemaRegistryApiFactory.java
+++ b/providers/jikkou-provider-schema-registry/src/main/java/io/jikkou/schema/registry/api/SchemaRegistryApiFactory.java
@@ -48,17 +48,17 @@ public final class SchemaRegistryApiFactory {
                 .baseUri(baseUri)
                 .enableClientDebugging(config.debugLoggingEnabled());
 
+        // Apply SSL config (truststore, keystore, hostname verification) regardless of
+        // auth method, so HTTPS endpoints with private CAs work for basicAuth/none too.
+        builder.sslConfig(config.sslConfig().get());
+
         builder = switch (config.authMethod()) {
             case BASICAUTH -> {
                 String buildAuthorizationHeader = getAuthorizationHeader(config);
                 builder.header("Authorization", buildAuthorizationHeader);
                 yield builder;
             }
-            case SSL -> {
-                builder.sslConfig(config.sslConfig().get());
-                yield builder;
-            }
-            case NONE -> builder;
+            case SSL, NONE -> builder;
 
             case INVALID -> throw new IllegalStateException("Unexpected value: " + config.authMethod());
         };

--- a/providers/jikkou-provider-schema-registry/src/test/java/io/jikkou/schema/registry/api/SchemaRegistryApiFactoryTest.java
+++ b/providers/jikkou-provider-schema-registry/src/test/java/io/jikkou/schema/registry/api/SchemaRegistryApiFactoryTest.java
@@ -10,14 +10,21 @@ import io.jikkou.core.config.Configuration;
 import io.jikkou.http.client.ssl.SSLConfig;
 import io.jikkou.schema.registry.mock.HttpPathBasedDispatcher;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyStore;
 import java.util.List;
 import mockwebserver3.MockResponse;
 import mockwebserver3.MockWebServer;
+import okhttp3.tls.HandshakeCertificates;
+import okhttp3.tls.HeldCertificate;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 class SchemaRegistryApiFactoryTest {
 
@@ -149,6 +156,69 @@ class SchemaRegistryApiFactoryTest {
         try (SchemaRegistryApi api = SchemaRegistryApiFactory.create(config)) {
             // Then - should be a FailoverSchemaRegistryApi
             Assertions.assertInstanceOf(FailoverSchemaRegistryApi.class, api);
+        }
+    }
+
+    @Test
+    @DisplayName("Should apply sslTrustStoreLocation when authMethod is basicAuth (HTTPS)")
+    public void shouldApplyTrustStoreForBasicAuthOverHttps(@TempDir Path tempDir) throws Exception {
+        // Given - a self-signed cert + an HTTPS MockWebServer using that cert
+        HeldCertificate localhostCert = new HeldCertificate.Builder()
+                .addSubjectAlternativeName("localhost")
+                .addSubjectAlternativeName("127.0.0.1")
+                .build();
+        HandshakeCertificates serverCertificates = new HandshakeCertificates.Builder()
+                .heldCertificate(localhostCert)
+                .build();
+
+        MockWebServer httpsServer = new MockWebServer();
+        httpsServer.useHttps(serverCertificates.sslSocketFactory());
+        httpsServer.start();
+        try {
+            HttpPathBasedDispatcher dispatcher = HttpPathBasedDispatcher.builder()
+                    .forPath("/subjects", new MockResponse.Builder()
+                            .code(200)
+                            .addHeader("Content-Type", "application/vnd.schemaregistry.v1+json")
+                            .body("[\"subject-1\"]")
+                            .build())
+                    .build();
+            httpsServer.setDispatcher(dispatcher);
+
+            // Write the cert into a JKS truststore on disk
+            Path truststorePath = tempDir.resolve("truststore.jks");
+            char[] password = "changeit".toCharArray();
+            KeyStore truststore = KeyStore.getInstance("JKS");
+            truststore.load(null, password);
+            truststore.setCertificateEntry("schema-registry-ca", localhostCert.certificate());
+            try (OutputStream os = Files.newOutputStream(truststorePath)) {
+                truststore.store(os, password);
+            }
+
+            SchemaRegistryClientConfig config = new SchemaRegistryClientConfig(
+                    List.of(String.format("https://%s:%s", httpsServer.getHostName(), httpsServer.getPort())),
+                    "generic",
+                    AuthMethod.BASICAUTH,
+                    () -> "username",
+                    () -> "password",
+                    () -> SSLConfig.from(Configuration.from(java.util.Map.of(
+                            SSLConfig.SSL_TRUST_STORE_LOCATION.key(), truststorePath.toString(),
+                            SSLConfig.SSL_TRUST_STORE_PASSWORD.key(), "changeit",
+                            SSLConfig.SSL_TRUST_STORE_TYPE.key(), "JKS"
+                    ))),
+                    false
+            );
+
+            // When
+            List<String> subjects;
+            try (SchemaRegistryApi schemaRegistryApi = SchemaRegistryApiFactory.create(config)) {
+                subjects = schemaRegistryApi.listSubjects();
+            }
+
+            // Then - the configured truststore must be wired into the SSL context;
+            // without the fix this fails with PKIX path building failed.
+            Assertions.assertEquals(List.of("subject-1"), subjects);
+        } finally {
+            httpsServer.close();
         }
     }
 


### PR DESCRIPTION
## Summary

The Kafka Connect and Schema Registry REST client factories only wired the configured `SSLConfig` (truststore, keystore, hostname verification) into the underlying HTTP client when `authMethod = SSL` (mTLS). For `authMethod = basicAuth` or `none`, the `sslTrustStoreLocation` property was loaded into the config object (visible in `jikkou config view`) but **never applied to the SSL context**. Any HTTPS call to a server backed by a private/internal CA failed with:

```
javax.net.ssl.SSLHandshakeException: PKIX path building failed:
  unable to find valid certification path to requested target
```

The only workaround today is to set `JAVA_TOOL_OPTIONS=-Djavax.net.ssl.trustStore=...` at the JVM level, which bypasses Jikkou's own config.

## Changes

- **`KafkaConnectApiFactory.create()`** and **`SchemaRegistryApiFactory.createForUrl()`** now call `builder.sslConfig(config.sslConfig().get())` *before* the `AuthMethod` switch, so the truststore (and keystore, and hostname-verification override) is honored for every auth method, not just `SSL`.
- **`RestClientBuilder.sslConfig()`** is now null-safe — it no longer NPEs on a sparsely populated `SSLConfig`:
  - Skips key-manager construction when `keyStoreLocation` is `null` (key managers stay `null`, which `SSLContext.init` already accepts).
  - Treats a `null` `trustStorePassword` / `keyStorePassword` as `null` `char[]` instead of NPEing on `.toCharArray()`. `SSLUtils.createTrustManagers()` already handles a `null` `trustStoreLocation` by falling back to the JVM's default `cacerts`.
  - Becomes a no-op when nothing is configured (no truststore, no keystore, no `ignoreHostnameVerification`).
- **Tests**:
  - `RestClientBuilderTest` — three new cases exercising the empty / hostname-only / truststore-only paths against a plain HTTP `MockWebServer`, all of which previously NPEd.
  - `SchemaRegistryApiFactoryTest` — new integration test that starts an HTTPS `MockWebServer` with a self-signed cert (via `okhttp-tls`'s `HeldCertificate` + `HandshakeCertificates`), writes the cert into a JKS truststore in `@TempDir`, and verifies that `listSubjects()` succeeds with `AuthMethod.BASICAUTH` + that truststore. **Without this PR's fix, the same test fails with the exact PKIX error from the issue.**

The Schema Registry test covers the fix structurally — the Kafka Connect factory takes the identical change. No HTTPS test was added in `jikkou-provider-kafka-connect` to keep this PR independent of the open #760 (which is what introduces `mockwebserver` to that pom).

## Test plan

- [x] `mvn test -pl extension-rest-client` — 16 tests pass (3 new SSL cases + 13 existing)
- [x] `mvn test -pl providers/jikkou-provider-schema-registry` — 59 tests pass (1 new HTTPS case + 58 existing)
- [x] `mvn test -pl providers/jikkou-provider-kafka-connect` — 37 tests pass (no regressions)
- [x] Reverting just the `SchemaRegistryApiFactory` change makes `shouldApplyTrustStoreForBasicAuthOverHttps` fail with the issue's exact error message — confirms the test catches the bug.

Fixes #757.

🤖 Generated with [Claude Code](https://claude.com/claude-code)