### PR TITLE
fix(kafka): avoid blocking Netty event loop on Kafka admin calls

### DIFF
--- a/providers/jikkou-provider-kafka/src/main/java/io/jikkou/kafka/action/TruncateKafkaTopicRecords.java
+++ b/providers/jikkou-provider-kafka/src/main/java/io/jikkou/kafka/action/TruncateKafkaTopicRecords.java
@@ -11,11 +11,13 @@ import static io.jikkou.kafka.reconciler.service.KafkaOffsetSpec.ToTimestamp.fro
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.jikkou.common.utils.AsyncUtils;
 import io.jikkou.common.utils.Pair;
 import io.jikkou.core.action.*;
 import io.jikkou.core.annotation.*;
 import io.jikkou.core.config.ConfigProperty;
 import io.jikkou.core.config.Configuration;
+import io.jikkou.core.exceptions.JikkouRuntimeException;
 import io.jikkou.core.extension.ContextualExtension;
 import io.jikkou.core.extension.ExtensionContext;
 import io.jikkou.core.models.BaseHasMetadata;
@@ -102,44 +104,50 @@ public class TruncateKafkaTopicRecords extends ContextualExtension implements Ac
             final Long timestamp = fromISODateTime(dateTime).timestamp();
 
 
-            List<ExecutionResult<V1TruncatedKafkaTopicRecords>> results = Flux.fromIterable(topics)
-                .flatMap(topic -> Mono.fromFuture(service.listOffsets(List.of(topic), OffsetSpec.forTimestamp(timestamp)))
-                    .flatMap(offsetsByTopicPartition -> {
-                        Map<TopicPartition, RecordsToDelete> recordsToDelete = offsetsByTopicPartition.entrySet()
-                            .stream()
-                            .collect(Collectors.toMap(
-                                    Map.Entry::getKey,
-                                    it -> RecordsToDelete.beforeOffset(it.getValue().offset())
-                                )
-                            );
+            List<ExecutionResult<V1TruncatedKafkaTopicRecords>> results = AsyncUtils.getValueOrThrowException(
+                Flux.fromIterable(topics)
+                    .flatMap(topic -> Mono.fromFuture(service.listOffsets(List.of(topic), OffsetSpec.forTimestamp(timestamp)))
+                        .flatMap(offsetsByTopicPartition -> {
+                            Map<TopicPartition, RecordsToDelete> recordsToDelete = offsetsByTopicPartition.entrySet()
+                                .stream()
+                                .collect(Collectors.toMap(
+                                        Map.Entry::getKey,
+                                        it -> RecordsToDelete.beforeOffset(it.getValue().offset())
+                                    )
+                                );
 
-                        LOG.info("Deleting record for topic '{}' from partition: {}", topic, recordsToDelete);
-                        Map<TopicPartition, KafkaFuture<DeletedRecords>> lowWatermarks = client.deleteRecords(recordsToDelete).lowWatermarks();
-                        return Flux
-                            .fromStream(lowWatermarks.entrySet().stream().map(Pair::of))
-                            .flatMap(pair ->
-                                Mono.fromFuture(pair._2().toCompletionStage().toCompletableFuture())
-                                    .map(deleted -> new TopicPartitionLowWatermark(pair._1().partition(), deleted.lowWatermark()))
+                            LOG.info("Deleting record for topic '{}' from partition: {}", topic, recordsToDelete);
+                            Map<TopicPartition, KafkaFuture<DeletedRecords>> lowWatermarks = client.deleteRecords(recordsToDelete).lowWatermarks();
+                            return Flux
+                                .fromStream(lowWatermarks.entrySet().stream().map(Pair::of))
+                                .flatMap(pair ->
+                                    Mono.fromFuture(pair._2().toCompletionStage().toCompletableFuture())
+                                        .map(deleted -> new TopicPartitionLowWatermark(pair._1().partition(), deleted.lowWatermark()))
+                                )
+                                .collectSortedList(Comparator.comparingInt(TopicPartitionLowWatermark::partition))
+                                .map(topicPartitionLowWatermarks ->
+                                    ExecutionResult.<V1TruncatedKafkaTopicRecords>newBuilder()
+                                        .status(ExecutionStatus.SUCCEEDED)
+                                        .data(new V1TruncatedKafkaTopicRecords(new TruncatedKafkaTopicRecordsResult(topic, topicPartitionLowWatermarks)))
+                                        .build()
+                                );
+                        })
+                        .onErrorResume(ex ->
+                            Mono.just(ExecutionResult.<V1TruncatedKafkaTopicRecords>newBuilder()
+                                .status(ExecutionStatus.FAILED)
+                                .errors(List.of(new ExecutionError(ex.getLocalizedMessage())))
+                                .data(new V1TruncatedKafkaTopicRecords(new TruncatedKafkaTopicRecordsResult(topic, null)))
+                                .build()
                             )
-                            .collectSortedList(Comparator.comparingInt(TopicPartitionLowWatermark::partition))
-                            .map(topicPartitionLowWatermarks ->
-                                ExecutionResult.<V1TruncatedKafkaTopicRecords>newBuilder()
-                                    .status(ExecutionStatus.SUCCEEDED)
-                                    .data(new V1TruncatedKafkaTopicRecords(new TruncatedKafkaTopicRecordsResult(topic, topicPartitionLowWatermarks)))
-                                    .build()
-                            );
-                    })
-                    .onErrorResume(ex ->
-                        Mono.just(ExecutionResult.<V1TruncatedKafkaTopicRecords>newBuilder()
-                            .status(ExecutionStatus.FAILED)
-                            .errors(List.of(new ExecutionError(ex.getLocalizedMessage())))
-                            .data(new V1TruncatedKafkaTopicRecords(new TruncatedKafkaTopicRecordsResult(topic, null)))
-                            .build()
                         )
                     )
-                )
-                .collectList()
-                .block();
+                    .collectList()
+                    .toFuture(),
+                cause -> cause instanceof JikkouRuntimeException jre
+                    ? jre
+                    : new JikkouRuntimeException(String.format(
+                        "Failed to truncate Kafka topic records. Cause %s: %s.",
+                        cause.getClass().getSimpleName(), cause.getLocalizedMessage()), cause));
 
             return ExecutionResultSet.<V1TruncatedKafkaTopicRecords>newBuilder()
                 .results(results)

--- a/providers/jikkou-provider-kafka/src/main/java/io/jikkou/kafka/reconciler/service/KafkaAdminService.java
+++ b/providers/jikkou-provider-kafka/src/main/java/io/jikkou/kafka/reconciler/service/KafkaAdminService.java
@@ -21,7 +21,6 @@ import io.jikkou.kafka.reconciler.service.KafkaOffsetSpec.ToOffset;
 import io.jikkou.kafka.reconciler.service.KafkaOffsetSpec.ToTimestamp;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.kafka.clients.admin.*;
@@ -34,7 +33,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 
 /**
  * Service to manage Kafka resources
@@ -210,6 +208,10 @@ public final class KafkaAdminService {
 
     /**
      * Lists all consumer groups for the specified states.
+     * <p>
+     * This method blocks the calling thread until the Kafka AdminClient completes.
+     * Callers running on a non-blocking thread (e.g. a Netty event loop or a Reactor
+     * scheduler) must offload, or use {@link #listConsumerGroupsAsync(List, boolean)}.
      *
      * @param groups          The consumer groups.
      * @param describeOffsets Specify whether offsets should be described.
@@ -218,66 +220,64 @@ public final class KafkaAdminService {
     @NotNull
     public V1KafkaConsumerGroupList listConsumerGroups(@NotNull List<String> groups,
                                                        boolean describeOffsets) {
+        return AsyncUtils.getValueOrThrowException(
+            listConsumerGroupsAsync(groups, describeOffsets).toFuture(),
+            cause -> cause instanceof JikkouRuntimeException jre
+                ? jre
+                : new JikkouRuntimeException(String.format(
+                    "Failed to describe consumer groups. Cause %s: %s.",
+                    cause.getClass().getSimpleName(), cause.getLocalizedMessage()), cause));
+    }
 
-        // List Consumer Group Offsets
-        final ListConsumerGroupOffsetsResult groupOffsetsResult;
-        if (describeOffsets) {
-            groupOffsetsResult = client.listConsumerGroupOffsets(groups.stream().collect(Collectors.toMap(
-                Function.identity(),
-                it -> new ListConsumerGroupOffsetsSpec()
-            )));
-        } else {
-            groupOffsetsResult = null;
-        }
+    /**
+     * Non-blocking variant of {@link #listConsumerGroups(List, boolean)}.
+     * <p>
+     * The returned {@link Mono} does not block any thread internally; the entire
+     * pipeline is driven by the Kafka AdminClient's I/O callbacks. Safe to consume
+     * from reactive contexts.
+     *
+     * @param groups          The consumer groups.
+     * @param describeOffsets Specify whether offsets should be described.
+     * @return A {@link Mono} that completes with the {@link V1KafkaConsumerGroupList}.
+     */
+    @NotNull
+    public Mono<V1KafkaConsumerGroupList> listConsumerGroupsAsync(@NotNull List<String> groups,
+                                                                  boolean describeOffsets) {
+        return Mono.defer(() -> {
+            final ListConsumerGroupOffsetsResult groupOffsetsResult = describeOffsets
+                ? client.listConsumerGroupOffsets(groups.stream().collect(Collectors.toMap(
+                    Function.identity(),
+                    it -> new ListConsumerGroupOffsetsSpec())))
+                : null;
 
-        // Describe Consumer Groups
-        try {
-            List<V1KafkaConsumerGroup> items = Flux
-                .fromStream(client
-                    .describeConsumerGroups(groups)
+            return Flux.fromStream(client.describeConsumerGroups(groups)
                     .describedGroups()
                     .values()
                     .stream()
-                    .map(consumerGroupDescriptionKafkaFuture -> Futures
-                        .toCompletableFuture(consumerGroupDescriptionKafkaFuture)
-                        .thenApply(this::mapToResource)
-                    )
-                )
-                .publishOn(Schedulers.boundedElastic())
+                    .map(future -> Futures.toCompletableFuture(future).thenApply(this::mapToResource)))
                 .flatMap(Mono::fromFuture)
                 .flatMap(group -> {
-                    String groupName = group.getMetadata().getName();
-                    if (groupOffsetsResult != null) {
-                        return Mono
-                            .fromFuture(Futures.toCompletableFuture(groupOffsetsResult.partitionsToOffsetAndMetadata(groupName)))
-                            .flatMap(partitions -> mapToResources(partitions).collectList()
-                                .map(offsets -> group.withStatus(group.getStatus().withOffsets(offsets))));
+                    if (groupOffsetsResult == null) {
+                        return Mono.just(group);
                     }
-                    return Mono.just(group);
+                    String groupName = group.getMetadata().getName();
+                    return Mono.fromFuture(Futures.toCompletableFuture(
+                            groupOffsetsResult.partitionsToOffsetAndMetadata(groupName)))
+                        .flatMap(partitions -> mapToResources(partitions).collectList()
+                            .map(offsets -> group.withStatus(group.getStatus().withOffsets(offsets))));
                 })
                 .collectList()
-                .toFuture()
-                .get();
-
-            return new V1KafkaConsumerGroupList.Builder().withItems(items).build();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            LOG.error("Failed to describe consumer groups.", e);
-            throw new JikkouRuntimeException(String.format(
-                "Failed to describe consumer groups. Cause %s: %s.", e.getClass().getSimpleName(), e.getLocalizedMessage())
-            );
-        } catch (ExecutionException e) {
-            Throwable cause = e.getCause() != null ? e.getCause() : e;
-            LOG.error("Failed to describe consumer groups.", cause);
-            throw new JikkouRuntimeException(String.format(
-                "Failed to describe consumer groups. Cause %s: %s.", cause.getClass().getSimpleName(), cause.getLocalizedMessage())
-            );
-        } catch (Exception e) {
-            LOG.error("Failed to describe consumer groups.", e);
-            throw new JikkouRuntimeException(String.format(
-                "Failed to describe consumer groups. Cause %s: %s.", e.getClass().getSimpleName(), e.getLocalizedMessage())
-            );
-        }
+                .map(items -> new V1KafkaConsumerGroupList.Builder().withItems(items).build());
+        })
+            .onErrorMap(e -> {
+                LOG.error("Failed to describe consumer groups.", e);
+                if (e instanceof JikkouRuntimeException) {
+                    return e;
+                }
+                return new JikkouRuntimeException(String.format(
+                    "Failed to describe consumer groups. Cause %s: %s.",
+                    e.getClass().getSimpleName(), e.getLocalizedMessage()), e);
+            });
     }
 
     @NotNull

--- a/providers/jikkou-provider-kafka/src/test/java/io/jikkou/kafka/reconciler/service/KafkaAdminServiceTest.java
+++ b/providers/jikkou-provider-kafka/src/test/java/io/jikkou/kafka/reconciler/service/KafkaAdminServiceTest.java
@@ -1,0 +1,130 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.jikkou.kafka.reconciler.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.jikkou.core.exceptions.JikkouRuntimeException;
+import io.jikkou.kafka.collections.V1KafkaConsumerGroupList;
+import java.util.List;
+import java.util.Map;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.DescribeConsumerGroupsResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+
+class KafkaAdminServiceTest {
+
+    private AdminClient adminClient;
+    private KafkaAdminService service;
+
+    @BeforeEach
+    void setUp() {
+        adminClient = mock(AdminClient.class);
+        service = new KafkaAdminService(adminClient);
+    }
+
+    @Test
+    void shouldReturnEmptyListWhenNoConsumerGroups() {
+        // Given
+        DescribeConsumerGroupsResult result = mock(DescribeConsumerGroupsResult.class);
+        when(adminClient.describeConsumerGroups(List.of())).thenReturn(result);
+        when(result.describedGroups()).thenReturn(Map.of());
+
+        // When
+        V1KafkaConsumerGroupList groups = service.listConsumerGroups(List.of(), false);
+
+        // Then
+        assertNotNull(groups);
+        assertTrue(groups.getItems().isEmpty());
+    }
+
+    @Test
+    void shouldReturnEmptyMonoWhenNoConsumerGroupsAsync() {
+        // Given
+        DescribeConsumerGroupsResult result = mock(DescribeConsumerGroupsResult.class);
+        when(adminClient.describeConsumerGroups(List.of())).thenReturn(result);
+        when(result.describedGroups()).thenReturn(Map.of());
+
+        // When
+        Mono<V1KafkaConsumerGroupList> mono = service.listConsumerGroupsAsync(List.of(), false);
+
+        // Then
+        V1KafkaConsumerGroupList groups = mono.block();
+        assertNotNull(groups);
+        assertTrue(groups.getItems().isEmpty());
+    }
+
+    @Test
+    void shouldChainCauseWhenAdminClientThrows() {
+        // Given
+        RuntimeException cause = new RuntimeException("kafka unreachable");
+        when(adminClient.describeConsumerGroups(List.of("g1"))).thenThrow(cause);
+
+        // When
+        JikkouRuntimeException ex = assertThrows(JikkouRuntimeException.class,
+            () -> service.listConsumerGroups(List.of("g1"), false));
+
+        // Then
+        assertNotNull(ex.getCause(), "JikkouRuntimeException must chain the original cause");
+        assertSame(cause, ex.getCause(),
+            "The chained cause must be the original RuntimeException thrown by the AdminClient");
+    }
+
+    @Test
+    void shouldChainCauseWhenAdminClientThrowsAsync() {
+        // Given
+        RuntimeException cause = new RuntimeException("kafka unreachable");
+        when(adminClient.describeConsumerGroups(List.of("g1"))).thenThrow(cause);
+
+        // When
+        Mono<V1KafkaConsumerGroupList> mono = service.listConsumerGroupsAsync(List.of("g1"), false);
+
+        // Then
+        JikkouRuntimeException ex = assertThrows(JikkouRuntimeException.class, mono::block);
+        assertNotNull(ex.getCause(), "JikkouRuntimeException must chain the original cause");
+        assertSame(cause, ex.getCause(),
+            "The chained cause must be the original RuntimeException thrown by the AdminClient");
+    }
+
+    @Test
+    void shouldNotDoubleWrapJikkouRuntimeException() {
+        // Given - AdminClient itself throws a JikkouRuntimeException (e.g. from a wrapping layer)
+        JikkouRuntimeException original = new JikkouRuntimeException("already wrapped");
+        when(adminClient.describeConsumerGroups(List.of("g1"))).thenThrow(original);
+
+        // When
+        JikkouRuntimeException ex = assertThrows(JikkouRuntimeException.class,
+            () -> service.listConsumerGroups(List.of("g1"), false));
+
+        // Then
+        assertSame(original, ex,
+            "An existing JikkouRuntimeException must be propagated as-is, not re-wrapped");
+    }
+
+    @Test
+    void shouldReturnSameResultFromSyncAndAsyncVariants() {
+        // Given
+        DescribeConsumerGroupsResult result = mock(DescribeConsumerGroupsResult.class);
+        when(adminClient.describeConsumerGroups(List.of())).thenReturn(result);
+        when(result.describedGroups()).thenReturn(Map.of());
+
+        // When
+        V1KafkaConsumerGroupList sync = service.listConsumerGroups(List.of(), false);
+        V1KafkaConsumerGroupList async = service.listConsumerGroupsAsync(List.of(), false).block();
+
+        // Then
+        assertEquals(sync.getItems(), async.getItems());
+    }
+}

--- a/server/jikkou-api-server/src/main/java/io/jikkou/rest/resources/ApiHealthIndicatorListResource.java
+++ b/server/jikkou-api-server/src/main/java/io/jikkou/rest/resources/ApiHealthIndicatorListResource.java
@@ -25,6 +25,8 @@ import io.micronaut.http.annotation.Produces;
 import io.micronaut.http.annotation.QueryValue;
 import io.micronaut.http.hateoas.Link;
 import io.micronaut.http.hateoas.Resource;
+import io.micronaut.scheduling.TaskExecutors;
+import io.micronaut.scheduling.annotation.ExecuteOn;
 import io.micronaut.security.annotation.Secured;
 import io.micronaut.security.rules.SecurityRule;
 import jakarta.annotation.security.PermitAll;
@@ -41,6 +43,7 @@ import org.jetbrains.annotations.NotNull;
 
 @Controller("/api/v1/healths")
 @Secured(SecurityRule.IS_AUTHENTICATED)
+@ExecuteOn(TaskExecutors.BLOCKING)
 public class ApiHealthIndicatorListResource extends AbstractController {
 
     public static final String STATUS_LINK_KEY = "status";


### PR DESCRIPTION
KafkaAdminService.listConsumerGroups blocked the calling thread via Reactor's block() on a pipeline collecting Kafka admin futures. When invoked from a Netty event loop (e.g. the api-server health endpoint), this either threw IllegalStateException (Reactor's non-blocking-thread guard) or silently starved the event loop.

Make the pipeline non-blocking end-to-end:

- KafkaAdminService: expose listConsumerGroupsAsync returning a Mono; the synchronous listConsumerGroups is now a thin wrapper delegating to it via AsyncUtils.getValueOrThrowException. The cause is chained into JikkouRuntimeException, and an already-wrapped exception is not re-wrapped.
- TruncateKafkaTopicRecords: same Mono plus AsyncUtils pattern, replacing the trailing .block() at the end of its pipeline.
- ApiHealthIndicatorListResource: offload to the blocking executor so KafkaBrokerHealthIndicator's KafkaFuture.get() calls no longer run on a Netty event loop.

Add KafkaAdminServiceTest covering empty results, cause chaining for both sync and async paths, and no double-wrapping of JikkouRuntimeException.