### PR TITLE
feat(rest): support HTTP proxy configuration for REST providers

### DIFF
--- a/docs/content/en/docs/Providers/Aiven/Configuration/_index.md
+++ b/docs/content/en/docs/Providers/Aiven/Configuration/_index.md
@@ -31,10 +31,38 @@ jikkou {
       apiUrl = "https://api.aiven.io/v1/"
       # Aiven Bearer Token. Tokens can be obtained from your Aiven profile page
       tokenAuth = null
+      # HTTP proxy URL, e.g. 'http://proxy.example.com:3128'. When empty, JVM proxy system properties are used.
+      proxyUrl = "http://proxy.example.com:3128"
+      # Username for proxy Basic authentication (optional).
+      proxyUsername = null
+      # Password for proxy Basic authentication (optional).
+      proxyPassword = null
+      # Comma-separated hosts that bypass the proxy, e.g. 'localhost,127.0.0.1,*.internal'.
+      nonProxyHosts = "localhost,127.0.0.1"
       # Enable debug logging
       debugLoggingEnabled = false
     }
   }
 }
 ```
+
+## HTTP proxy
+
+Jikkou can reach the Aiven REST API through an HTTP/HTTPS forward proxy.
+
+| Property         | Description                                                                                        |
+|------------------|----------------------------------------------------------------------------------------------------|
+| `proxyUrl`       | Proxy URL, e.g. `http://proxy.example.com:3128`. When empty, JVM proxy system properties are used.  |
+| `proxyUsername`  | Username for proxy Basic authentication (optional).                                                |
+| `proxyPassword`  | Password for proxy Basic authentication (optional).                                                |
+| `nonProxyHosts`  | Comma-separated hosts that bypass the proxy, e.g. `localhost,127.0.0.1,*.internal`.                |
+
+If `proxyUrl` is not set, Jikkou honors the standard JVM proxy system properties
+(`-Dhttps.proxyHost`, `-Dhttp.proxyHost`, `-Dhttp.proxyUser`, `-Dhttp.proxyPassword`,
+`-Dhttp.nonProxyHosts`), which can be supplied via `JAVA_TOOL_OPTIONS`.
+
+{{% alert title="Note" color="info" %}}
+The OS-level `http_proxy` / `https_proxy` environment variables are **not** read by the JVM
+and have no effect. Use `proxyUrl` or the JVM system properties above.
+{{% /alert %}}
 

--- a/docs/content/en/docs/Providers/Confluent Cloud/Configuration/_index.md
+++ b/docs/content/en/docs/Providers/Confluent Cloud/Configuration/_index.md
@@ -31,6 +31,14 @@ jikkou {
       apiSecret = ${CONFLUENT_CLOUD_API_SECRET}
       # CRN pattern used to scope role binding list operations
       crnPattern = ${CONFLUENT_CLOUD_CRN_PATTERN}
+      # HTTP proxy URL, e.g. 'http://proxy.example.com:3128' (optional)
+      proxyUrl = "http://proxy.example.com:3128"
+      # Username for proxy Basic authentication (optional)
+      proxyUsername = null
+      # Password for proxy Basic authentication (optional)
+      proxyPassword = null
+      # Comma-separated hosts that bypass the proxy (optional)
+      nonProxyHosts = "localhost,127.0.0.1"
       # Enable debug logging (default: false)
       debugLoggingEnabled = false
     }
@@ -46,7 +54,16 @@ jikkou {
 | `apiKey`             | String  | Yes      |                                | Cloud API Key. Must be a **Cloud API Key**, not a Cluster API Key. |
 | `apiSecret`          | String  | Yes      |                                | Cloud API Secret.                                                |
 | `crnPattern`         | String  | Yes      |                                | CRN pattern to scope role binding list operations.               |
+| `proxyUrl`           | String  | No       |                                | HTTP proxy URL, e.g. `http://proxy.example.com:3128`. When empty, JVM proxy system properties are used. |
+| `proxyUsername`      | String  | No       |                                | Username for proxy Basic authentication.                         |
+| `proxyPassword`      | String  | No       |                                | Password for proxy Basic authentication.                         |
+| `nonProxyHosts`      | String  | No       |                                | Comma-separated hosts that bypass the proxy, e.g. `localhost,*.internal`. |
 | `debugLoggingEnabled`| Boolean | No       | `false`                        | Enable debug logging for REST API calls.                         |
+
+> If `proxyUrl` is not set, Jikkou honors the standard JVM proxy system properties
+> (`-Dhttps.proxyHost`, `-Dhttp.proxyHost`, `-Dhttp.proxyUser`, `-Dhttp.proxyPassword`,
+> `-Dhttp.nonProxyHosts`), which can be supplied via `JAVA_TOOL_OPTIONS`. The OS-level
+> `http_proxy` / `https_proxy` environment variables are **not** read by the JVM and have no effect.
 
 ### Creating a Cloud API Key
 

--- a/docs/content/en/docs/Providers/Kafka Connect/Configuration/_index.md
+++ b/docs/content/en/docs/Providers/Kafka Connect/Configuration/_index.md
@@ -57,9 +57,39 @@ jikkou {
           sslTrustStorePassword = "password"
           # Specifies whether to ignore the hostname verification.
           sslIgnoreHostnameVerification = true
+
+          # HTTP proxy: route requests to the Kafka Connect REST API through a forward proxy.
+          # Proxy URL, e.g. 'http://proxy.example.com:3128'. When empty, JVM proxy system properties are used.
+          proxyUrl = "http://proxy.example.com:3128"
+          # Username for proxy Basic authentication (optional).
+          proxyUsername = null
+          # Password for proxy Basic authentication (optional).
+          proxyPassword = null
+          # Comma-separated hosts that bypass the proxy, e.g. 'localhost,127.0.0.1,*.internal'.
+          nonProxyHosts = "localhost,127.0.0.1"
         }
       ]
     }
   }
 }
 ```
+
+## HTTP proxy
+
+Jikkou can reach the Kafka Connect REST API through an HTTP/HTTPS forward proxy.
+
+| Property         | Description                                                                                        |
+|------------------|----------------------------------------------------------------------------------------------------|
+| `proxyUrl`       | Proxy URL, e.g. `http://proxy.example.com:3128`. When empty, JVM proxy system properties are used.  |
+| `proxyUsername`  | Username for proxy Basic authentication (optional).                                                |
+| `proxyPassword`  | Password for proxy Basic authentication (optional).                                                |
+| `nonProxyHosts`  | Comma-separated hosts that bypass the proxy, e.g. `localhost,127.0.0.1,*.internal`.                |
+
+If `proxyUrl` is not set, Jikkou honors the standard JVM proxy system properties
+(`-Dhttps.proxyHost`, `-Dhttp.proxyHost`, `-Dhttp.proxyUser`, `-Dhttp.proxyPassword`,
+`-Dhttp.nonProxyHosts`), which can be supplied via `JAVA_TOOL_OPTIONS`.
+
+{{% alert title="Note" color="info" %}}
+The OS-level `http_proxy` / `https_proxy` environment variables are **not** read by the JVM
+and have no effect. Use `proxyUrl` or the JVM system properties above.
+{{% /alert %}}

--- a/docs/content/en/docs/Providers/Schema Registry/Configuration/_index.md
+++ b/docs/content/en/docs/Providers/Schema Registry/Configuration/_index.md
@@ -53,7 +53,37 @@ jikkou {
       sslTrustStorePassword = "password"
       # Specifies whether to ignore the hostname verification.
       sslIgnoreHostnameVerification = true
+
+      # HTTP proxy: route requests to the Schema Registry through a forward proxy.
+      # Proxy URL, e.g. 'http://proxy.example.com:3128'. When empty, JVM proxy system properties are used.
+      proxyUrl = "http://proxy.example.com:3128"
+      # Username for proxy Basic authentication (optional).
+      proxyUsername = null
+      # Password for proxy Basic authentication (optional).
+      proxyPassword = null
+      # Comma-separated hosts that bypass the proxy, e.g. 'localhost,127.0.0.1,*.internal'.
+      nonProxyHosts = "localhost,127.0.0.1"
     }
   }
 }
 ```
+
+## HTTP proxy
+
+Jikkou can reach the Schema Registry REST API through an HTTP/HTTPS forward proxy.
+
+| Property         | Description                                                                                        |
+|------------------|----------------------------------------------------------------------------------------------------|
+| `proxyUrl`       | Proxy URL, e.g. `http://proxy.example.com:3128`. When empty, JVM proxy system properties are used.  |
+| `proxyUsername`  | Username for proxy Basic authentication (optional).                                                |
+| `proxyPassword`  | Password for proxy Basic authentication (optional).                                                |
+| `nonProxyHosts`  | Comma-separated hosts that bypass the proxy, e.g. `localhost,127.0.0.1,*.internal`.                |
+
+If `proxyUrl` is not set, Jikkou honors the standard JVM proxy system properties
+(`-Dhttps.proxyHost`, `-Dhttp.proxyHost`, `-Dhttp.proxyUser`, `-Dhttp.proxyPassword`,
+`-Dhttp.nonProxyHosts`), which can be supplied via `JAVA_TOOL_OPTIONS`.
+
+{{% alert title="Note" color="info" %}}
+The OS-level `http_proxy` / `https_proxy` environment variables are **not** read by the JVM
+and have no effect. Use `proxyUrl` or the JVM system properties above.
+{{% /alert %}}

--- a/extension-rest-client/src/main/java/io/jikkou/http/client/RestClientBuilder.java
+++ b/extension-rest-client/src/main/java/io/jikkou/http/client/RestClientBuilder.java
@@ -9,6 +9,7 @@ package io.jikkou.http.client;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jikkou.core.exceptions.JikkouRuntimeException;
 import io.jikkou.core.io.Jackson;
+import io.jikkou.http.client.proxy.ProxyConfig;
 import io.jikkou.http.client.ssl.SSLConfig;
 import io.jikkou.http.client.ssl.SSLContextFactory;
 import io.jikkou.http.client.ssl.SSLUtils;
@@ -28,6 +29,7 @@ import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -36,10 +38,24 @@ import java.util.concurrent.TimeUnit;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSession;
 import javax.net.ssl.TrustManager;
+import org.apache.http.HttpException;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpRequest;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.conn.DefaultProxyRoutePlanner;
+import org.apache.http.protocol.HttpContext;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
+import org.jboss.resteasy.client.jaxrs.engines.ApacheHttpClient43Engine;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -60,6 +76,11 @@ public class RestClientBuilder {
     private boolean enableClientDebugging = false;
     private final ResteasyClientBuilder clientBuilder;
     private ObjectMapper objectMapper = Jackson.JSON_OBJECT_MAPPER;
+    private SSLContext sslContext;
+    private boolean ignoreHostnameVerification;
+    private Duration connectTimeout;
+    private Duration readTimeout;
+    private ProxyConfig proxyConfig;
 
     /**
      * Creates a new {@link RestClientBuilder} instance.
@@ -128,6 +149,7 @@ public class RestClientBuilder {
     }
 
     public RestClientBuilder sslIgnoreHostnameVerification() {
+        this.ignoreHostnameVerification = true;
         clientBuilder.hostnameVerifier(NO_HOST_NAME_VERIFIER);
         return this;
     }
@@ -138,6 +160,7 @@ public class RestClientBuilder {
      * @return {@code this}.
      */
     public RestClientBuilder writeTimeout(Duration writeTimeout) {
+        this.connectTimeout = writeTimeout;
         clientBuilder.connectTimeout(writeTimeout.toMillis(), TimeUnit.MILLISECONDS);
         return this;
     }
@@ -149,6 +172,7 @@ public class RestClientBuilder {
      * @return {@code this}.
      */
     public RestClientBuilder readTimeout(Duration readTimeout) {
+        this.readTimeout = readTimeout;
         clientBuilder.readTimeout(readTimeout.toMillis(), TimeUnit.MILLISECONDS);
         return this;
     }
@@ -235,10 +259,26 @@ public class RestClientBuilder {
             }
 
             SSLContextFactory sslContextFactory = new SSLContextFactory();
-            clientBuilder.sslContext(sslContextFactory.getSSLContext(keyManagers, trustManagers));
+            this.sslContext = sslContextFactory.getSSLContext(keyManagers, trustManagers);
+            clientBuilder.sslContext(this.sslContext);
         }
 
-        return sslConfig.ignoreHostnameVerification() ? sslIgnoreHostnameVerification() : this;
+        if (sslConfig.ignoreHostnameVerification()) {
+            return sslIgnoreHostnameVerification();
+        }
+        return this;
+    }
+
+    /**
+     * Sets the proxy configuration. When the proxy URL is set, requests are routed
+     * through it; otherwise standard JVM proxy system properties are honored as a fallback.
+     *
+     * @param proxyConfig the proxy configuration.
+     * @return {@code this}.
+     */
+    public RestClientBuilder proxyConfig(final ProxyConfig proxyConfig) {
+        this.proxyConfig = proxyConfig;
+        return this;
     }
 
     private static char[] toCharArrayOrNull(String value) {
@@ -269,11 +309,82 @@ public class RestClientBuilder {
             clientBuilder.register(new LoggingRequestFilter());
         }
 
+        // Install a custom Apache engine only when a proxy must be used, so that the
+        // default path is completely unchanged for users without any proxy.
+        if (shouldUseProxyEngine()) {
+            clientBuilder.httpEngine(buildProxyEngine());
+        }
+
         Client client = clientBuilder.build();
         ResteasyWebTarget target = (ResteasyWebTarget) client.target(baseUri);
         target.property("org.jboss.resteasy.follow.redirects", followRedirects);
 
         return target.proxy(resourceInterface);
+    }
+
+    private boolean shouldUseProxyEngine() {
+        boolean explicit = proxyConfig != null && proxyConfig.hasExplicitProxy();
+        return explicit || hasProxySystemProperties();
+    }
+
+    private static boolean hasProxySystemProperties() {
+        return isNotBlank(System.getProperty("http.proxyHost"))
+            || isNotBlank(System.getProperty("https.proxyHost"));
+    }
+
+    private static boolean isNotBlank(String value) {
+        return value != null && !value.isBlank();
+    }
+
+    private ApacheHttpClient43Engine buildProxyEngine() {
+        HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
+
+        if (proxyConfig != null && proxyConfig.hasExplicitProxy()) {
+            URI proxyUri = URI.create(proxyConfig.proxyUrl());
+            String scheme = proxyUri.getScheme() != null ? proxyUri.getScheme() : "http";
+            int port = proxyUri.getPort() != -1
+                ? proxyUri.getPort()
+                : ("https".equalsIgnoreCase(scheme) ? 443 : 80);
+            HttpHost proxyHost = new HttpHost(proxyUri.getHost(), port, scheme);
+
+            List<String> nonProxyHosts = NonProxyHostsRoutePlanner.parse(proxyConfig.nonProxyHosts());
+            httpClientBuilder.setRoutePlanner(new NonProxyHostsRoutePlanner(proxyHost, nonProxyHosts));
+
+            if (proxyConfig.hasCredentials()) {
+                CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+                credentialsProvider.setCredentials(
+                    new AuthScope(proxyHost.getHostName(), proxyHost.getPort()),
+                    new UsernamePasswordCredentials(proxyConfig.proxyUsername(), proxyConfig.proxyPassword()));
+                httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
+            }
+            LOG.info("Routing REST client traffic through proxy: {}://{}:{}",
+                scheme, proxyHost.getHostName(), proxyHost.getPort());
+        } else {
+            // Fallback: honor -Dhttp.proxyHost / -Dhttps.proxyHost / http.proxyUser etc.
+            httpClientBuilder.useSystemProperties();
+            LOG.info("Routing REST client traffic using JVM proxy system properties");
+        }
+
+        if (sslContext != null) {
+            httpClientBuilder.setSSLContext(sslContext);
+        }
+        if (ignoreHostnameVerification) {
+            httpClientBuilder.setSSLHostnameVerifier(NO_HOST_NAME_VERIFIER);
+        }
+
+        RequestConfig.Builder requestConfig = RequestConfig.custom();
+        if (connectTimeout != null) {
+            requestConfig.setConnectTimeout((int) connectTimeout.toMillis());
+        }
+        if (readTimeout != null) {
+            requestConfig.setSocketTimeout((int) readTimeout.toMillis());
+        }
+        httpClientBuilder.setDefaultRequestConfig(requestConfig.build());
+
+        CloseableHttpClient httpClient = httpClientBuilder.build();
+        ApacheHttpClient43Engine engine = new ApacheHttpClient43Engine(httpClient);
+        engine.setFollowRedirects(followRedirects);
+        return engine;
     }
 
     /**
@@ -330,6 +441,58 @@ public class RestClientBuilder {
         @Override
         public boolean verify(final String hostname, final SSLSession sslSession) {
             return true;
+        }
+    }
+
+    /**
+     * A route planner that sends traffic through the given proxy except for hosts
+     * matching one of the configured {@code nonProxyHosts} patterns (JVM-style,
+     * supporting leading/trailing '*' wildcards).
+     */
+    static final class NonProxyHostsRoutePlanner extends DefaultProxyRoutePlanner {
+
+        private final List<String> nonProxyHosts;
+
+        NonProxyHostsRoutePlanner(final HttpHost proxy, final List<String> nonProxyHosts) {
+            super(proxy);
+            this.nonProxyHosts = nonProxyHosts;
+        }
+
+        @Override
+        protected HttpHost determineProxy(final HttpHost target,
+                                          final HttpRequest request,
+                                          final HttpContext context) throws HttpException {
+            final String host = target.getHostName();
+            for (String pattern : nonProxyHosts) {
+                if (matches(host, pattern)) {
+                    return null; // bypass proxy, connect directly
+                }
+            }
+            return super.determineProxy(target, request, context);
+        }
+
+        static boolean matches(final String host, final String rawPattern) {
+            final String pattern = rawPattern.trim();
+            if (pattern.isEmpty()) {
+                return false;
+            }
+            if (pattern.startsWith("*")) {
+                return host.toLowerCase().endsWith(pattern.substring(1).toLowerCase());
+            }
+            if (pattern.endsWith("*")) {
+                return host.toLowerCase().startsWith(pattern.substring(0, pattern.length() - 1).toLowerCase());
+            }
+            return host.equalsIgnoreCase(pattern);
+        }
+
+        static List<String> parse(final String nonProxyHosts) {
+            if (nonProxyHosts == null || nonProxyHosts.isBlank()) {
+                return List.of();
+            }
+            return Arrays.stream(nonProxyHosts.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .toList();
         }
     }
 }

--- a/extension-rest-client/src/main/java/io/jikkou/http/client/proxy/ProxyConfig.java
+++ b/extension-rest-client/src/main/java/io/jikkou/http/client/proxy/ProxyConfig.java
@@ -1,0 +1,73 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.jikkou.http.client.proxy;
+
+import io.jikkou.core.config.ConfigProperty;
+import io.jikkou.core.config.Configuration;
+
+/**
+ * HTTP proxy configuration for REST-based providers.
+ *
+ * @param proxyUrl       the proxy URL, e.g. {@code http://proxy.example.com:3128}.
+ * @param proxyUsername  the username for proxy Basic authentication (optional).
+ * @param proxyPassword  the password for proxy Basic authentication (optional).
+ * @param nonProxyHosts  comma-separated list of hosts that bypass the proxy (optional).
+ */
+public record ProxyConfig(
+    String proxyUrl,
+    String proxyUsername,
+    String proxyPassword,
+    String nonProxyHosts
+) {
+
+    public static final ConfigProperty<String> PROXY_URL = ConfigProperty
+        .ofString("proxyUrl")
+        .description("HTTP proxy URL used to reach the target API, e.g. 'http://proxy.example.com:3128'. "
+            + "When empty, standard JVM proxy system properties (http.proxyHost / https.proxyHost) are honored as a fallback.");
+
+    public static final ConfigProperty<String> PROXY_USERNAME = ConfigProperty
+        .ofString("proxyUsername")
+        .description("Username for proxy Basic authentication. Optional.");
+
+    public static final ConfigProperty<String> PROXY_PASSWORD = ConfigProperty
+        .ofString("proxyPassword")
+        .description("Password for proxy Basic authentication. Optional.");
+
+    public static final ConfigProperty<String> NON_PROXY_HOSTS = ConfigProperty
+        .ofString("nonProxyHosts")
+        .description("Comma-separated list of hosts that should bypass the proxy. "
+            + "Supports leading or trailing '*' wildcards, e.g. 'localhost,127.0.0.1,*.internal'.");
+
+    /**
+     * Creates a {@link ProxyConfig} from the given configuration.
+     *
+     * @param configuration the configuration.
+     * @return a new {@link ProxyConfig}.
+     */
+    public static ProxyConfig from(final Configuration configuration) {
+        return new ProxyConfig(
+            PROXY_URL.getOptional(configuration).orElse(null),
+            PROXY_USERNAME.getOptional(configuration).orElse(null),
+            PROXY_PASSWORD.getOptional(configuration).orElse(null),
+            NON_PROXY_HOSTS.getOptional(configuration).orElse(null)
+        );
+    }
+
+    /**
+     * @return {@code true} if an explicit proxy URL has been configured.
+     */
+    public boolean hasExplicitProxy() {
+        return proxyUrl != null && !proxyUrl.isBlank();
+    }
+
+    /**
+     * @return {@code true} if proxy Basic-auth credentials have been configured.
+     */
+    public boolean hasCredentials() {
+        return proxyUsername != null && !proxyUsername.isBlank();
+    }
+}

--- a/extension-rest-client/src/test/java/io/jikkou/http/client/RestClientBuilderProxyTest.java
+++ b/extension-rest-client/src/test/java/io/jikkou/http/client/RestClientBuilderProxyTest.java
@@ -1,0 +1,144 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.jikkou.http.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.jikkou.http.client.proxy.ProxyConfig;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import java.io.IOException;
+import java.util.Base64;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class RestClientBuilderProxyTest {
+
+    private MockWebServer proxy;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        proxy = new MockWebServer();
+        proxy.start();
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        proxy.shutdown();
+    }
+
+    @Test
+    void shouldRouteRequestThroughExplicitProxy() throws Exception {
+        proxy.enqueue(new MockResponse()
+                .setHeader("Content-Type", MediaType.APPLICATION_JSON)
+                .setResponseCode(200)
+                .setBody("pong"));
+
+        ProxyConfig proxyConfig = new ProxyConfig(proxy.url("/").toString(), null, null, null);
+
+        Ping resource = RestClientBuilder.newBuilder()
+                .baseUri("http://dummy-target.invalid/")
+                .proxyConfig(proxyConfig)
+                .build(Ping.class);
+
+        assertEquals("pong", resource.ping());
+
+        RecordedRequest request = proxy.takeRequest();
+        // A forward proxy receives the absolute request URI in the request line.
+        assertTrue(request.getPath().startsWith("http://dummy-target.invalid"),
+                "expected absolute-form request target, got: " + request.getPath());
+    }
+
+    @Test
+    void shouldSendProxyAuthorizationAfterChallenge() throws Exception {
+        proxy.enqueue(new MockResponse()
+                .setResponseCode(407)
+                .setHeader("Proxy-Authenticate", "Basic realm=\"proxy\""));
+        proxy.enqueue(new MockResponse()
+                .setHeader("Content-Type", MediaType.APPLICATION_JSON)
+                .setResponseCode(200)
+                .setBody("pong"));
+
+        ProxyConfig proxyConfig = new ProxyConfig(proxy.url("/").toString(), "alice", "secret", null);
+
+        Ping resource = RestClientBuilder.newBuilder()
+                .baseUri("http://dummy-target.invalid/")
+                .proxyConfig(proxyConfig)
+                .build(Ping.class);
+
+        assertEquals("pong", resource.ping());
+
+        RecordedRequest first = proxy.takeRequest();   // no credentials yet
+        RecordedRequest second = proxy.takeRequest();  // retried with credentials
+        String expected = "Basic " + Base64.getEncoder()
+                .encodeToString("alice:secret".getBytes());
+        assertEquals(expected, second.getHeader("Proxy-Authorization"));
+    }
+
+    @Test
+    void shouldBypassProxyForNonProxyHosts() {
+        // Proxy points to an unreachable address; nonProxyHosts must force a direct
+        // connection to the MockWebServer, otherwise the request would fail.
+        proxy.enqueue(new MockResponse()
+                .setHeader("Content-Type", MediaType.APPLICATION_JSON)
+                .setResponseCode(200)
+                .setBody("pong"));
+
+        ProxyConfig proxyConfig = new ProxyConfig(
+                "http://bogus-proxy.invalid:3128", null, null, "localhost,127.0.0.1");
+
+        Ping resource = RestClientBuilder.newBuilder()
+                .baseUri(proxy.url("/").toString())
+                .proxyConfig(proxyConfig)
+                .build(Ping.class);
+
+        assertEquals("pong", resource.ping());
+    }
+
+    @Test
+    void shouldHonorSystemPropertyProxyAsFallback() throws Exception {
+        proxy.enqueue(new MockResponse()
+                .setHeader("Content-Type", MediaType.APPLICATION_JSON)
+                .setResponseCode(200)
+                .setBody("pong"));
+
+        System.setProperty("http.proxyHost", proxy.getHostName());
+        System.setProperty("http.proxyPort", String.valueOf(proxy.getPort()));
+        try {
+            ProxyConfig emptyProxyConfig = new ProxyConfig(null, null, null, null);
+
+            Ping resource = RestClientBuilder.newBuilder()
+                    .baseUri("http://dummy-target.invalid/")
+                    .proxyConfig(emptyProxyConfig)
+                    .build(Ping.class);
+
+            assertEquals("pong", resource.ping());
+
+            RecordedRequest request = proxy.takeRequest();
+            assertTrue(request.getPath().startsWith("http://dummy-target.invalid"),
+                    "expected request routed via system-property proxy, got: " + request.getPath());
+        } finally {
+            System.clearProperty("http.proxyHost");
+            System.clearProperty("http.proxyPort");
+        }
+    }
+
+    @Path("/")
+    public interface Ping {
+        @GET
+        @Produces(MediaType.APPLICATION_JSON)
+        @Path("ping")
+        String ping();
+    }
+}

--- a/extension-rest-client/src/test/java/io/jikkou/http/client/proxy/ProxyConfigTest.java
+++ b/extension-rest-client/src/test/java/io/jikkou/http/client/proxy/ProxyConfigTest.java
@@ -1,0 +1,58 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.jikkou.http.client.proxy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.jikkou.core.config.Configuration;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ProxyConfigTest {
+
+    @Test
+    void shouldParseAllPropertiesFromConfiguration() {
+        Configuration configuration = Configuration.from(Map.of(
+                "proxyUrl", "http://proxy.example.com:3128",
+                "proxyUsername", "alice",
+                "proxyPassword", "secret",
+                "nonProxyHosts", "localhost,*.internal"
+        ));
+
+        ProxyConfig proxyConfig = ProxyConfig.from(configuration);
+
+        assertEquals("http://proxy.example.com:3128", proxyConfig.proxyUrl());
+        assertEquals("alice", proxyConfig.proxyUsername());
+        assertEquals("secret", proxyConfig.proxyPassword());
+        assertEquals("localhost,*.internal", proxyConfig.nonProxyHosts());
+        assertTrue(proxyConfig.hasExplicitProxy());
+        assertTrue(proxyConfig.hasCredentials());
+    }
+
+    @Test
+    void shouldReturnEmptyProxyConfigWhenNoPropertiesSet() {
+        ProxyConfig proxyConfig = ProxyConfig.from(Configuration.empty());
+
+        assertNull(proxyConfig.proxyUrl());
+        assertNull(proxyConfig.proxyUsername());
+        assertNull(proxyConfig.nonProxyHosts());
+        assertFalse(proxyConfig.hasExplicitProxy());
+        assertFalse(proxyConfig.hasCredentials());
+    }
+
+    @Test
+    void shouldNotReportCredentialsWhenOnlyUrlSet() {
+        ProxyConfig proxyConfig = ProxyConfig.from(
+                Configuration.from(Map.of("proxyUrl", "http://proxy.example.com:3128")));
+
+        assertTrue(proxyConfig.hasExplicitProxy());
+        assertFalse(proxyConfig.hasCredentials());
+    }
+}

--- a/providers/jikkou-provider-aiven/src/main/java/io/jikkou/extension/aiven/AivenExtensionProvider.java
+++ b/providers/jikkou-provider-aiven/src/main/java/io/jikkou/extension/aiven/AivenExtensionProvider.java
@@ -40,6 +40,7 @@ import io.jikkou.extension.aiven.reconciler.AivenSchemaRegistrySubjectCollector;
 import io.jikkou.extension.aiven.reconciler.AivenSchemaRegistrySubjectController;
 import io.jikkou.extension.aiven.validation.AivenSchemaCompatibilityValidation;
 import io.jikkou.extension.aiven.validation.SchemaRegistryAclEntryValidation;
+import io.jikkou.http.client.proxy.ProxyConfig;
 import io.jikkou.kafka.models.V1KafkaTopic;
 import io.jikkou.schema.registry.models.V1SchemaRegistrySubject;
 import io.jikkou.spi.BaseExtensionProvider;
@@ -111,6 +112,7 @@ public final class AivenExtensionProvider extends BaseExtensionProvider {
             Config.TOKEN_AUTH.get(configuration),
             Config.PROJECT.get(configuration),
             Config.SERVICE.get(configuration),
+            ProxyConfig.from(configuration),
             Config.DEBUG_LOGGING_ENABLED.get(configuration)
         );
     }
@@ -129,6 +131,10 @@ public final class AivenExtensionProvider extends BaseExtensionProvider {
             Config.TOKEN_AUTH,
             Config.PROJECT,
             Config.SERVICE,
+            ProxyConfig.PROXY_URL,
+            ProxyConfig.PROXY_USERNAME,
+            ProxyConfig.PROXY_PASSWORD,
+            ProxyConfig.NON_PROXY_HOSTS,
             Config.DEBUG_LOGGING_ENABLED,
             Config.TOPIC_DELETE_EXCLUDE_PATTERNS
         );

--- a/providers/jikkou-provider-aiven/src/main/java/io/jikkou/extension/aiven/api/AivenApiClientConfig.java
+++ b/providers/jikkou-provider-aiven/src/main/java/io/jikkou/extension/aiven/api/AivenApiClientConfig.java
@@ -6,11 +6,14 @@
  */
 package io.jikkou.extension.aiven.api;
 
+import io.jikkou.http.client.proxy.ProxyConfig;
+
 public record AivenApiClientConfig(
     String apiUrl,
     String tokenAuth,
     String project,
     String service,
+    ProxyConfig proxyConfig,
     boolean debugLoggingEnabled
 ) {
 }

--- a/providers/jikkou-provider-aiven/src/main/java/io/jikkou/extension/aiven/api/AivenApiClientFactory.java
+++ b/providers/jikkou-provider-aiven/src/main/java/io/jikkou/extension/aiven/api/AivenApiClientFactory.java
@@ -34,6 +34,7 @@ public class AivenApiClientFactory {
                 .baseUri(baseUri);
 
         builder.header("Authorization", "Bearer " + config.tokenAuth());
+        builder.proxyConfig(config.proxyConfig());
         return new AivenApiClient(
                 builder.build(AivenApi.class),
                 config.project(),

--- a/providers/jikkou-provider-confluent/src/main/java/io/jikkou/extension/confluent/ConfluentCloudExtensionProvider.java
+++ b/providers/jikkou-provider-confluent/src/main/java/io/jikkou/extension/confluent/ConfluentCloudExtensionProvider.java
@@ -18,6 +18,7 @@ import io.jikkou.extension.confluent.collections.V1RoleBindingList;
 import io.jikkou.extension.confluent.models.V1RoleBinding;
 import io.jikkou.extension.confluent.reconciler.ConfluentCloudRoleBindingCollector;
 import io.jikkou.extension.confluent.reconciler.ConfluentCloudRoleBindingController;
+import io.jikkou.http.client.proxy.ProxyConfig;
 import io.jikkou.spi.BaseExtensionProvider;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
@@ -70,6 +71,7 @@ public final class ConfluentCloudExtensionProvider extends BaseExtensionProvider
             Config.API_KEY.get(configuration),
             Config.API_SECRET.get(configuration),
             Config.CRN_PATTERN.get(configuration),
+            ProxyConfig.from(configuration),
             Config.DEBUG_LOGGING_ENABLED.get(configuration)
         );
     }
@@ -84,6 +86,10 @@ public final class ConfluentCloudExtensionProvider extends BaseExtensionProvider
             Config.API_KEY,
             Config.API_SECRET,
             Config.CRN_PATTERN,
+            ProxyConfig.PROXY_URL,
+            ProxyConfig.PROXY_USERNAME,
+            ProxyConfig.PROXY_PASSWORD,
+            ProxyConfig.NON_PROXY_HOSTS,
             Config.DEBUG_LOGGING_ENABLED
         );
     }

--- a/providers/jikkou-provider-confluent/src/main/java/io/jikkou/extension/confluent/api/ConfluentCloudApiClientConfig.java
+++ b/providers/jikkou-provider-confluent/src/main/java/io/jikkou/extension/confluent/api/ConfluentCloudApiClientConfig.java
@@ -6,6 +6,8 @@
  */
 package io.jikkou.extension.confluent.api;
 
+import io.jikkou.http.client.proxy.ProxyConfig;
+
 /**
  * Configuration for the Confluent Cloud API client.
  *
@@ -13,6 +15,7 @@ package io.jikkou.extension.confluent.api;
  * @param apiKey               Cloud API key (used as HTTP Basic username).
  * @param apiSecret            Cloud API secret (used as HTTP Basic password).
  * @param crnPattern           CRN pattern used to scope role binding list operations.
+ * @param proxyConfig          HTTP proxy configuration.
  * @param debugLoggingEnabled  Whether to enable debug logging.
  */
 public record ConfluentCloudApiClientConfig(
@@ -20,6 +23,7 @@ public record ConfluentCloudApiClientConfig(
     String apiKey,
     String apiSecret,
     String crnPattern,
+    ProxyConfig proxyConfig,
     boolean debugLoggingEnabled
 ) {
 }

--- a/providers/jikkou-provider-confluent/src/main/java/io/jikkou/extension/confluent/api/ConfluentCloudApiClientFactory.java
+++ b/providers/jikkou-provider-confluent/src/main/java/io/jikkou/extension/confluent/api/ConfluentCloudApiClientFactory.java
@@ -41,6 +41,7 @@ public class ConfluentCloudApiClientFactory {
             .baseUri(baseUri);
 
         builder.header("Authorization", "Basic " + credentials);
+        builder.proxyConfig(config.proxyConfig());
         return new ConfluentCloudApiClient(
             builder.build(ConfluentCloudApi.class),
             config.crnPattern()

--- a/providers/jikkou-provider-kafka-connect/src/main/java/io/jikkou/kafka/connect/api/KafkaConnectApiFactory.java
+++ b/providers/jikkou-provider-kafka-connect/src/main/java/io/jikkou/kafka/connect/api/KafkaConnectApiFactory.java
@@ -57,6 +57,7 @@ public final class KafkaConnectApiFactory {
         // Apply SSL config (truststore, keystore, hostname verification) regardless of
         // auth method, so HTTPS endpoints with private CAs work for basicAuth/none too.
         builder.sslConfig(config.sslConfig().get());
+        builder.proxyConfig(config.proxyConfig().get());
 
         builder = switch (config.authMethod()) {
             case BASICAUTH -> {

--- a/providers/jikkou-provider-kafka-connect/src/main/java/io/jikkou/kafka/connect/api/KafkaConnectClientConfig.java
+++ b/providers/jikkou-provider-kafka-connect/src/main/java/io/jikkou/kafka/connect/api/KafkaConnectClientConfig.java
@@ -9,6 +9,7 @@ package io.jikkou.kafka.connect.api;
 import io.jikkou.common.utils.Enums;
 import io.jikkou.core.config.ConfigProperty;
 import io.jikkou.core.config.Configuration;
+import io.jikkou.http.client.proxy.ProxyConfig;
 import io.jikkou.http.client.ssl.SSLConfig;
 import java.util.function.Supplier;
 
@@ -19,6 +20,7 @@ public record KafkaConnectClientConfig(
     Supplier<String> basicAuthUser,
     Supplier<String> basicAuthPassword,
     Supplier<SSLConfig> sslConfig,
+    Supplier<ProxyConfig> proxyConfig,
     Boolean debugLoggingEnabled
 ) {
 
@@ -62,6 +64,7 @@ public record KafkaConnectClientConfig(
             () -> KAFKA_CONNECT_BASIC_AUTH_USERNAME.get(configuration),
             () -> KAFKA_CONNECT_BASIC_AUTH_PASSWORD.get(configuration),
             () -> SSLConfig.from(configuration),
+            () -> ProxyConfig.from(configuration),
             KAFKA_CONNECT_DEBUG_LOGGING_ENABLED.get(configuration)
         );
     }

--- a/providers/jikkou-provider-kafka-connect/src/test/java/io/jikkou/kafka/connect/api/KafkaConnectApiFactoryTest.java
+++ b/providers/jikkou-provider-kafka-connect/src/test/java/io/jikkou/kafka/connect/api/KafkaConnectApiFactoryTest.java
@@ -7,6 +7,7 @@
 package io.jikkou.kafka.connect.api;
 
 import io.jikkou.core.config.Configuration;
+import io.jikkou.http.client.proxy.ProxyConfig;
 import io.jikkou.http.client.ssl.SSLConfig;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -50,6 +51,7 @@ class KafkaConnectApiFactoryTest {
                 () -> "alice",
                 () -> "secret",
                 () -> SSLConfig.from(Configuration.empty()),
+                () -> ProxyConfig.from(Configuration.empty()),
                 false
         );
 

--- a/providers/jikkou-provider-schema-registry/src/main/java/io/jikkou/schema/registry/SchemaRegistryExtensionProvider.java
+++ b/providers/jikkou-provider-schema-registry/src/main/java/io/jikkou/schema/registry/SchemaRegistryExtensionProvider.java
@@ -15,6 +15,7 @@ import io.jikkou.core.extension.ExtensionRegistry;
 import io.jikkou.core.models.change.GenericResourceChange;
 import io.jikkou.core.models.change.ResourceChange;
 import io.jikkou.core.resource.ResourceRegistry;
+import io.jikkou.http.client.proxy.ProxyConfig;
 import io.jikkou.http.client.ssl.SSLConfig;
 import io.jikkou.schema.registry.api.AuthMethod;
 import io.jikkou.schema.registry.api.SchemaRegistryClientConfig;
@@ -117,6 +118,7 @@ public final class SchemaRegistryExtensionProvider extends BaseExtensionProvider
             () -> Config.SCHEMA_REGISTRY_BASIC_AUTH_USER.get(configuration),
             () -> Config.SCHEMA_REGISTRY_BASIC_AUTH_PASSWORD.get(configuration),
             () -> SSLConfig.from(configuration),
+            () -> ProxyConfig.from(configuration),
             Config.SCHEMA_REGISTRY_DEBUG_LOGGING_ENABLED.get(configuration)
         );
     }

--- a/providers/jikkou-provider-schema-registry/src/main/java/io/jikkou/schema/registry/api/SchemaRegistryApiFactory.java
+++ b/providers/jikkou-provider-schema-registry/src/main/java/io/jikkou/schema/registry/api/SchemaRegistryApiFactory.java
@@ -51,6 +51,7 @@ public final class SchemaRegistryApiFactory {
         // Apply SSL config (truststore, keystore, hostname verification) regardless of
         // auth method, so HTTPS endpoints with private CAs work for basicAuth/none too.
         builder.sslConfig(config.sslConfig().get());
+        builder.proxyConfig(config.proxyConfig().get());
 
         builder = switch (config.authMethod()) {
             case BASICAUTH -> {

--- a/providers/jikkou-provider-schema-registry/src/main/java/io/jikkou/schema/registry/api/SchemaRegistryClientConfig.java
+++ b/providers/jikkou-provider-schema-registry/src/main/java/io/jikkou/schema/registry/api/SchemaRegistryClientConfig.java
@@ -6,6 +6,7 @@
  */
 package io.jikkou.schema.registry.api;
 
+import io.jikkou.http.client.proxy.ProxyConfig;
 import io.jikkou.http.client.ssl.SSLConfig;
 import java.util.List;
 import java.util.function.Supplier;
@@ -17,6 +18,7 @@ public record SchemaRegistryClientConfig(
     Supplier<String> basicAuthUser,
     Supplier<String> basicAuthPassword,
     Supplier<SSLConfig> sslConfig,
+    Supplier<ProxyConfig> proxyConfig,
     Boolean debugLoggingEnabled
 ) {
 

--- a/providers/jikkou-provider-schema-registry/src/test/java/io/jikkou/schema/registry/api/SchemaRegistryApiFactoryTest.java
+++ b/providers/jikkou-provider-schema-registry/src/test/java/io/jikkou/schema/registry/api/SchemaRegistryApiFactoryTest.java
@@ -7,6 +7,7 @@
 package io.jikkou.schema.registry.api;
 
 import io.jikkou.core.config.Configuration;
+import io.jikkou.http.client.proxy.ProxyConfig;
 import io.jikkou.http.client.ssl.SSLConfig;
 import io.jikkou.schema.registry.mock.HttpPathBasedDispatcher;
 import java.io.IOException;
@@ -55,6 +56,7 @@ class SchemaRegistryApiFactoryTest {
                 () -> "username",
                 () -> "password",
                 () -> SSLConfig.from(Configuration.empty()),
+                () -> ProxyConfig.from(Configuration.empty()),
                 false
         );
 
@@ -101,6 +103,7 @@ class SchemaRegistryApiFactoryTest {
                 () -> null,
                 () -> null,
                 () -> SSLConfig.from(Configuration.empty()),
+                () -> ProxyConfig.from(Configuration.empty()),
                 false
         );
 
@@ -128,6 +131,7 @@ class SchemaRegistryApiFactoryTest {
                 () -> null,
                 () -> null,
                 () -> SSLConfig.from(Configuration.empty()),
+                () -> ProxyConfig.from(Configuration.empty()),
                 false
         );
 
@@ -149,6 +153,7 @@ class SchemaRegistryApiFactoryTest {
                 () -> null,
                 () -> null,
                 () -> SSLConfig.from(Configuration.empty()),
+                () -> ProxyConfig.from(Configuration.empty()),
                 false
         );
 
@@ -205,6 +210,7 @@ class SchemaRegistryApiFactoryTest {
                             SSLConfig.SSL_TRUST_STORE_PASSWORD.key(), "changeit",
                             SSLConfig.SSL_TRUST_STORE_TYPE.key(), "JKS"
                     ))),
+                    () -> ProxyConfig.from(Configuration.empty()),
                     false
             );
 


### PR DESCRIPTION
Add first-class HTTP proxy support to all REST-based providers (Kafka Connect, Schema Registry, Confluent Cloud, Aiven) through a shared ProxyConfig and a custom Apache HTTP engine in RestClientBuilder.

The default RESTEasy Apache engine ignores JVM proxy system properties, and the JVM never reads OS http_proxy/https_proxy environment variables, so neither workaround previously routed Jikkou's REST calls through a corporate proxy.

- Add ProxyConfig record (proxyUrl, proxyUsername, proxyPassword, nonProxyHosts) with ConfigProperty constants and from(Configuration).
- Install a custom ApacheHttpClient43Engine in RestClientBuilder only when a proxy is resolved, with explicit proxy host, scoped credentials for CONNECT-tunneled HTTPS auth, JVM-style nonProxyHosts wildcards, and a system-property fallback. Default path is unchanged.
- Wire proxy config through the four REST providers.
- Document proxy configuration for each provider.

Closes #773