### PR TITLE
fix(provider-schema-registry): dynamically order schema and compatibility level updates

### DIFF
--- a/providers/jikkou-provider-schema-registry/src/main/java/io/jikkou/schema/registry/change/handler/UpdateSchemaSubjectChangeHandler.java
+++ b/providers/jikkou-provider-schema-registry/src/main/java/io/jikkou/schema/registry/change/handler/UpdateSchemaSubjectChangeHandler.java
@@ -13,6 +13,7 @@ import static io.jikkou.schema.registry.change.SchemaSubjectChangeComputer.*;
 import static io.jikkou.schema.registry.change.SchemaSubjectChangeComputer.DATA_COMPATIBILITY_LEVEL;
 import static io.jikkou.schema.registry.change.SchemaSubjectChangeComputer.DATA_SCHEMA;
 
+import io.jikkou.core.data.TypeConverter;
 import io.jikkou.core.models.change.ResourceChange;
 import io.jikkou.core.models.change.StateChange;
 import io.jikkou.core.models.change.StateChangeList;
@@ -21,6 +22,7 @@ import io.jikkou.core.reconciler.ChangeResponse;
 import io.jikkou.core.reconciler.Operation;
 import io.jikkou.schema.registry.api.AsyncSchemaRegistryApi;
 import io.jikkou.schema.registry.api.SchemaRegistryApi;
+import io.jikkou.schema.registry.model.CompatibilityLevels;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -57,43 +59,77 @@ public final class UpdateSchemaSubjectChangeHandler
         List<ChangeResponse> results = new ArrayList<>();
         for (ResourceChange change : changes) {
             Mono<Void> mono = Mono.empty();
-            // COMPATIBILITY
-            StateChange compatibilityLevels = StateChangeList
+
+            StateChange compatibilityChange = StateChangeList
                     .of(change.getSpec().getChanges())
                     .getLast(DATA_COMPATIBILITY_LEVEL);
 
-            if (UPDATE == compatibilityLevels.getOp() || CREATE == compatibilityLevels.getOp()) {
-                mono = mono.then(updateCompatibilityLevel(change));
-            }
-
-            if (DELETE == compatibilityLevels.getOp()) {
-                mono = mono.then(deleteCompatibilityLevel(change));
-            }
-
-            // MODE
-            StateChange modes = StateChangeList
-                .of(change.getSpec().getChanges())
-                .getLast(DATA_MODE);
-
-            if (UPDATE == modes.getOp() || CREATE == modes.getOp()) {
-                mono = mono.then(updateMode(change));
-            }
-
-            if (DELETE == modes.getOp()) {
-                mono = mono.then(deleteMode(change));
-            }
-
-            // SCHEMA
-            StateChange schema = StateChangeList
+            StateChange schemaChange = StateChangeList
                     .of(change.getSpec().getChanges())
                     .getLast(DATA_SCHEMA);
 
-            if (UPDATE == schema.getOp()) {
-                mono = mono.then(registerSubjectVersion(change));
+            StateChange modeChange = StateChangeList
+                .of(change.getSpec().getChanges())
+                .getLast(DATA_MODE);
+
+            // When both schema and compatibility are changing, the order matters:
+            // - Tightening compatibility (e.g., NONE -> BACKWARD): register schema first
+            //   so it is validated under the old, less restrictive level.
+            // - Loosening compatibility (e.g., BACKWARD -> NONE): update compatibility first
+            //   so the schema can be registered under the new, less restrictive level.
+            // See: https://github.com/streamthoughts/jikkou/issues/756
+            boolean isTightening = isCompatibilityTightening(compatibilityChange);
+
+            if (isTightening) {
+                mono = applySchemaChange(mono, change, schemaChange);
+                mono = applyModeChange(mono, change, modeChange);
+                mono = applyCompatibilityChange(mono, change, compatibilityChange);
+            } else {
+                mono = applyCompatibilityChange(mono, change, compatibilityChange);
+                mono = applyModeChange(mono, change, modeChange);
+                mono = applySchemaChange(mono, change, schemaChange);
             }
 
             results.add(toChangeResponse(change, mono.toFuture()));
         }
         return results;
+    }
+
+    private boolean isCompatibilityTightening(@NotNull StateChange compatibilityChange) {
+        if (UPDATE != compatibilityChange.getOp()) {
+            return false;
+        }
+        CompatibilityLevels before = TypeConverter.of(CompatibilityLevels.class)
+                .convertValue(compatibilityChange.getBefore());
+        CompatibilityLevels after = TypeConverter.of(CompatibilityLevels.class)
+                .convertValue(compatibilityChange.getAfter());
+        return after.isMoreRestrictiveThan(before);
+    }
+
+    private Mono<Void> applyCompatibilityChange(Mono<Void> mono, ResourceChange change, StateChange compatibilityChange) {
+        if (UPDATE == compatibilityChange.getOp() || CREATE == compatibilityChange.getOp()) {
+            mono = mono.then(updateCompatibilityLevel(change));
+        }
+        if (DELETE == compatibilityChange.getOp()) {
+            mono = mono.then(deleteCompatibilityLevel(change));
+        }
+        return mono;
+    }
+
+    private Mono<Void> applyModeChange(Mono<Void> mono, ResourceChange change, StateChange modeChange) {
+        if (UPDATE == modeChange.getOp() || CREATE == modeChange.getOp()) {
+            mono = mono.then(updateMode(change));
+        }
+        if (DELETE == modeChange.getOp()) {
+            mono = mono.then(deleteMode(change));
+        }
+        return mono;
+    }
+
+    private Mono<Void> applySchemaChange(Mono<Void> mono, ResourceChange change, StateChange schemaChange) {
+        if (UPDATE == schemaChange.getOp()) {
+            mono = mono.then(registerSubjectVersion(change));
+        }
+        return mono;
     }
 }

--- a/providers/jikkou-provider-schema-registry/src/main/java/io/jikkou/schema/registry/model/CompatibilityLevels.java
+++ b/providers/jikkou-provider-schema-registry/src/main/java/io/jikkou/schema/registry/model/CompatibilityLevels.java
@@ -7,15 +7,31 @@
 package io.jikkou.schema.registry.model;
 
 /**
- * Schema compatibility levels
+ * Schema compatibility levels, ordered by restrictiveness.
  */
 public enum CompatibilityLevels {
 
-    BACKWARD,
-    BACKWARD_TRANSITIVE,
-    FORWARD,
-    FORWARD_TRANSITIVE,
-    FULL,
-    FULL_TRANSITIVE,
-    NONE
+    BACKWARD(1),
+    BACKWARD_TRANSITIVE(2),
+    FORWARD(1),
+    FORWARD_TRANSITIVE(2),
+    FULL(3),
+    FULL_TRANSITIVE(4),
+    NONE(0);
+
+    private final int restrictiveness;
+
+    CompatibilityLevels(int restrictiveness) {
+        this.restrictiveness = restrictiveness;
+    }
+
+    /**
+     * Returns {@code true} if this level is more restrictive than the given level.
+     *
+     * @param other the level to compare against.
+     * @return {@code true} if this level is more restrictive.
+     */
+    public boolean isMoreRestrictiveThan(CompatibilityLevels other) {
+        return this.restrictiveness > other.restrictiveness;
+    }
 }

--- a/providers/jikkou-provider-schema-registry/src/test/java/io/jikkou/schema/registry/change/handler/UpdateSchemaSubjectChangeHandlerTest.java
+++ b/providers/jikkou-provider-schema-registry/src/test/java/io/jikkou/schema/registry/change/handler/UpdateSchemaSubjectChangeHandlerTest.java
@@ -1,0 +1,183 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.jikkou.schema.registry.change.handler;
+
+import static io.jikkou.schema.registry.change.SchemaSubjectChangeComputer.DATA_COMPATIBILITY_LEVEL;
+import static io.jikkou.schema.registry.change.SchemaSubjectChangeComputer.DATA_MODE;
+import static io.jikkou.schema.registry.change.SchemaSubjectChangeComputer.DATA_REFERENCES;
+import static io.jikkou.schema.registry.change.SchemaSubjectChangeComputer.DATA_SCHEMA;
+import static io.jikkou.schema.registry.change.SchemaSubjectChangeComputer.DATA_SCHEMA_TYPE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.jikkou.core.data.SchemaAndType;
+import io.jikkou.core.data.SchemaType;
+import io.jikkou.core.models.ObjectMeta;
+import io.jikkou.core.models.change.GenericResourceChange;
+import io.jikkou.core.models.change.ResourceChange;
+import io.jikkou.core.models.change.ResourceChangeSpec;
+import io.jikkou.core.models.change.StateChange;
+import io.jikkou.core.reconciler.ChangeResponse;
+import io.jikkou.core.reconciler.Operation;
+import io.jikkou.schema.registry.api.AsyncSchemaRegistryApi;
+import io.jikkou.schema.registry.api.data.CompatibilityObject;
+import io.jikkou.schema.registry.api.data.SubjectSchemaId;
+import io.jikkou.schema.registry.model.CompatibilityLevels;
+import io.jikkou.schema.registry.models.V1SchemaRegistrySubject;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+import reactor.core.publisher.Mono;
+
+class UpdateSchemaSubjectChangeHandlerTest {
+
+    private static final String TEST_SUBJECT = "test-subject";
+
+    private static final Map<String, Object> DEFAULT_DATA = Map.of(
+            "permanentDelete", false,
+            "normalizeSchema", false,
+            "schemaId", "",
+            "version", ""
+    );
+
+    @Test
+    void shouldRegisterSchemaBeforeUpdatingCompatibilityWhenTightening() {
+        // Given
+        AsyncSchemaRegistryApi api = mock(AsyncSchemaRegistryApi.class);
+        when(api.registerSubjectVersion(eq(TEST_SUBJECT), any(), anyBoolean()))
+                .thenReturn(Mono.just(new SubjectSchemaId(1)));
+        when(api.updateSubjectCompatibilityLevel(eq(TEST_SUBJECT), any()))
+                .thenReturn(Mono.just(new CompatibilityObject(CompatibilityLevels.BACKWARD.name())));
+
+        UpdateSchemaSubjectChangeHandler handler = new UpdateSchemaSubjectChangeHandler(api);
+        ResourceChange change = createUpdateChange(
+                CompatibilityLevels.NONE, CompatibilityLevels.BACKWARD,
+                "schema-v1", "schema-v2"
+        );
+
+        // When
+        List<ChangeResponse> responses = handler.handleChanges(List.of(change));
+        responses.forEach(r -> r.getResults().join());
+
+        // Then - schema must be registered BEFORE compatibility is updated
+        InOrder inOrder = Mockito.inOrder(api);
+        inOrder.verify(api).registerSubjectVersion(eq(TEST_SUBJECT), any(), anyBoolean());
+        inOrder.verify(api).updateSubjectCompatibilityLevel(eq(TEST_SUBJECT), any());
+    }
+
+    @Test
+    void shouldUpdateCompatibilityBeforeRegisteringSchemaWhenLoosening() {
+        // Given
+        AsyncSchemaRegistryApi api = mock(AsyncSchemaRegistryApi.class);
+        when(api.updateSubjectCompatibilityLevel(eq(TEST_SUBJECT), any()))
+                .thenReturn(Mono.just(new CompatibilityObject(CompatibilityLevels.NONE.name())));
+        when(api.registerSubjectVersion(eq(TEST_SUBJECT), any(), anyBoolean()))
+                .thenReturn(Mono.just(new SubjectSchemaId(1)));
+
+        UpdateSchemaSubjectChangeHandler handler = new UpdateSchemaSubjectChangeHandler(api);
+        ResourceChange change = createUpdateChange(
+                CompatibilityLevels.BACKWARD, CompatibilityLevels.NONE,
+                "schema-v1", "schema-v2"
+        );
+
+        // When
+        List<ChangeResponse> responses = handler.handleChanges(List.of(change));
+        responses.forEach(r -> r.getResults().join());
+
+        // Then - compatibility must be updated BEFORE schema is registered
+        InOrder inOrder = Mockito.inOrder(api);
+        inOrder.verify(api).updateSubjectCompatibilityLevel(eq(TEST_SUBJECT), any());
+        inOrder.verify(api).registerSubjectVersion(eq(TEST_SUBJECT), any(), anyBoolean());
+    }
+
+    @Test
+    void shouldOnlyUpdateCompatibilityWhenSchemaUnchanged() {
+        // Given
+        AsyncSchemaRegistryApi api = mock(AsyncSchemaRegistryApi.class);
+        when(api.updateSubjectCompatibilityLevel(eq(TEST_SUBJECT), any()))
+                .thenReturn(Mono.just(new CompatibilityObject(CompatibilityLevels.BACKWARD.name())));
+
+        UpdateSchemaSubjectChangeHandler handler = new UpdateSchemaSubjectChangeHandler(api);
+        ResourceChange change = createUpdateChange(
+                CompatibilityLevels.NONE, CompatibilityLevels.BACKWARD,
+                "schema-v1", "schema-v1"
+        );
+
+        // When
+        List<ChangeResponse> responses = handler.handleChanges(List.of(change));
+        responses.forEach(r -> r.getResults().join());
+
+        // Then
+        verify(api).updateSubjectCompatibilityLevel(eq(TEST_SUBJECT), any());
+        verify(api, never()).registerSubjectVersion(any(), any(), anyBoolean());
+    }
+
+    @Test
+    void shouldOnlyRegisterSchemaWhenCompatibilityUnchanged() {
+        // Given
+        AsyncSchemaRegistryApi api = mock(AsyncSchemaRegistryApi.class);
+        when(api.registerSubjectVersion(eq(TEST_SUBJECT), any(), anyBoolean()))
+                .thenReturn(Mono.just(new SubjectSchemaId(1)));
+
+        UpdateSchemaSubjectChangeHandler handler = new UpdateSchemaSubjectChangeHandler(api);
+        ResourceChange change = createUpdateChange(
+                CompatibilityLevels.BACKWARD, CompatibilityLevels.BACKWARD,
+                "schema-v1", "schema-v2"
+        );
+
+        // When
+        List<ChangeResponse> responses = handler.handleChanges(List.of(change));
+        responses.forEach(r -> r.getResults().join());
+
+        // Then
+        verify(api).registerSubjectVersion(eq(TEST_SUBJECT), any(), anyBoolean());
+        verify(api, never()).updateSubjectCompatibilityLevel(any(), any());
+    }
+
+    private ResourceChange createUpdateChange(
+            CompatibilityLevels compatBefore,
+            CompatibilityLevels compatAfter,
+            String schemaBefore,
+            String schemaAfter) {
+
+        StateChange compatChange = compatBefore.equals(compatAfter)
+                ? StateChange.none(DATA_COMPATIBILITY_LEVEL, compatBefore)
+                : StateChange.update(DATA_COMPATIBILITY_LEVEL, compatBefore, compatAfter);
+
+        SchemaAndType schemaAndTypeBefore = new SchemaAndType(schemaBefore, SchemaType.AVRO);
+        SchemaAndType schemaAndTypeAfter = new SchemaAndType(schemaAfter, SchemaType.AVRO);
+        StateChange schemaChange = schemaBefore.equals(schemaAfter)
+                ? StateChange.none(DATA_SCHEMA, schemaAndTypeBefore)
+                : StateChange.update(DATA_SCHEMA, schemaAndTypeBefore, schemaAndTypeAfter);
+
+        return GenericResourceChange
+                .builder(V1SchemaRegistrySubject.class)
+                .withMetadata(ObjectMeta
+                        .builder()
+                        .withName(TEST_SUBJECT)
+                        .build())
+                .withSpec(ResourceChangeSpec
+                        .builder()
+                        .withOperation(Operation.UPDATE)
+                        .withData(DEFAULT_DATA)
+                        .withChange(compatChange)
+                        .withChange(schemaChange)
+                        .withChange(StateChange.none(DATA_SCHEMA_TYPE, SchemaType.AVRO))
+                        .withChange(StateChange.none(DATA_REFERENCES, Collections.emptyList()))
+                        .withChange(StateChange.none(DATA_MODE, null))
+                        .build())
+                .build();
+    }
+}

--- a/providers/jikkou-provider-schema-registry/src/test/java/io/jikkou/schema/registry/model/CompatibilityLevelsTest.java
+++ b/providers/jikkou-provider-schema-registry/src/test/java/io/jikkou/schema/registry/model/CompatibilityLevelsTest.java
@@ -1,0 +1,50 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.jikkou.schema.registry.model;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class CompatibilityLevelsTest {
+
+    @Test
+    void shouldReturnTrueWhenBackwardIsMoreRestrictiveThanNone() {
+        assertTrue(CompatibilityLevels.BACKWARD.isMoreRestrictiveThan(CompatibilityLevels.NONE));
+    }
+
+    @Test
+    void shouldReturnTrueWhenFullTransitiveIsMoreRestrictiveThanNone() {
+        assertTrue(CompatibilityLevels.FULL_TRANSITIVE.isMoreRestrictiveThan(CompatibilityLevels.NONE));
+    }
+
+    @Test
+    void shouldReturnTrueWhenFullIsMoreRestrictiveThanBackward() {
+        assertTrue(CompatibilityLevels.FULL.isMoreRestrictiveThan(CompatibilityLevels.BACKWARD));
+    }
+
+    @Test
+    void shouldReturnTrueWhenFullTransitiveIsMoreRestrictiveThanFull() {
+        assertTrue(CompatibilityLevels.FULL_TRANSITIVE.isMoreRestrictiveThan(CompatibilityLevels.FULL));
+    }
+
+    @Test
+    void shouldReturnFalseWhenNoneIsMoreRestrictiveThanBackward() {
+        assertFalse(CompatibilityLevels.NONE.isMoreRestrictiveThan(CompatibilityLevels.BACKWARD));
+    }
+
+    @Test
+    void shouldReturnFalseWhenSameLevel() {
+        assertFalse(CompatibilityLevels.BACKWARD.isMoreRestrictiveThan(CompatibilityLevels.BACKWARD));
+    }
+
+    @Test
+    void shouldReturnFalseWhenBackwardComparedToForward() {
+        assertFalse(CompatibilityLevels.BACKWARD.isMoreRestrictiveThan(CompatibilityLevels.FORWARD));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #756

When updating a Schema Registry subject with both a schema change and a compatibility level change, the execution order now depends on the **direction** of the compatibility change:

- **Tightening** (e.g., NONE → BACKWARD): registers the schema first under the old, less restrictive level, then updates compatibility
- **Loosening** (e.g., BACKWARD → NONE): updates compatibility first so the schema can be registered under the new, less restrictive level

This fixes the issue where changing compatibility from NONE to BACKWARD alongside a schema update would fail because the compatibility was updated before the schema was registered.

### Changes

- Added restrictiveness ordering to `CompatibilityLevels` enum with `isMoreRestrictiveThan()` method
- Refactored `UpdateSchemaSubjectChangeHandler` to dynamically order operations based on compatibility change direction

### Context

PR #646 previously moved compatibility updates before schema registration to fix the loosening case. This caused a regression for the tightening case (#756). The fix now handles both directions correctly.

## Test plan

- [ ] Existing unit tests pass (`./mvnw surefire:test -pl providers/jikkou-provider-schema-registry` — 58 tests, 0 failures)
- [ ] Code formatting passes (`./mvnw spotless:check -pl providers/jikkou-provider-schema-registry`)
- [ ] Add integration test: update subject with NONE → BACKWARD + schema change
- [ ] Add integration test: update subject with BACKWARD → NONE + schema change