### PR TITLE
test(kafka): use JVM apache/kafka image to fix flaky CI segfault

### DIFF
--- a/providers/jikkou-provider-kafka/src/integration-test/java/io/jikkou/kafka/AbstractKafkaIntegrationTest.java
+++ b/providers/jikkou-provider-kafka/src/integration-test/java/io/jikkou/kafka/AbstractKafkaIntegrationTest.java
@@ -40,8 +40,11 @@ public class AbstractKafkaIntegrationTest {
     public static final short DEFAULT_REPLICATION_FACTOR = (short) 1;
 
     @Container
+    // Uses the JVM-based 'apache/kafka' image rather than the experimental 'apache/kafka-native'
+    // one: the native image intermittently segfaults at startup (GraalVM getpwuid crash in the
+    // jvmstat perf-data thread), which made CI flaky after the upgrade to 4.3.0.
     final KafkaContainer kafka = new KafkaContainer(
-            DockerImageName.parse("apache/kafka-native").withTag(APACHE_KAFKA_VERSION))
+            DockerImageName.parse("apache/kafka").withTag(APACHE_KAFKA_VERSION))
             .withNetwork(KAFKA_NETWORK)
             .withEnv("KAFKA_TRANSACTION_STATE_LOG_MIN_ISR", "1")
             .withEnv("KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR", "1")


### PR DESCRIPTION
## Problem

CI on `main` is intermittently failing in `jikkou-provider-kafka` with:

```
TruncateKafkaTopicRecordsTest.shouldFailedTruncateTopicGivenUnknownTopic
  » ContainerLaunch Container startup failed for image apache/kafka-native:4.3.0
Caused by: Timed out waiting for log output matching '.*Transitioning from RECOVERY to RUNNING.*'
Caused by: Wait strategy failed. Container exited with code 1
```

The streamed broker logs show the container **segfaults at startup**:

```
[ SegfaultHandler caught a segfault ... ] si_signo: 11 (SIGSEGV)
  com.oracle.svm.core.posix.headers.Pwd.getpwuid(Pwd.java)
  com.oracle.svm.core.posix.PosixSystemPropertiesSupport.userNameValue(...)
  com.oracle.svm.core.jdk.SystemPropertiesSupport.userName(...)   // System.getProperty("user.name")
  com.oracle.svm.core.jvmstat.PerfManager$PerfDataThread.run(...)
Segfault detected, aborting process.
```

This is a GraalVM native-image crash in `getpwuid()` from the jvmstat perf-data thread while resolving `user.name`. It is **non-deterministic** — the same commit (`4c63fca08`) produced both passing and failing CI runs. The flakiness was introduced when the integration-test broker switched to the experimental `apache/kafka-native` image in the upgrade to Kafka 4.3.0.

## Fix

Switch the test broker from the experimental `apache/kafka-native` image to the JVM-based `apache/kafka` image. Same `KafkaContainer`, same env vars; trades a slightly slower container startup for a reliable boot with no native-image segfault.

## Verification

Ran the previously-failing class locally against the JVM image:

```
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0 -- in io.jikkou.kafka.action.TruncateKafkaTopicRecordsTest
```

Kafka 4.3.0 booted cleanly, no segfault.