### PR TITLE
build(deps): upgrade Apache Kafka to 4.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
         <testcontainer.version>2.0.3</testcontainer.version>
         <mockwebserver.version>5.3.2</mockwebserver.version>
         <!-- Dependencies -->
-        <kafka.version>3.9.2</kafka.version>
+        <kafka.version>4.3.0</kafka.version>
         <picocli.version>4.7.7</picocli.version>
         <jackson.version>2.18.6</jackson.version>
         <jinjava.version>2.8.3</jinjava.version>
@@ -174,11 +174,6 @@
                 <version>${netty.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.zookeeper</groupId>
-                <artifactId>zookeeper</artifactId>
-                <version>3.8.6</version>
             </dependency>
             <dependency>
                 <groupId>org.graalvm.sdk</groupId>

--- a/providers/jikkou-provider-kafka/src/integration-test/java/io/jikkou/kafka/AbstractKafkaIntegrationTest.java
+++ b/providers/jikkou-provider-kafka/src/integration-test/java/io/jikkou/kafka/AbstractKafkaIntegrationTest.java
@@ -35,7 +35,7 @@ public class AbstractKafkaIntegrationTest {
     private static final Logger LOG = LoggerFactory.getLogger(AbstractKafkaIntegrationTest.class);
     private static final Network KAFKA_NETWORK = Network.newNetwork();
 
-    public static final String APACHE_KAFKA_VERSION = "3.8.0";
+    public static final String APACHE_KAFKA_VERSION = "4.3.0";
     public static final int DEFAULT_NUM_PARTITIONS = 1;
     public static final short DEFAULT_REPLICATION_FACTOR = (short) 1;
 

--- a/providers/jikkou-provider-kafka/src/main/java/io/jikkou/kafka/internals/producer/DefaultProducerFactory.java
+++ b/providers/jikkou-provider-kafka/src/main/java/io/jikkou/kafka/internals/producer/DefaultProducerFactory.java
@@ -30,6 +30,7 @@ import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.errors.ProducerFencedException;
+import org.apache.kafka.common.metrics.KafkaMetric;
 import org.apache.kafka.common.serialization.Serializer;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -196,22 +197,28 @@ public final class DefaultProducerFactory<K, V> implements ProducerFactory<K, V>
         }
 
         /**
-         * @see KafkaProducer#sendOffsetsToTransaction(Map, String)
-         **/
-        @Deprecated
-        @Override
-        public void sendOffsetsToTransaction(Map<TopicPartition, OffsetAndMetadata> offsets,
-                                             String consumerGroupId) throws ProducerFencedException {
-            delegate.getResourceHandle().sendOffsetsToTransaction(offsets, consumerGroupId);
-        }
-
-        /**
          * @see KafkaProducer#sendOffsetsToTransaction(Map, ConsumerGroupMetadata)
          **/
         @Override
         public void sendOffsetsToTransaction(Map<TopicPartition, OffsetAndMetadata> offsets,
                                              ConsumerGroupMetadata groupMetadata) throws ProducerFencedException {
             delegate.getResourceHandle().sendOffsetsToTransaction(offsets, groupMetadata);
+        }
+
+        /**
+         * @see KafkaProducer#registerMetricForSubscription(KafkaMetric)
+         **/
+        @Override
+        public void registerMetricForSubscription(KafkaMetric metric) {
+            delegate.getResourceHandle().registerMetricForSubscription(metric);
+        }
+
+        /**
+         * @see KafkaProducer#unregisterMetricFromSubscription(KafkaMetric)
+         **/
+        @Override
+        public void unregisterMetricFromSubscription(KafkaMetric metric) {
+            delegate.getResourceHandle().unregisterMetricFromSubscription(metric);
         }
 
         /**

--- a/providers/jikkou-provider-kafka/src/main/resources/META-INF/native-image/io.jikkou/jikkou-extension-kafka/reachability-metadata.json
+++ b/providers/jikkou-provider-kafka/src/main/resources/META-INF/native-image/io.jikkou/jikkou-extension-kafka/reachability-metadata.json
@@ -309,6 +309,24 @@
       ]
     },
     {
+      "type": "org.apache.kafka.common.security.oauthbearer.DefaultJwtRetriever",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.apache.kafka.common.security.oauthbearer.DefaultJwtValidator",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
       "type": "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginCallbackHandler",
       "methods": [
         {


### PR DESCRIPTION
Bump kafka-clients from 3.9.2 to 4.3.0 (latest 4.x release).

- Adapt OpaqueProducer to the Kafka 4.x Producer interface: drop the removed sendOffsetsToTransaction(Map, String) overload and implement the new registerMetricForSubscription / unregisterMetricFromSubscription methods.
- Bump the integration-test broker image (apache/kafka-native) to 4.3.0.
- Remove the redundant zookeeper dependencyManagement override; Hadoop 3.5.0 already pins the same 3.8.6 transitively.