### PR TITLE
fix(deps): bump kafka-clients, override netty, exclude vulnerable Jetty

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -47,6 +47,16 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- Netty BOM must be imported BEFORE Micronaut so its 4.2.11 pins win
+                 (Maven first-declaration-wins). Micronaut platform 4.10.10 otherwise
+                 pulls in netty-codec-http* 4.2.9 (CVE-2026-33870, CVE-2026-33871). -->
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>${netty.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <!-- Micronaut -->
             <dependency>
                 <groupId>io.micronaut.platform</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
         <testcontainer.version>2.0.3</testcontainer.version>
         <mockwebserver.version>5.3.2</mockwebserver.version>
         <!-- Dependencies -->
-        <kafka.version>3.9.1</kafka.version>
+        <kafka.version>3.9.2</kafka.version>
         <picocli.version>4.7.7</picocli.version>
         <jackson.version>2.18.6</jackson.version>
         <jinjava.version>2.8.3</jinjava.version>

--- a/providers/jikkou-provider-iceberg/pom.xml
+++ b/providers/jikkou-provider-iceberg/pom.xml
@@ -84,6 +84,13 @@
                     <groupId>ch.qos.reload4j</groupId>
                     <artifactId>reload4j</artifactId>
                 </exclusion>
+                <!-- Jikkou uses Iceberg as a client only; Hadoop's embedded HTTP server
+                     (HttpServer2) is never started. Excluding Jetty removes CVE-2026-2332
+                     (jetty 9.4.58); 9.4.60 is not published to Maven Central. -->
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/server/jikkou-api-server/pom.xml
+++ b/server/jikkou-api-server/pom.xml
@@ -171,6 +171,16 @@
     </dependencies>
     <dependencyManagement>
         <dependencies>
+            <!-- Netty BOM must be imported BEFORE Micronaut so its 4.2.11 pins win
+                 (Maven first-declaration-wins). Micronaut platform 4.10.10 otherwise
+                 pulls in netty-codec-http* 4.2.9 (CVE-2026-33870, CVE-2026-33871). -->
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>${netty.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>io.micronaut.platform</groupId>
                 <artifactId>micronaut-parent</artifactId>


### PR DESCRIPTION
## Summary

Resolves the four HIGH-severity CVEs flagged by Trivy on PR #765:

| Library | CVE | Action |
|---|---|---|
| `org.apache.kafka:kafka-clients` | CVE-2026-35554 | Bumped 3.9.1 → 3.9.2 (root `pom.xml`) |
| `io.netty:netty-codec-http` | CVE-2026-33870 | Re-imported `netty-bom 4.2.11` as the FIRST BOM in `cli/pom.xml` and `server/jikkou-api-server/pom.xml` `<dependencyManagement>` (Micronaut platform 4.10.10 was overriding our parent's netty-bom and pulling 4.2.9.Final transitively) |
| `io.netty:netty-codec-http2` | CVE-2026-33871 | Same as above |
| `org.eclipse.jetty:jetty-http` (and 8 sibling 9.4.x modules) | CVE-2026-2332 | Excluded `org.eclipse.jetty:*` from `hadoop-common` in the iceberg provider |

### Note on Jetty

The Trivy advisory lists `9.4.60` as the upstream fix for CVE-2026-2332, but **9.4.60 is not published to Maven Central** — Eclipse Jetty 9.4.x is community-EOL on Central; 9.4.58.v20250814 is the latest available. Backports for 9.4 are commercial-support-only.

Since Jikkou uses Iceberg purely as a client (REST/JDBC catalogs), Hadoop's embedded HTTP server (`HttpServer2`) is never started at runtime. Excluding the transitive `jetty-*` jars from `hadoop-common` removes the vulnerable code from the classpath entirely and shrinks the runtime attack surface.

## Test plan
- [x] `./mvnw clean verify` passes across all 18 modules (11:39 locally)
- [x] `dependency:tree` confirms `kafka-clients:3.9.2`, `netty-codec-http*:4.2.11.Final`, zero `org.eclipse.jetty:*` on the iceberg classpath
- [x] Iceberg provider unit tests (78) + Kafka provider unit tests (142) + cli + server tests all green
- [ ] CI Trivy scan reports no HIGH/CRITICAL on these libraries