### PR TITLE
fix(cli): tolerate empty Jikkou config file

### DIFF
--- a/cli/src/main/java/io/jikkou/client/context/ConfigurationContext.java
+++ b/cli/src/main/java/io/jikkou/client/context/ConfigurationContext.java
@@ -11,6 +11,8 @@ import io.jikkou.core.exceptions.JikkouRuntimeException;
 import io.jikkou.core.io.Jackson;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -76,7 +78,18 @@ public final class ConfigurationContext {
     }
 
     public boolean isExists() {
-        return configFile.exists();
+        if (!configFile.exists()) {
+            return false;
+        }
+        try {
+            // Treat an empty or whitespace-only file as if it did not exist,
+            // so the CLI can fall back to the default context instead of failing.
+            return Files.size(configFile.toPath()) > 0
+                    && !Files.readString(configFile.toPath(), StandardCharsets.UTF_8).isBlank();
+        } catch (IOException e) {
+            // File is present but unreadable here; defer error surfacing to tryReadConfiguration().
+            return true;
+        }
     }
 
     public Map<String, Context> getContexts() {

--- a/cli/src/test/java/io/jikkou/client/context/ConfigurationContextTest.java
+++ b/cli/src/test/java/io/jikkou/client/context/ConfigurationContextTest.java
@@ -1,0 +1,60 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.jikkou.client.context;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jikkou.core.exceptions.JikkouRuntimeException;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ConfigurationContextTest {
+
+    @Test
+    void shouldTolerateEmptyConfigFile(@TempDir Path tempDir) throws Exception {
+        // Given an existing but empty config file
+        File configFile = Files.createFile(tempDir.resolve("config")).toFile();
+
+        ConfigurationContext context = new ConfigurationContext(configFile, new ObjectMapper());
+
+        // Then it is treated as if no configuration existed
+        assertFalse(context.isExists());
+        assertEquals(ConfigurationContext.EMPTY_CONTEXT, context.getCurrentContextName());
+        assertTrue(context.getContexts().isEmpty());
+        assertNotNull(context.getCurrentContext());
+    }
+
+    @Test
+    void shouldTolerateWhitespaceOnlyConfigFile(@TempDir Path tempDir) throws Exception {
+        File configFile = tempDir.resolve("config").toFile();
+        Files.writeString(configFile.toPath(), "  \n\t  \n");
+
+        ConfigurationContext context = new ConfigurationContext(configFile, new ObjectMapper());
+
+        assertFalse(context.isExists());
+        assertTrue(context.getContexts().isEmpty());
+    }
+
+    @Test
+    void shouldStillFailOnMalformedJson(@TempDir Path tempDir) throws Exception {
+        File configFile = tempDir.resolve("config").toFile();
+        Files.writeString(configFile.toPath(), "{ not valid json");
+
+        ConfigurationContext context = new ConfigurationContext(configFile, new ObjectMapper());
+
+        assertTrue(context.isExists());
+        assertThrows(JikkouRuntimeException.class, context::getContexts);
+    }
+}


### PR DESCRIPTION
## Summary

- Make the CLI fault-tolerant when `~/.jikkou/config` exists but is empty (or whitespace-only). It now falls back to the default context instead of crashing with `Couldn't read configuration file`.
- Malformed JSON still surfaces as an error — only truly empty files are tolerated.
- Implementation: tightened `ConfigurationContext.isExists()` so every existing fallback branch handles the empty-file case the same way it handles the missing-file case. No changes to callers.

## Test plan

- [x] New `ConfigurationContextTest` covers: empty file, whitespace-only file, and malformed JSON (regression guard)
- [x] `./mvnw -pl cli -Dtest=ConfigurationContextTest test` — 3/3 passing