### PR TITLE
chore: set development version to 1.1.0-SNAPSHOT

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.jikkou</groupId>
         <artifactId>jikkou-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.jikkou</groupId>
         <artifactId>jikkou-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/extension-rest-client/pom.xml
+++ b/extension-rest-client/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>io.jikkou</groupId>
         <artifactId>jikkou-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <groupId>io.jikkou</groupId>
     <artifactId>jikkou-parent</artifactId>
     <packaging>pom</packaging>
-    <version>1.1.0</version>
+    <version>1.1.0-SNAPSHOT</version>
     <modules>
         <module>resource-generator</module>
         <module>core</module>

--- a/processor/pom.xml
+++ b/processor/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.jikkou</groupId>
         <artifactId>jikkou-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <name>Jikkou Extension :: Annotation Processor</name>

--- a/providers/jikkou-provider-aiven/pom.xml
+++ b/providers/jikkou-provider-aiven/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.jikkou</groupId>
         <artifactId>jikkou-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/providers/jikkou-provider-aws/pom.xml
+++ b/providers/jikkou-provider-aws/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.jikkou</groupId>
         <artifactId>jikkou-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/providers/jikkou-provider-confluent/pom.xml
+++ b/providers/jikkou-provider-confluent/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.jikkou</groupId>
         <artifactId>jikkou-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/providers/jikkou-provider-core/pom.xml
+++ b/providers/jikkou-provider-core/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.jikkou</groupId>
         <artifactId>jikkou-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/providers/jikkou-provider-iceberg/pom.xml
+++ b/providers/jikkou-provider-iceberg/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.jikkou</groupId>
         <artifactId>jikkou-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/providers/jikkou-provider-kafka-connect/pom.xml
+++ b/providers/jikkou-provider-kafka-connect/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.jikkou</groupId>
         <artifactId>jikkou-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/providers/jikkou-provider-kafka/pom.xml
+++ b/providers/jikkou-provider-kafka/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>io.jikkou</groupId>
         <artifactId>jikkou-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/providers/jikkou-provider-schema-registry/pom.xml
+++ b/providers/jikkou-provider-schema-registry/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.jikkou</groupId>
         <artifactId>jikkou-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/resource-generator/pom.xml
+++ b/resource-generator/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>io.jikkou</groupId>
         <artifactId>jikkou-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/server/jikkou-api-client/pom.xml
+++ b/server/jikkou-api-client/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.jikkou</groupId>
         <artifactId>jikkou-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/server/jikkou-api-data/pom.xml
+++ b/server/jikkou-api-data/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.jikkou</groupId>
         <artifactId>jikkou-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/server/jikkou-api-server/pom.xml
+++ b/server/jikkou-api-server/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.jikkou</groupId>
         <artifactId>jikkou-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/template-jinja/pom.xml
+++ b/template-jinja/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.jikkou</groupId>
         <artifactId>jikkou-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
## Summary

Restores the development version on `main` to `1.1.0-SNAPSHOT`. It was left at the released `1.1.0` after cutting the release.

## Why

The **Early Access** workflow failed during JReleaser config validation:

\`\`\`
[ERROR] distributions.jikkou.sdkman.consumerKey must not be blank.
[ERROR] distributions.jikkou.sdkman.consumerToken must not be blank.
[ERROR] JReleaser has not been properly configured.
\`\`\`

The SDKMAN distribution is configured with \`<active>RELEASE</active>\`, which activates SDKMAN only for **non-snapshot** versions. While \`main\` was a \`-SNAPSHOT\`, SDKMAN stayed inactive and its credentials were never validated. Bumping the version to the released \`1.1.0\` activated SDKMAN, and the early-access workflow does not provide the SDKMAN consumer key/token (only \`release.yml\` does) — so validation failed.

Restoring \`1.1.0-SNAPSHOT\` keeps SDKMAN inactive for early-access builds and matches prior behavior.

## Changes

- Set version to \`1.1.0-SNAPSHOT\` across the parent pom and all 17 child module poms (via \`versions:set\`).

## Test plan

- [x] \`versions:set\` applied cleanly; no \`1.1.0\` release references remain in any pom
- [ ] Early Access workflow runs green on this branch / after merge