### PR TITLE
fix(core): in health endpoint, filter enabled extension providers

### DIFF
--- a/core/src/main/java/io/jikkou/core/DefaultApi.java
+++ b/core/src/main/java/io/jikkou/core/DefaultApi.java
@@ -262,7 +262,7 @@ public final class DefaultApi extends BaseApi implements AutoCloseable, JikkouAp
     @Override
     public ApiHealthIndicatorList getApiHealthIndicators() {
         List<ApiHealthIndicator> indicators = extensionFactory
-            .findAllDescriptorsByClass(HealthIndicator.class)
+            .findAllDescriptorsByClass(HealthIndicator.class, Qualifiers.enabled())
             .stream()
             .map(descriptor -> new ApiHealthIndicator(descriptor.name(), descriptor.description()))
             .toList();


### PR DESCRIPTION
The /health endpoint is throwing internal server errors e.g. when only having the jikkou and kafka providers enabled:

```
Health indicator [iceberg] reported exception: io.jikkou.core.extension.exceptions.NoSuchExtensionException: No extension registered for type 'interface io.jikkou.core.health.HealthIndicator', and qualifier '@Named(iceberg) and @Enabled(true)'
```

This is caused by the findAllDescriptorsByClass() call not filtering for enabled extensions. This commit implemenents a trivial fix to do such filtering.