### PR TITLE
feat(kafka): support Kafka 4.x share groups and declarative group configs

### DIFF
--- a/docs/content/en/docs/Providers/Kafka/Actions/KafkaShareGroupsResetOffsets.md
+++ b/docs/content/en/docs/Providers/Kafka/Actions/KafkaShareGroupsResetOffsets.md
@@ -1,0 +1,57 @@
+---
+categories: [ ]
+tags: [ "feature", "actions" ]
+title: "KafkaShareGroupsResetOffsets"
+linkTitle: "KafkaShareGroupsResetOffsets"
+weight: 20
+description: >
+  Learn how to reset the offsets of Kafka Share Groups.
+---
+
+{{% pageinfo color="info" %}}
+This section describes the `KafkaShareGroupsResetOffsets` action, used to reset the
+Share-Partition Start Offset (SPSO) of one or more Kafka share groups.
+{{% /pageinfo %}}
+
+{{% alert title="Broker requirement" color="warning" %}}
+Requires a Kafka **4.x** cluster with share groups enabled (`group.share.enable=true`).
+{{% /alert %}}
+
+## Usage
+
+You must choose one of the following reset specifications: `to-earliest`, `to-latest`, `to-offset`,
+or `delete-offsets`.
+
+| Option            | Description                                                                          |
+|-------------------|--------------------------------------------------------------------------------------|
+| `--group`         | The share group to act on.                                                           |
+| `--groups`        | The share groups to act on.                                                          |
+| `--all`           | Act on all share groups.                                                             |
+| `--topic`         | Topics to include. Each entry is `topic` (all partitions) or `topic:partition`.      |
+| `--to-earliest`   | Reset offsets to the earliest offset.                                                |
+| `--to-latest`     | Reset offsets to the latest offset.                                                  |
+| `--to-offset`     | Reset offsets to a specific offset.                                                  |
+| `--delete-offsets`| Delete the share-partition offsets for the given topics.                             |
+| `--includes`      | Patterns of share groups to include.                                                 |
+| `--excludes`      | Patterns of share groups to exclude.                                                 |
+| `--dry-run`       | Only show results without executing changes.                                         |
+
+## Examples
+
+Reset a single share group to the earliest offset for a topic:
+
+```bash
+$ jikkou action KafkaShareGroupsResetOffsets execute \
+    --group my-share-group \
+    --topic my-topic \
+    --to-earliest
+```
+
+Delete the share-partition offsets for a topic:
+
+```bash
+$ jikkou action KafkaShareGroupsResetOffsets execute \
+    --group my-share-group \
+    --topic my-topic \
+    --delete-offsets
+```

--- a/docs/content/en/docs/Providers/Kafka/Resources/consumer_groups.md
+++ b/docs/content/en/docs/Providers/Kafka/Resources/consumer_groups.md
@@ -96,3 +96,22 @@ status:
     host: "localhost"
     port: 9092
 ```
+
+## Managing consumer group configuration
+
+Since Kafka 4.x, consumer groups support dynamic group-level configuration. You can manage these
+declaratively through the `spec.configs` map, which is reconciled against the Kafka `GROUP`
+configuration resource (drift detection + incremental alter), just like topic configs.
+
+```yaml
+apiVersion: "kafka.jikkou.io/v1"
+kind: "KafkaConsumerGroup"
+metadata:
+  name: "my-group"
+spec:
+  configs:
+    consumer.session.timeout.ms: 50000
+```
+
+By default, group configs present on the cluster but absent from the resource are removed
+(`config-delete-orphans=true`). Set it to `false` to leave externally-managed configs untouched.

--- a/docs/content/en/docs/Providers/Kafka/Resources/share_groups.md
+++ b/docs/content/en/docs/Providers/Kafka/Resources/share_groups.md
@@ -1,0 +1,100 @@
+---
+categories: [ ]
+tags: [ "feature", "resources" ]
+title: "Kafka Share Groups"
+linkTitle: "Share Groups"
+weight: 11
+description: >
+  Learn how to manage Kafka Share Groups (Queues).
+---
+
+{{% pageinfo color="info" %}}
+This section describes the resource definition format for `KafkaShareGroup` entities, which can be used to
+manage the share groups (Queues, [KIP-932](https://cwiki.apache.org/confluence/display/KAFKA/KIP-932%3A+Queues+for+Kafka))
+of a specific Kafka cluster.
+{{% /pageinfo %}}
+
+{{% alert title="Broker requirement" color="warning" %}}
+Share groups require a Kafka **4.x** cluster with share groups enabled on the brokers
+(`group.share.enable=true` and the `share.version` feature). On older clusters the share group
+operations are not available.
+{{% /alert %}}
+
+## Listing `KafkaShareGroup`
+
+You can retrieve the state of Kafka Share Groups using the `jikkou get kafkasharegroups` (or `jikkou get ksg`) command.
+
+### Examples
+
+(command)
+
+```bash
+$ jikkou get kafkasharegroups --in-states STABLE --offsets
+```
+
+(output)
+
+```yaml
+---
+apiVersion: "kafka.jikkou.io/v1"
+kind: "KafkaShareGroup"
+metadata:
+  name: "my-share-group"
+spec:
+  configs:
+    share.auto.offset.reset: "earliest"
+status:
+  state: "STABLE"
+  members:
+    - memberId: "share-consumer-b103994e-bcd5-4236-9d03-97065057e594"
+      clientId: "share-consumer"
+      host: "/127.0.0.1"
+      rackId: "rack-1"
+      assignments:
+        - "my-topic-0"
+  offsets:
+    - topic: "my-topic"
+      partition: 0
+      offset: 0
+  coordinator:
+    id: "101"
+    host: "localhost"
+    port: 9092
+```
+
+## Managing share group configuration
+
+The `spec.configs` map lets you declaratively manage the dynamic group configuration of a share group
+(e.g. `share.auto.offset.reset`, `share.record.lock.duration.ms`, `share.isolation.level`). These are applied
+against the Kafka `GROUP` configuration resource and are reconciled like topic configs (drift detection +
+incremental alter).
+
+```yaml
+apiVersion: "kafka.jikkou.io/v1"
+kind: "KafkaShareGroup"
+metadata:
+  name: "orders-queue"
+spec:
+  configs:
+    share.record.lock.duration.ms: 30000
+    share.auto.offset.reset: "earliest"
+```
+
+Apply it with:
+
+```bash
+$ jikkou apply --files orders-queue.yaml
+```
+
+By default, group configs present on the cluster but absent from the resource are removed
+(`config-delete-orphans=true`). Set it to `false` to leave externally-managed configs untouched.
+
+## Deleting `KafkaShareGroup`
+
+A share group can be deleted by reconciling a resource flagged for deletion (`jikkou delete`),
+which removes the group via the AdminClient `deleteShareGroups` API.
+
+## Resetting share group offsets
+
+See the [`KafkaShareGroupsResetOffsets`]({{< relref "../Actions/KafkaShareGroupsResetOffsets.md" >}}) action
+to reset the Share-Partition Start Offset (SPSO) of one or more share groups.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -45,7 +45,10 @@ e2e/
 │   ├── schema-avro.yaml         # AVRO schema (v1)
 │   ├── schema-avro-v2.yaml      # AVRO schema (v2, adds field)
 │   ├── kafka-connector.yaml     # FileStreamSink connector
-│   └── kafka-connector-update.yaml # Updated connector config
+│   ├── kafka-connector-update.yaml # Updated connector config
+│   ├── kafka-share-group.yaml          # Share group (Queue) with dynamic configs
+│   ├── kafka-share-group-update.yaml   # Updated share group configs
+│   └── kafka-consumer-group-configs.yaml # Consumer group with dynamic configs
 └── README.md
 ```
 
@@ -113,11 +116,14 @@ Tests run sequentially in the order listed, so place tests that depend on prior 
 
 The Docker Compose file starts three services with health checks:
 
-| Service         | Image                                   | Port | Purpose              |
-|-----------------|-----------------------------------------|------|----------------------|
-| Kafka (KRaft)   | `confluentinc/cp-kafka:7.5.0`           | 9092 | Topics, ACLs, Quotas |
-| Schema Registry | `confluentinc/cp-schema-registry:7.5.0` | 8081 | AVRO/JSON schemas    |
-| Kafka Connect   | `confluentinc/cp-kafka-connect:7.5.0`   | 8083 | Connectors           |
+| Service         | Image                                   | Port | Purpose                            |
+|-----------------|-----------------------------------------|------|------------------------------------|
+| Kafka (KRaft)   | `confluentinc/cp-kafka:8.2.0`           | 9092 | Topics, ACLs, Quotas, Share Groups |
+| Schema Registry | `confluentinc/cp-schema-registry:8.2.0` | 8081 | AVRO/JSON schemas                  |
+| Kafka Connect   | `confluentinc/cp-kafka-connect:8.2.0`   | 8083 | Connectors                         |
+
+The Kafka broker runs Apache Kafka 4.x (Confluent 8.2.0) with **share groups enabled**
+(`group.share.enable=true`), required by the `KafkaShareGroup` and group-config tests.
 
 The test script waits up to 180 seconds for all services to report healthy before running tests.
 

--- a/e2e/docker-compose-e2e.yml
+++ b/e2e/docker-compose-e2e.yml
@@ -8,7 +8,7 @@
 # Minimal setup: Kafka (KRaft), Schema Registry, Kafka Connect.
 services:
   kafka:
-    image: "confluentinc/cp-kafka:7.5.0"
+    image: "confluentinc/cp-kafka:8.2.0"
     ports:
       - "9092:9092"
     container_name: e2e-kafka
@@ -27,6 +27,11 @@ services:
       KAFKA_AUTHORIZER_CLASS_NAME: org.apache.kafka.metadata.authorizer.StandardAuthorizer
       KAFKA_ALLOW_EVERYONE_IF_NO_ACL_FOUND: 'true'
       KAFKA_SUPER_USERS: 'User:anonymous'
+      # Enable share groups / Queues (KIP-932) for e2e coverage of KafkaShareGroup.
+      KAFKA_GROUP_COORDINATOR_REBALANCE_PROTOCOLS: 'classic,consumer,share'
+      KAFKA_GROUP_SHARE_ENABLE: 'true'
+      KAFKA_SHARE_COORDINATOR_STATE_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_SHARE_COORDINATOR_STATE_TOPIC_MIN_ISR: 1
     healthcheck:
       test: ["CMD", "kafka-broker-api-versions", "--bootstrap-server", "localhost:9092"]
       interval: 10s
@@ -36,7 +41,7 @@ services:
       - e2e-network
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.5.0
+    image: confluentinc/cp-schema-registry:8.2.0
     hostname: schema-registry
     container_name: e2e-schema-registry
     ports:
@@ -57,7 +62,7 @@ services:
       - e2e-network
 
   connect:
-    image: confluentinc/cp-kafka-connect:7.5.0
+    image: confluentinc/cp-kafka-connect:8.2.0
     container_name: e2e-connect
     depends_on:
       kafka:

--- a/e2e/resources/kafka-consumer-group-configs.yaml
+++ b/e2e/resources/kafka-consumer-group-configs.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: "kafka.jikkou.io/v1"
+kind: "KafkaConsumerGroup"
+metadata:
+  name: 'e2e-consumer-group'
+spec:
+  configs:
+    consumer.session.timeout.ms: 50000

--- a/e2e/resources/kafka-share-group-update.yaml
+++ b/e2e/resources/kafka-share-group-update.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: "kafka.jikkou.io/v1"
+kind: "KafkaShareGroup"
+metadata:
+  name: 'e2e-share-queue'
+spec:
+  configs:
+    share.auto.offset.reset: 'latest'
+    share.record.lock.duration.ms: 45000

--- a/e2e/resources/kafka-share-group.yaml
+++ b/e2e/resources/kafka-share-group.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: "kafka.jikkou.io/v1"
+kind: "KafkaShareGroup"
+metadata:
+  name: 'e2e-share-queue'
+spec:
+  configs:
+    share.auto.offset.reset: 'earliest'
+    share.record.lock.duration.ms: 30000

--- a/e2e/run-tests.sh
+++ b/e2e/run-tests.sh
@@ -487,6 +487,39 @@ EOF
   assert_output_not_contains "e2e-client" || return 1
 }
 
+# ── Kafka Share Groups & Group Configs (Kafka 4.x) ──────────────────────────
+# Requires a Kafka 4.x broker with share groups enabled (group.share.enable=true).
+
+test_kafka_share_group_configs_apply() {
+  run_jikkou_capture apply --files "${E2E_RESOURCES}/kafka-share-group.yaml"
+  assert_exit_code 0 || return 1
+
+  # The new resource type must be queryable.
+  run_jikkou_capture get kafkasharegroups
+  assert_exit_code 0 || return 1
+
+  # Re-applying is idempotent (no error, configs already in desired state).
+  run_jikkou_capture apply --files "${E2E_RESOURCES}/kafka-share-group.yaml"
+  assert_exit_code 0 || return 1
+}
+
+test_kafka_share_group_configs_update() {
+  run_jikkou_capture apply --files "${E2E_RESOURCES}/kafka-share-group-update.yaml"
+  assert_exit_code 0 || return 1
+
+  # A diff against the updated desired state must report no pending change.
+  run_jikkou_capture diff --files "${E2E_RESOURCES}/kafka-share-group-update.yaml"
+  assert_exit_code 0 || return 1
+}
+
+test_kafka_consumer_group_configs_apply() {
+  run_jikkou_capture apply --files "${E2E_RESOURCES}/kafka-consumer-group-configs.yaml"
+  assert_exit_code 0 || return 1
+
+  run_jikkou_capture get kafkaconsumergroups
+  assert_exit_code 0 || return 1
+}
+
 # ── Schema Registry (full CRUD) ─────────────────────────────────────────────
 
 test_schema_registry_create() {
@@ -721,6 +754,11 @@ main() {
   run_test "Kafka Quotas: read"             test_kafka_quotas_read
   run_test "Kafka Quotas: update"           test_kafka_quotas_update
   run_test "Kafka Quotas: delete"           test_kafka_quotas_delete
+
+  # ── Kafka Share Groups & Group Configs (Kafka 4.x) ──
+  run_test "Kafka Share Group: apply configs"    test_kafka_share_group_configs_apply
+  run_test "Kafka Share Group: update configs"   test_kafka_share_group_configs_update
+  run_test "Kafka Consumer Group: apply configs" test_kafka_consumer_group_configs_apply
 
   # ── Schema Registry CRUD ──
   run_test "Schema Registry: create"        test_schema_registry_create

--- a/providers/jikkou-provider-kafka/src/integration-test/java/io/jikkou/kafka/reconciler/AdminClientShareGroupIT.java
+++ b/providers/jikkou-provider-kafka/src/integration-test/java/io/jikkou/kafka/reconciler/AdminClientShareGroupIT.java
@@ -1,0 +1,192 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.jikkou.kafka.reconciler;
+
+import io.jikkou.core.CoreExtensionProvider;
+import io.jikkou.core.JikkouApi;
+import io.jikkou.core.ReconciliationContext;
+import io.jikkou.core.ReconciliationMode;
+import io.jikkou.core.config.Configuration;
+import io.jikkou.core.models.ApiChangeResultList;
+import io.jikkou.core.models.Configs;
+import io.jikkou.core.models.ObjectMeta;
+import io.jikkou.core.models.ResourceList;
+import io.jikkou.kafka.KafkaExtensionProvider;
+import io.jikkou.kafka.collections.V1KafkaShareGroupList;
+import io.jikkou.kafka.models.V1KafkaConsumerGroup;
+import io.jikkou.kafka.models.V1KafkaConsumerGroupSpec;
+import io.jikkou.kafka.models.V1KafkaShareGroup;
+import io.jikkou.kafka.models.V1KafkaShareGroupSpec;
+import io.jikkou.kafka.reconciler.service.KafkaAdminService;
+import io.jikkou.runtime.JikkouContext;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AlterConfigOp;
+import org.apache.kafka.clients.admin.Config;
+import org.apache.kafka.clients.admin.ConfigEntry;
+import org.apache.kafka.common.GroupState;
+import org.apache.kafka.common.config.ConfigResource;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.kafka.KafkaContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Integration tests for share group support against a real broker.
+ * <p>
+ * Share groups (KIP-932) require the broker to be started with {@code group.share.enable=true}
+ * and the {@code share} rebalance protocol enabled. This test starts its own broker with those
+ * settings, and is gated behind the {@code it.kafka.shareGroups} system property so the default
+ * CI build (which uses a broker without share-group support) is not broken.
+ * <p>
+ * Run with: {@code ./mvnw failsafe:integration-test -pl providers/jikkou-provider-kafka
+ * -Dit.test=AdminClientShareGroupIT -Dit.kafka.shareGroups=true}
+ */
+@Testcontainers
+@Tag("integration")
+@EnabledIfSystemProperty(named = "it.kafka.shareGroups", matches = "true")
+public class AdminClientShareGroupIT {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AdminClientShareGroupIT.class);
+
+    private static final String APACHE_KAFKA_VERSION = "4.3.0";
+
+    @Container
+    final KafkaContainer kafka = new KafkaContainer(
+        DockerImageName.parse("apache/kafka").withTag(APACHE_KAFKA_VERSION))
+        .withEnv("KAFKA_TRANSACTION_STATE_LOG_MIN_ISR", "1")
+        .withEnv("KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR", "1")
+        .withEnv("KAFKA_GROUP_COORDINATOR_REBALANCE_PROTOCOLS", "classic,consumer,share")
+        .withEnv("KAFKA_GROUP_SHARE_ENABLE", "true")
+        .withEnv("KAFKA_SHARE_COORDINATOR_STATE_TOPIC_REPLICATION_FACTOR", "1")
+        .withEnv("KAFKA_SHARE_COORDINATOR_STATE_TOPIC_MIN_ISR", "1")
+        .withLogConsumer(new Slf4jLogConsumer(LOG));
+
+    private JikkouApi api;
+
+    @BeforeEach
+    public void initApi() {
+        Map<String, Object> clientConfig = Map.of(
+            CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, kafka.getBootstrapServers());
+        api = JikkouContext.defaultContext()
+            .newApiBuilder()
+            .register(new CoreExtensionProvider())
+            .register(new KafkaExtensionProvider(), Configuration.of("client", clientConfig))
+            .build()
+            .enableBuiltInAnnotations(false);
+    }
+
+    private AdminClient adminClient() {
+        return AdminClient.create(Map.of(
+            CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, kafka.getBootstrapServers()));
+    }
+
+    private String readGroupConfig(String groupId, String key) throws Exception {
+        try (AdminClient client = adminClient()) {
+            ConfigResource resource = new ConfigResource(ConfigResource.Type.GROUP, groupId);
+            Config config = client.describeConfigs(List.of(resource)).all().get().get(resource);
+            return config.get(key) == null ? null : config.get(key).value();
+        }
+    }
+
+    @Test
+    public void shouldReadDynamicGroupConfigsFilteringDefaults() throws Exception {
+        String groupId = "it-share-group-configs";
+        try (AdminClient client = adminClient()) {
+            // GIVEN a dynamic group config set on the GROUP resource
+            ConfigResource resource = new ConfigResource(ConfigResource.Type.GROUP, groupId);
+            client.incrementalAlterConfigs(Map.of(resource, List.of(
+                new AlterConfigOp(new ConfigEntry("share.auto.offset.reset", "earliest"),
+                    AlterConfigOp.OpType.SET)))).all().get();
+
+            // WHEN reading the configs through our service
+            KafkaAdminService service = new KafkaAdminService(client);
+            Map<String, Configs> configs = service.describeGroupConfigs(List.of(groupId));
+
+            // THEN only the user-set DYNAMIC_GROUP_CONFIG entry is returned
+            Configs groupConfigs = configs.get(groupId);
+            Assertions.assertNotNull(groupConfigs, "expected configs for group " + groupId);
+            Assertions.assertEquals("earliest",
+                String.valueOf(groupConfigs.get("share.auto.offset.reset").value()));
+            // Broker defaults must be filtered out (only the single dynamic entry remains).
+            Assertions.assertEquals(1, groupConfigs.size(),
+                "expected only DYNAMIC_GROUP_CONFIG entries, got: " + groupConfigs);
+        }
+    }
+
+    @Test
+    public void shouldListShareGroupsWithoutError() {
+        try (AdminClient client = adminClient()) {
+            KafkaAdminService service = new KafkaAdminService(client);
+            // No active share consumers, so the listing is expected to be empty but must not error.
+            V1KafkaShareGroupList list = service.listShareGroups(Set.<GroupState>of(), false);
+            Assertions.assertNotNull(list);
+            Assertions.assertNotNull(list.getItems());
+        }
+    }
+
+    @Test
+    public void shouldReconcileShareGroupConfigsThroughApi() throws Exception {
+        // Regression for: "Cannot find controller for resource type: kind='KafkaShareGroupChange'".
+        String groupId = "it-reconcile-share-group";
+        V1KafkaShareGroup group = V1KafkaShareGroup.builder()
+            .withApiVersion("kafka.jikkou.io/v1")
+            .withKind("KafkaShareGroup")
+            .withMetadata(ObjectMeta.builder().withName(groupId).build())
+            .withSpec(V1KafkaShareGroupSpec.builder()
+                .withConfigs(Configs.of("share.auto.offset.reset", "earliest"))
+                .build())
+            .build();
+
+        ReconciliationContext context = ReconciliationContext.builder().dryRun(false).build();
+
+        ApiChangeResultList first = api.reconcile(
+            ResourceList.of(group), ReconciliationMode.FULL, context);
+        Assertions.assertFalse(first.results().isEmpty(), "expected a change result");
+        Assertions.assertEquals("earliest", readGroupConfig(groupId, "share.auto.offset.reset"));
+
+        // Idempotent: re-reconciling reports no change (drift detection via describeGroupConfigs).
+        ApiChangeResultList second = api.reconcile(
+            ResourceList.of(group), ReconciliationMode.FULL, context);
+        Assertions.assertTrue(second.results().stream().noneMatch(r -> r.isChanged()),
+            "expected no change on second reconciliation");
+    }
+
+    @Test
+    public void shouldReconcileConsumerGroupConfigsForNonExistentGroup() throws Exception {
+        // Regression for GroupIdNotFoundException when planning configs for a group that does
+        // not exist yet on a Kafka 4.x broker.
+        String groupId = "it-reconcile-consumer-group";
+        V1KafkaConsumerGroup group = V1KafkaConsumerGroup.builder()
+            .withApiVersion("kafka.jikkou.io/v1")
+            .withKind("KafkaConsumerGroup")
+            .withMetadata(ObjectMeta.builder().withName(groupId).build())
+            .withSpec(V1KafkaConsumerGroupSpec.builder()
+                // Must be within [group.consumer.min/max.session.timeout.ms] (default 45000..60000).
+                .withConfigs(Configs.of("consumer.session.timeout.ms", "50000"))
+                .build())
+            .build();
+
+        ReconciliationContext context = ReconciliationContext.builder().dryRun(false).build();
+
+        ApiChangeResultList result = api.reconcile(
+            ResourceList.of(group), ReconciliationMode.FULL, context);
+        Assertions.assertFalse(result.results().isEmpty(), "expected a change result");
+        Assertions.assertEquals("50000", readGroupConfig(groupId, "consumer.session.timeout.ms"));
+    }
+}

--- a/providers/jikkou-provider-kafka/src/main/java/io/jikkou/kafka/KafkaExtensionProvider.java
+++ b/providers/jikkou-provider-kafka/src/main/java/io/jikkou/kafka/KafkaExtensionProvider.java
@@ -14,6 +14,7 @@ import io.jikkou.core.models.change.GenericResourceChange;
 import io.jikkou.core.models.change.ResourceChange;
 import io.jikkou.core.resource.ResourceRegistry;
 import io.jikkou.kafka.action.KafkaConsumerGroupsResetOffsets;
+import io.jikkou.kafka.action.KafkaShareGroupsResetOffsets;
 import io.jikkou.kafka.action.TruncateKafkaTopicRecords;
 import io.jikkou.kafka.collections.V1KafkaBrokerList;
 import io.jikkou.kafka.collections.V1KafkaClientQuotaList;
@@ -149,6 +150,7 @@ public final class KafkaExtensionProvider extends BaseExtensionProvider {
         registry.register(AdminClientKafkaTopicController.class, AdminClientKafkaTopicController::new);
         registry.register(AdminClientKafkaQuotaController.class, AdminClientKafkaQuotaController::new);
         registry.register(AdminClientConsumerGroupController.class, AdminClientConsumerGroupController::new);
+        registry.register(AdminClientShareGroupController.class, AdminClientShareGroupController::new);
         registry.register(AdminClientKafkaUserController.class, AdminClientKafkaUserController::new);
 
         // collectors
@@ -159,6 +161,7 @@ public final class KafkaExtensionProvider extends BaseExtensionProvider {
         registry.register(AdminClientKafkaTableCollector.class, AdminClientKafkaTableCollector::new);
         registry.register(AdminClientKafkaTableController.class, AdminClientKafkaTableController::new);
         registry.register(AdminClientConsumerGroupCollector.class, AdminClientConsumerGroupCollector::new);
+        registry.register(AdminClientShareGroupCollector.class, AdminClientShareGroupCollector::new);
         registry.register(AdminClientKafkaUserCollector.class, AdminClientKafkaUserCollector::new);
 
         // transformations
@@ -189,6 +192,7 @@ public final class KafkaExtensionProvider extends BaseExtensionProvider {
 
         // actions
         registry.register(KafkaConsumerGroupsResetOffsets.class, KafkaConsumerGroupsResetOffsets::new);
+        registry.register(KafkaShareGroupsResetOffsets.class, KafkaShareGroupsResetOffsets::new);
         registry.register(TruncateKafkaTopicRecords.class, TruncateKafkaTopicRecords::new);
     }
 
@@ -215,6 +219,7 @@ public final class KafkaExtensionProvider extends BaseExtensionProvider {
         registerWithOrder(registry, V1KafkaClientQuota.class, 150);
         registerWithOrder(registry, V1KafkaPrincipalAuthorization.class, 200);
         registerWithOrder(registry, V1KafkaConsumerGroup.class, 250);
+        registerWithOrder(registry, V1KafkaShareGroup.class, 250);
         registerWithOrder(registry, V1KafkaTableRecord.class, 300);
 
         // register collections

--- a/providers/jikkou-provider-kafka/src/main/java/io/jikkou/kafka/action/KafkaShareGroupsResetOffsets.java
+++ b/providers/jikkou-provider-kafka/src/main/java/io/jikkou/kafka/action/KafkaShareGroupsResetOffsets.java
@@ -1,0 +1,173 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.jikkou.kafka.action;
+
+import io.jikkou.core.action.Action;
+import io.jikkou.core.action.ExecutionError;
+import io.jikkou.core.action.ExecutionResult;
+import io.jikkou.core.action.ExecutionResultSet;
+import io.jikkou.core.action.ExecutionStatus;
+import io.jikkou.core.annotation.Description;
+import io.jikkou.core.annotation.Named;
+import io.jikkou.core.annotation.SupportedResource;
+import io.jikkou.core.annotation.Title;
+import io.jikkou.core.config.ConfigProperty;
+import io.jikkou.core.config.Configuration;
+import io.jikkou.core.extension.ContextualExtension;
+import io.jikkou.core.extension.ExtensionContext;
+import io.jikkou.kafka.KafkaExtensionProvider;
+import io.jikkou.kafka.internals.admin.AdminClientFactory;
+import io.jikkou.kafka.models.V1KafkaShareGroup;
+import io.jikkou.kafka.reconciler.service.KafkaAdminService;
+import io.jikkou.kafka.reconciler.service.KafkaOffsetSpec;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.common.GroupState;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Named("KafkaShareGroupsResetOffsets")
+@Title("Reset offsets of share groups.")
+@Description("""
+    Reset the Share-Partition Start Offset (SPSO) of share groups. Supports multiple share groups.
+    Choose one of: to-earliest, to-latest, to-offset, or delete-offsets.
+    """)
+@SupportedResource(type = V1KafkaShareGroup.class)
+public final class KafkaShareGroupsResetOffsets extends ContextualExtension implements Action<V1KafkaShareGroup> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaShareGroupsResetOffsets.class);
+
+    interface Config {
+        ConfigProperty<Boolean> TO_EARLIEST = ConfigProperty.ofBoolean("to-earliest")
+            .displayName("To Earliest").description("Reset offsets to earliest offset.");
+        ConfigProperty<Boolean> TO_LATEST = ConfigProperty.ofBoolean("to-latest")
+            .displayName("To Latest").description("Reset offsets to latest offset.");
+        ConfigProperty<Long> TO_OFFSET = ConfigProperty.ofLong("to-offset")
+            .displayName("To Offset").description("Reset offsets to a specific offset.");
+        ConfigProperty<Boolean> DELETE_OFFSETS = ConfigProperty.ofBoolean("delete-offsets")
+            .displayName("Delete Offsets").description("Delete the share-partition offsets for the given topics.");
+        ConfigProperty<Boolean> ALL = ConfigProperty.ofBoolean("all")
+            .displayName("All Groups").description("Act on all share groups.");
+        ConfigProperty<String> GROUP = ConfigProperty.ofString("group")
+            .displayName("Group").description("The share group to act on.");
+        ConfigProperty<List<String>> GROUPS = ConfigProperty.ofList("groups")
+            .displayName("Groups").description("The share groups to act on.");
+        ConfigProperty<List<String>> TOPIC = ConfigProperty.ofList("topic")
+            .displayName("Topic").description("Topics to include. Each entry is 'topic' or 'topic:partition'.");
+        ConfigProperty<List<String>> INCLUDES = ConfigProperty.ofList("includes")
+            .displayName("Includes").description("Patterns of share groups to include.");
+        ConfigProperty<List<String>> EXCLUDES = ConfigProperty.ofList("excludes")
+            .displayName("Excludes").description("Patterns of share groups to exclude.");
+        ConfigProperty<Boolean> DRY_RUN = ConfigProperty.ofBoolean("dry-run")
+            .displayName("Dry Run").description("Only show results without executing changes.").defaultValue(false);
+    }
+
+    private AdminClientFactory adminClientFactory;
+
+    /**
+     * Creates a new {@link KafkaShareGroupsResetOffsets} instance.
+     * CLI requires any empty constructor.
+     */
+    public KafkaShareGroupsResetOffsets() {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void init(@NotNull ExtensionContext context) {
+        super.init(context);
+        this.adminClientFactory = context.<KafkaExtensionProvider>provider().newAdminClientFactory();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public @NotNull ExecutionResultSet<V1KafkaShareGroup> execute(@NotNull Configuration configuration) {
+        try (AdminClient client = adminClientFactory.createAdminClient()) {
+            KafkaAdminService service = new KafkaAdminService(client);
+
+            boolean deleteOffsets = Config.DELETE_OFFSETS.getOptional(configuration).orElse(false);
+            KafkaOffsetSpec offsetSpec = null;
+            offsetSpec = Config.TO_EARLIEST.getOptional(configuration)
+                .map(u -> (KafkaOffsetSpec) new KafkaOffsetSpec.ToEarliest()).orElse(offsetSpec);
+            offsetSpec = Config.TO_LATEST.getOptional(configuration)
+                .map(u -> (KafkaOffsetSpec) new KafkaOffsetSpec.ToLatest()).orElse(offsetSpec);
+            offsetSpec = Config.TO_OFFSET.getOptional(configuration)
+                .map(o -> (KafkaOffsetSpec) new KafkaOffsetSpec.ToOffset(o)).orElse(offsetSpec);
+
+            if (offsetSpec == null && !deleteOffsets) {
+                return ExecutionResultSet.<V1KafkaShareGroup>newBuilder()
+                    .result(ExecutionResult.<V1KafkaShareGroup>newBuilder()
+                        .status(ExecutionStatus.FAILED)
+                        .errors(List.of(new ExecutionError(
+                            "No reset specification. Expected one of: [to-earliest, to-latest, to-offset, delete-offsets].")))
+                        .build())
+                    .build();
+            }
+
+            Stream<String> group = Config.GROUP.getOptional(configuration).stream();
+            Stream<String> groups = Config.GROUPS.getOptional(configuration).stream().flatMap(Collection::stream);
+            Stream<String> all = Config.ALL.getOptional(configuration).orElse(false)
+                ? service.listShareGroups(Set.<GroupState>of(), false).stream().map(it -> it.getMetadata().getName())
+                : Stream.empty();
+
+            List<Pattern> includes = Config.INCLUDES.getOptional(configuration).stream()
+                .flatMap(Collection::stream).map(Pattern::compile).toList();
+            List<Pattern> excludes = Config.EXCLUDES.getOptional(configuration).stream()
+                .flatMap(Collection::stream).map(Pattern::compile).toList();
+
+            List<String> groupIds = Stream.of(group, groups, all)
+                .flatMap(Function.identity())
+                .filter(id -> isIncluded(id, excludes, includes))
+                .toList();
+
+            final KafkaOffsetSpec spec = offsetSpec;
+            final boolean dryRun = Config.DRY_RUN.get(configuration);
+            final List<String> topics = Config.TOPIC.get(configuration);
+
+            List<ExecutionResult<V1KafkaShareGroup>> results = groupIds.stream().map(groupId -> {
+                try {
+                    if (LOG.isInfoEnabled()) {
+                        LOG.info("Reset share group '{}' for topics '{}' spec={} (DRY_RUN: {}).",
+                            groupId, topics, spec, dryRun);
+                    }
+                    V1KafkaShareGroup result = service.resetShareGroupOffsets(groupId, topics, spec, dryRun);
+                    return ExecutionResult.<V1KafkaShareGroup>newBuilder()
+                        .status(ExecutionStatus.SUCCEEDED).data(result).build();
+                } catch (Exception ex) {
+                    return ExecutionResult.<V1KafkaShareGroup>newBuilder()
+                        .status(ExecutionStatus.FAILED)
+                        .errors(List.of(new ExecutionError(ex.getLocalizedMessage()))).build();
+                }
+            }).toList();
+            return ExecutionResultSet.<V1KafkaShareGroup>newBuilder().results(results).build();
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<ConfigProperty<?>> configProperties() {
+        return List.of(Config.TO_EARLIEST, Config.TO_LATEST, Config.TO_OFFSET, Config.DELETE_OFFSETS,
+            Config.GROUP, Config.GROUPS, Config.TOPIC, Config.ALL, Config.INCLUDES, Config.EXCLUDES, Config.DRY_RUN);
+    }
+
+    private static boolean isIncluded(String id, List<Pattern> excludes, List<Pattern> includes) {
+        boolean isExcluded = excludes.stream().anyMatch(p -> p.matcher(id).matches());
+        boolean isIncluded = includes.isEmpty() || includes.stream().anyMatch(p -> p.matcher(id).matches());
+        return isIncluded && !isExcluded;
+    }
+}

--- a/providers/jikkou-provider-kafka/src/main/java/io/jikkou/kafka/change/group/GroupConfigs.java
+++ b/providers/jikkou-provider-kafka/src/main/java/io/jikkou/kafka/change/group/GroupConfigs.java
@@ -1,0 +1,73 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.jikkou.kafka.change.group;
+
+import static io.jikkou.core.reconciler.Operation.DELETE;
+
+import io.jikkou.core.models.ConfigValue;
+import io.jikkou.core.models.Configs;
+import io.jikkou.core.models.change.StateChange;
+import io.jikkou.core.reconciler.change.ChangeComputer;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Shared helper for diffing dynamic configurations of a Kafka GROUP resource
+ * (consumer groups and share groups). Mirrors the topic config-diff logic but
+ * is config-only and emits config entries prefixed with {@link #CONFIG_PREFIX}.
+ */
+public final class GroupConfigs {
+
+    public static final String CONFIG_PREFIX = "config.";
+
+    private GroupConfigs() {
+    }
+
+    /**
+     * Computes the prefixed config {@link StateChange}s between two config sets.
+     *
+     * @param before        the actual configs, or {@code null}.
+     * @param after         the desired configs, or {@code null}.
+     * @param deleteOrphans {@code true} to emit DELETE for configs present in {@code before} but not {@code after}.
+     * @return the list of prefixed config changes.
+     */
+    public static List<StateChange> getConfigChanges(@Nullable Configs before,
+                                                     @Nullable Configs after,
+                                                     boolean deleteOrphans) {
+        List<StateChange> changes = configEntryChangeComputer(deleteOrphans).computeChanges(before, after);
+        return changes.stream()
+            .map(change -> StateChange.builder()
+                .withName(CONFIG_PREFIX + change.getName())
+                .withOp(change.getOp())
+                .withBefore(change.getBefore())
+                .withAfter(change.getAfter())
+                .build())
+            .collect(Collectors.toList());
+    }
+
+    /**
+     * Returns the core config-entry change computer, identical to the one used for topics.
+     *
+     * @param deleteOrphans {@code true} to emit DELETE for orphaned config entries.
+     * @return the {@link ChangeComputer}.
+     */
+    public static ChangeComputer<ConfigValue, StateChange> configEntryChangeComputer(boolean deleteOrphans) {
+        return ChangeComputer
+            .<String, ConfigValue, StateChange>builder()
+            .withDeleteOrphans(deleteOrphans)
+            .withKeyMapper(ConfigValue::name)
+            .withChangeFactory((key, before, after) -> {
+                Object beforeValue = Optional.ofNullable(before).map(ConfigValue::value).orElse(null);
+                Object afterValue = Optional.ofNullable(after).map(ConfigValue::value).orElse(null);
+                StateChange change = StateChange.with(key, beforeValue, afterValue);
+                return change.getOp() == DELETE && !before.isDeletable() ? Optional.empty() : Optional.of(change);
+            })
+            .build();
+    }
+}

--- a/providers/jikkou-provider-kafka/src/main/java/io/jikkou/kafka/change/group/UpdateGroupConfigsHandler.java
+++ b/providers/jikkou-provider-kafka/src/main/java/io/jikkou/kafka/change/group/UpdateGroupConfigsHandler.java
@@ -1,0 +1,108 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.jikkou.kafka.change.group;
+
+import io.jikkou.common.utils.CollectionUtils;
+import io.jikkou.core.models.change.ResourceChange;
+import io.jikkou.core.models.change.StateChange;
+import io.jikkou.core.models.change.StateChangeList;
+import io.jikkou.core.reconciler.ChangeMetadata;
+import io.jikkou.core.reconciler.ChangeResponse;
+import io.jikkou.core.reconciler.Operation;
+import io.jikkou.core.reconciler.TextDescription;
+import io.jikkou.core.reconciler.change.BaseChangeHandler;
+import io.jikkou.kafka.internals.Futures;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AlterConfigOp;
+import org.apache.kafka.clients.admin.ConfigEntry;
+import org.apache.kafka.common.config.ConfigResource;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Shared change handler that applies dynamic configuration changes to Kafka GROUP
+ * resources (consumer groups and share groups) via {@code incrementalAlterConfigs}.
+ * Handles both CREATE (set configs for a not-yet-existing group id) and UPDATE.
+ */
+public final class UpdateGroupConfigsHandler extends BaseChangeHandler {
+
+    private final AdminClient client;
+
+    /**
+     * Creates a new {@link UpdateGroupConfigsHandler} instance.
+     *
+     * @param client the {@link AdminClient} to be used.
+     */
+    public UpdateGroupConfigsHandler(final @NotNull AdminClient client) {
+        super(Set.of(Operation.CREATE, Operation.UPDATE));
+        this.client = Objects.requireNonNull(client, "client cannot be null");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public @NotNull List<ChangeResponse> handleChanges(final @NotNull List<ResourceChange> items) {
+        final Map<ConfigResource, Collection<AlterConfigOp>> alterConfigs = new HashMap<>();
+
+        for (ResourceChange item : items) {
+            final String groupId = item.getMetadata().getName();
+            StateChangeList<? extends StateChange> data = item.getSpec().getChanges();
+            StateChangeList<StateChange> configs = data.allWithPrefix(GroupConfigs.CONFIG_PREFIX);
+            final List<AlterConfigOp> alters = new ArrayList<>(configs.size());
+            for (StateChange configEntryChange : configs) {
+                Operation op = configEntryChange.getOp();
+                if (op == Operation.DELETE) {
+                    alters.add(new AlterConfigOp(
+                        new ConfigEntry(configEntryChange.getName(), null), AlterConfigOp.OpType.DELETE));
+                } else if (op == Operation.UPDATE || op == Operation.CREATE) {
+                    alters.add(new AlterConfigOp(
+                        new ConfigEntry(configEntryChange.getName(), String.valueOf(configEntryChange.getAfter())),
+                        AlterConfigOp.OpType.SET));
+                }
+            }
+            if (!alters.isEmpty()) {
+                alterConfigs.put(new ConfigResource(ConfigResource.Type.GROUP, groupId), alters);
+            }
+        }
+
+        final Map<String, List<CompletableFuture<Void>>> results = new HashMap<>();
+        items.forEach(it -> results.put(it.getMetadata().getName(), new ArrayList<>()));
+
+        if (!alterConfigs.isEmpty()) {
+            client.incrementalAlterConfigs(alterConfigs).values()
+                .forEach((k, v) -> results.get(k.name()).add(Futures.toCompletableFuture(v)));
+        }
+
+        Map<String, ResourceChange> changesByName = CollectionUtils.keyBy(items, it -> it.getMetadata().getName());
+        return results.entrySet().stream()
+            .map(e -> {
+                ResourceChange item = changesByName.get(e.getKey());
+                List<CompletableFuture<ChangeMetadata>> futures = e.getValue().stream()
+                    .map(f -> f.thenApply(unused -> ChangeMetadata.empty()))
+                    .toList();
+                return new ChangeResponse(item, futures);
+            })
+            .toList();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public TextDescription describe(@NotNull ResourceChange change) {
+        return () -> String.format("%s configs for group '%s'",
+            change.getSpec().getOp().humanize(), change.getMetadata().getName());
+    }
+}

--- a/providers/jikkou-provider-kafka/src/main/java/io/jikkou/kafka/change/share/DeleteShareGroupHandler.java
+++ b/providers/jikkou-provider-kafka/src/main/java/io/jikkou/kafka/change/share/DeleteShareGroupHandler.java
@@ -1,0 +1,67 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.jikkou.kafka.change.share;
+
+import io.jikkou.core.models.change.ResourceChange;
+import io.jikkou.core.reconciler.ChangeMetadata;
+import io.jikkou.core.reconciler.ChangeResponse;
+import io.jikkou.core.reconciler.Operation;
+import io.jikkou.core.reconciler.TextDescription;
+import io.jikkou.core.reconciler.change.BaseChangeHandler;
+import io.jikkou.kafka.internals.Futures;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.DeleteShareGroupsResult;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class DeleteShareGroupHandler extends BaseChangeHandler {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DeleteShareGroupHandler.class);
+
+    private final AdminClient client;
+
+    public DeleteShareGroupHandler(@NotNull AdminClient client) {
+        super(Operation.DELETE);
+        this.client = Objects.requireNonNull(client, "client cannot be null");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<ChangeResponse> handleChanges(@NotNull List<ResourceChange> changes) {
+        Map<String, ResourceChange> byName = changes.stream()
+            .collect(Collectors.toMap(r -> r.getMetadata().getName(), Function.identity()));
+
+        DeleteShareGroupsResult result = client.deleteShareGroups(byName.keySet());
+        return result.deletedGroups().entrySet().stream()
+            .map(e -> {
+                CompletableFuture<ChangeMetadata> future = Futures.toCompletableFuture(e.getValue())
+                    .thenApply(unused -> {
+                        LOG.info("Completed deletion of Kafka Share Group {}", e.getKey());
+                        return ChangeMetadata.empty();
+                    });
+                return new ChangeResponse(byName.get(e.getKey()), future);
+            })
+            .toList();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public TextDescription describe(@NotNull ResourceChange change) {
+        return new ShareGroupChangeDescription(change);
+    }
+}

--- a/providers/jikkou-provider-kafka/src/main/java/io/jikkou/kafka/change/share/ShareGroupChangeComputer.java
+++ b/providers/jikkou-provider-kafka/src/main/java/io/jikkou/kafka/change/share/ShareGroupChangeComputer.java
@@ -4,7 +4,7 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.jikkou.kafka.change.consumer;
+package io.jikkou.kafka.change.share;
 
 import io.jikkou.core.models.Configs;
 import io.jikkou.core.models.change.GenericResourceChange;
@@ -16,63 +16,51 @@ import io.jikkou.core.reconciler.change.ChangeComputerBuilder;
 import io.jikkou.core.reconciler.change.ResourceChangeComputer;
 import io.jikkou.core.reconciler.change.ResourceChangeFactory;
 import io.jikkou.kafka.change.group.GroupConfigs;
-import io.jikkou.kafka.models.V1KafkaConsumerGroup;
-import io.jikkou.kafka.models.V1KafkaConsumerGroupSpec;
+import io.jikkou.kafka.models.V1KafkaShareGroup;
+import io.jikkou.kafka.models.V1KafkaShareGroupSpec;
 import java.util.List;
 import java.util.Optional;
 
-public final class ConsumerGroupChangeComputer extends ResourceChangeComputer<String, V1KafkaConsumerGroup> {
+public final class ShareGroupChangeComputer extends ResourceChangeComputer<String, V1KafkaShareGroup> {
 
-    /**
-     * Creates a new {@link ConsumerGroupChangeComputer} instance with config-deletion disabled.
-     */
-    public ConsumerGroupChangeComputer() {
-        this(false);
-    }
-
-    /**
-     * Creates a new {@link ConsumerGroupChangeComputer} instance.
-     *
-     * @param isConfigDeletionEnabled {@code true} to delete orphaned config entries.
-     */
-    public ConsumerGroupChangeComputer(boolean isConfigDeletionEnabled) {
+    public ShareGroupChangeComputer(boolean isConfigDeletionEnabled) {
         super(ChangeComputerBuilder.KeyMapper.byName(),
-            new ConsumerGroupChangeFactory(isConfigDeletionEnabled),
+            new ShareGroupChangeFactory(isConfigDeletionEnabled),
             false);
     }
 
-    public static class ConsumerGroupChangeFactory extends ResourceChangeFactory<String, V1KafkaConsumerGroup> {
+    public static final class ShareGroupChangeFactory extends ResourceChangeFactory<String, V1KafkaShareGroup> {
 
         private final boolean isConfigDeletionEnabled;
 
-        public ConsumerGroupChangeFactory(boolean isConfigDeletionEnabled) {
+        public ShareGroupChangeFactory(boolean isConfigDeletionEnabled) {
             this.isConfigDeletionEnabled = isConfigDeletionEnabled;
         }
 
         @Override
-        public ResourceChange createChangeForCreate(String key, V1KafkaConsumerGroup after) {
+        public ResourceChange createChangeForCreate(String key, V1KafkaShareGroup after) {
             return build(after, Operation.CREATE, GroupConfigs.getConfigChanges(null, configs(after), false));
         }
 
         @Override
-        public ResourceChange createChangeForDelete(String key, V1KafkaConsumerGroup before) {
+        public ResourceChange createChangeForDelete(String key, V1KafkaShareGroup before) {
             return build(before, Operation.DELETE, List.of());
         }
 
         @Override
-        public ResourceChange createChangeForUpdate(String key, V1KafkaConsumerGroup before, V1KafkaConsumerGroup after) {
+        public ResourceChange createChangeForUpdate(String key, V1KafkaShareGroup before, V1KafkaShareGroup after) {
             List<StateChange> configChanges =
                 GroupConfigs.getConfigChanges(configs(before), configs(after), isConfigDeletionEnabled);
             boolean changed = configChanges.stream().anyMatch(c -> c.getOp() != Operation.NONE);
             return build(after, changed ? Operation.UPDATE : Operation.NONE, configChanges);
         }
 
-        private static Configs configs(V1KafkaConsumerGroup group) {
-            return Optional.ofNullable(group.getSpec()).map(V1KafkaConsumerGroupSpec::getConfigs).orElse(null);
+        private static Configs configs(V1KafkaShareGroup group) {
+            return Optional.ofNullable(group.getSpec()).map(V1KafkaShareGroupSpec::getConfigs).orElse(null);
         }
 
-        private static ResourceChange build(V1KafkaConsumerGroup resource, Operation op, List<StateChange> changes) {
-            return GenericResourceChange.builder(V1KafkaConsumerGroup.class)
+        private static ResourceChange build(V1KafkaShareGroup resource, Operation op, List<StateChange> changes) {
+            return GenericResourceChange.builder(V1KafkaShareGroup.class)
                 .withMetadata(resource.getMetadata())
                 .withSpec(ResourceChangeSpec.builder().withOperation(op).withChanges(changes).build())
                 .build();

--- a/providers/jikkou-provider-kafka/src/main/java/io/jikkou/kafka/change/share/ShareGroupChangeDescription.java
+++ b/providers/jikkou-provider-kafka/src/main/java/io/jikkou/kafka/change/share/ShareGroupChangeDescription.java
@@ -1,0 +1,31 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.jikkou.kafka.change.share;
+
+import io.jikkou.core.models.change.ResourceChange;
+import io.jikkou.core.reconciler.TextDescription;
+import java.util.Objects;
+import org.jetbrains.annotations.NotNull;
+
+public final class ShareGroupChangeDescription implements TextDescription {
+
+    private final ResourceChange object;
+
+    public ShareGroupChangeDescription(final @NotNull ResourceChange object) {
+        this.object = Objects.requireNonNull(object, "change must not be null");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String textual() {
+        return String.format("%s share group '%s'",
+            object.getSpec().getOp().humanize(),
+            object.getMetadata().getName());
+    }
+}

--- a/providers/jikkou-provider-kafka/src/main/java/io/jikkou/kafka/collections/V1KafkaShareGroupList.java
+++ b/providers/jikkou-provider-kafka/src/main/java/io/jikkou/kafka/collections/V1KafkaShareGroupList.java
@@ -1,0 +1,65 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.jikkou.kafka.collections;
+
+import io.jikkou.core.annotation.ApiVersion;
+import io.jikkou.core.annotation.Kind;
+import io.jikkou.core.models.ObjectMeta;
+import io.jikkou.core.models.SpecificResourceList;
+import io.jikkou.kafka.models.V1KafkaShareGroup;
+import java.beans.ConstructorProperties;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+@ApiVersion("kafka.jikkou.io/v1")
+@Kind("KafkaShareGroupList")
+public class V1KafkaShareGroupList extends SpecificResourceList<V1KafkaShareGroupList, V1KafkaShareGroup> {
+
+    /**
+     * Creates a new {@link V1KafkaShareGroupList} instance.
+     *
+     * @param apiVersion The resource API Version.
+     * @param kind       The resource Kind.
+     * @param metadata   The resource metadata.
+     * @param items      The items.
+     */
+    @ConstructorProperties({
+        "apiVersion",
+        "kind",
+        "metadata",
+        "items"
+    })
+    public V1KafkaShareGroupList(@Nullable String apiVersion,
+                                 @Nullable String kind,
+                                 @Nullable ObjectMeta metadata,
+                                 @NotNull List<V1KafkaShareGroup> items) {
+        super(apiVersion, kind, metadata, items);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public V1KafkaShareGroupList.Builder toBuilder() {
+        return new V1KafkaShareGroupList.Builder()
+            .withApiVersion(apiVersion)
+            .withKind(kind)
+            .withMetadata(metadata)
+            .withItems(items);
+    }
+
+    public static final class Builder extends SpecificResourceList.Builder<V1KafkaShareGroupList.Builder, V1KafkaShareGroupList, V1KafkaShareGroup> {
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public V1KafkaShareGroupList build() {
+            return new V1KafkaShareGroupList(apiVersion, kind, metadata, items);
+        }
+    }
+}

--- a/providers/jikkou-provider-kafka/src/main/java/io/jikkou/kafka/models/V1KafkaConsumerGroupSpec.java
+++ b/providers/jikkou-provider-kafka/src/main/java/io/jikkou/kafka/models/V1KafkaConsumerGroupSpec.java
@@ -1,0 +1,145 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.jikkou.kafka.models;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.jikkou.core.annotation.Reflectable;
+import io.jikkou.core.models.Configs;
+import io.jikkou.core.models.HasConfigRefs;
+import java.beans.ConstructorProperties;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import javax.annotation.processing.Generated;
+import lombok.Builder;
+import lombok.Setter;
+import lombok.Singular;
+import lombok.With;
+import lombok.extern.jackson.Jacksonized;
+
+
+/**
+ * V1KafkaConsumerGroupSpec
+ * <p>
+ * 
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Builder(builderMethodName = "builder", toBuilder = true, setterPrefix = "with")
+@With
+@Setter
+@JsonPropertyOrder({
+    "configs",
+    "configMapRefs"
+})
+@Jacksonized
+@Reflectable
+@Generated("jsonschema2pojo")
+public class V1KafkaConsumerGroupSpec implements HasConfigRefs
+{
+
+    /**
+     * The consumer group dynamic configuration properties.
+     * 
+     */
+    @JsonProperty("configs")
+    @JsonPropertyDescription("The consumer group dynamic configuration properties.")
+    private Configs configs;
+    /**
+     * The list of ConfigMap names from which to resolve consumer group configuration.
+     * 
+     */
+    @JsonProperty("configMapRefs")
+    @JsonDeserialize(as = java.util.LinkedHashSet.class)
+    @JsonPropertyDescription("The list of ConfigMap names from which to resolve consumer group configuration.")
+    @Singular
+    private Set<String> configMapRefs = new LinkedHashSet<String>();
+
+    /**
+     * No args constructor for use in serialization
+     * 
+     */
+    public V1KafkaConsumerGroupSpec() {
+    }
+
+    /**
+     * 
+     * @param configs
+     * @param configMapRefs
+     */
+    @ConstructorProperties({
+        "configs",
+        "configMapRefs"
+    })
+    public V1KafkaConsumerGroupSpec(Configs configs, Set<String> configMapRefs) {
+        super();
+        this.configs = configs;
+        this.configMapRefs = configMapRefs;
+    }
+
+    /**
+     * The consumer group dynamic configuration properties.
+     * 
+     */
+    @JsonProperty("configs")
+    public Configs getConfigs() {
+        return configs;
+    }
+
+    /**
+     * The list of ConfigMap names from which to resolve consumer group configuration.
+     * 
+     */
+    @JsonProperty("configMapRefs")
+    public Set<String> getConfigMapRefs() {
+        return configMapRefs;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(V1KafkaConsumerGroupSpec.class.getName()).append('@').append(Integer.toHexString(System.identityHashCode(this))).append('[');
+        sb.append("configs");
+        sb.append('=');
+        sb.append(((this.configs == null)?"<null>":this.configs));
+        sb.append(',');
+        sb.append("configMapRefs");
+        sb.append('=');
+        sb.append(((this.configMapRefs == null)?"<null>":this.configMapRefs));
+        sb.append(',');
+        if (sb.charAt((sb.length()- 1)) == ',') {
+            sb.setCharAt((sb.length()- 1), ']');
+        } else {
+            sb.append(']');
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.configs == null)? 0 :this.configs.hashCode()));
+        result = ((result* 31)+((this.configMapRefs == null)? 0 :this.configMapRefs.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof V1KafkaConsumerGroupSpec) == false) {
+            return false;
+        }
+        V1KafkaConsumerGroupSpec rhs = ((V1KafkaConsumerGroupSpec) other);
+        return (((this.configs == rhs.configs)||((this.configs!= null)&&this.configs.equals(rhs.configs)))&&((this.configMapRefs == rhs.configMapRefs)||((this.configMapRefs!= null)&&this.configMapRefs.equals(rhs.configMapRefs))));
+    }
+
+}

--- a/providers/jikkou-provider-kafka/src/main/java/io/jikkou/kafka/models/V1KafkaShareGroup.java
+++ b/providers/jikkou-provider-kafka/src/main/java/io/jikkou/kafka/models/V1KafkaShareGroup.java
@@ -31,18 +31,18 @@ import lombok.extern.jackson.Jacksonized;
 
 
 /**
- * V1KafkaConsumerGroup
+ * V1KafkaShareGroup
  * <p>
- * Manage consumer groups in a Kafka cluster.
+ * Manage share groups (queues) in a Kafka cluster.
  * 
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Builder(builderMethodName = "builder", toBuilder = true, setterPrefix = "with")
 @With
-@Description("Manage consumer groups in a Kafka cluster.")
-@JsonClassDescription("Manage consumer groups in a Kafka cluster.")
-@Names(singular = "kafkaconsumergroup", plural = "kafkaconsumergroups", local = "consumer-groups", shortNames = {
-    "kcg"
+@Description("Manage share groups (queues) in a Kafka cluster.")
+@JsonClassDescription("Manage share groups (queues) in a Kafka cluster.")
+@Names(singular = "kafkasharegroup", plural = "kafkasharegroups", local = "share-groups", shortNames = {
+    "ksg"
 })
 @Verbs({
     Verb.LIST,
@@ -60,11 +60,11 @@ import lombok.extern.jackson.Jacksonized;
     "status"
 })
 @ApiVersion("kafka.jikkou.io/v1")
-@Kind("KafkaConsumerGroup")
+@Kind("KafkaShareGroup")
 @Jacksonized
 @Reflectable
 @Generated("jsonschema2pojo")
-public class V1KafkaConsumerGroup implements HasMetadata, HasSpec<V1KafkaConsumerGroupSpec> , Resource
+public class V1KafkaShareGroup implements HasMetadata, HasSpec<V1KafkaShareGroupSpec> , Resource
 {
 
     /**
@@ -82,7 +82,7 @@ public class V1KafkaConsumerGroup implements HasMetadata, HasSpec<V1KafkaConsume
      */
     @JsonProperty("kind")
     @Builder.Default
-    private String kind = "KafkaConsumerGroup";
+    private String kind = "KafkaShareGroup";
     /**
      * ObjectMeta
      * <p>
@@ -103,28 +103,27 @@ public class V1KafkaConsumerGroup implements HasMetadata, HasSpec<V1KafkaConsume
     @JsonPropertyDescription("Data values to be passed to the template engine.")
     private ObjectTemplate template;
     /**
-     * V1KafkaConsumerGroupSpec
+     * V1KafkaShareGroupSpec
      * <p>
      * 
      * 
      */
     @JsonProperty("spec")
-    private io.jikkou.kafka.models.V1KafkaConsumerGroupSpec spec;
+    private io.jikkou.kafka.models.V1KafkaShareGroupSpec spec;
     /**
-     * V1KafkaConsumerGroupStatus
+     * V1KafkaShareGroupStatus
      * <p>
      * 
-     * (Required)
      * 
      */
     @JsonProperty("status")
-    private V1KafkaConsumerGroupStatus status;
+    private V1KafkaShareGroupStatus status;
 
     /**
      * No args constructor for use in serialization
      * 
      */
-    public V1KafkaConsumerGroup() {
+    public V1KafkaShareGroup() {
     }
 
     /**
@@ -144,7 +143,7 @@ public class V1KafkaConsumerGroup implements HasMetadata, HasSpec<V1KafkaConsume
         "spec",
         "status"
     })
-    public V1KafkaConsumerGroup(String apiVersion, String kind, ObjectMeta metadata, ObjectTemplate template, io.jikkou.kafka.models.V1KafkaConsumerGroupSpec spec, V1KafkaConsumerGroupStatus status) {
+    public V1KafkaShareGroup(String apiVersion, String kind, ObjectMeta metadata, ObjectTemplate template, io.jikkou.kafka.models.V1KafkaShareGroupSpec spec, V1KafkaShareGroupStatus status) {
         super();
         this.apiVersion = apiVersion;
         this.kind = kind;
@@ -198,32 +197,31 @@ public class V1KafkaConsumerGroup implements HasMetadata, HasSpec<V1KafkaConsume
     }
 
     /**
-     * V1KafkaConsumerGroupSpec
+     * V1KafkaShareGroupSpec
      * <p>
      * 
      * 
      */
     @JsonProperty("spec")
-    public io.jikkou.kafka.models.V1KafkaConsumerGroupSpec getSpec() {
+    public io.jikkou.kafka.models.V1KafkaShareGroupSpec getSpec() {
         return spec;
     }
 
     /**
-     * V1KafkaConsumerGroupStatus
+     * V1KafkaShareGroupStatus
      * <p>
      * 
-     * (Required)
      * 
      */
     @JsonProperty("status")
-    public V1KafkaConsumerGroupStatus getStatus() {
+    public V1KafkaShareGroupStatus getStatus() {
         return status;
     }
 
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
-        sb.append(V1KafkaConsumerGroup.class.getName()).append('@').append(Integer.toHexString(System.identityHashCode(this))).append('[');
+        sb.append(V1KafkaShareGroup.class.getName()).append('@').append(Integer.toHexString(System.identityHashCode(this))).append('[');
         sb.append("apiVersion");
         sb.append('=');
         sb.append(((this.apiVersion == null)?"<null>":this.apiVersion));
@@ -273,10 +271,10 @@ public class V1KafkaConsumerGroup implements HasMetadata, HasSpec<V1KafkaConsume
         if (other == this) {
             return true;
         }
-        if ((other instanceof V1KafkaConsumerGroup) == false) {
+        if ((other instanceof V1KafkaShareGroup) == false) {
             return false;
         }
-        V1KafkaConsumerGroup rhs = ((V1KafkaConsumerGroup) other);
+        V1KafkaShareGroup rhs = ((V1KafkaShareGroup) other);
         return (((((((this.template == rhs.template)||((this.template!= null)&&this.template.equals(rhs.template)))&&((this.metadata == rhs.metadata)||((this.metadata!= null)&&this.metadata.equals(rhs.metadata))))&&((this.apiVersion == rhs.apiVersion)||((this.apiVersion!= null)&&this.apiVersion.equals(rhs.apiVersion))))&&((this.kind == rhs.kind)||((this.kind!= null)&&this.kind.equals(rhs.kind))))&&((this.spec == rhs.spec)||((this.spec!= null)&&this.spec.equals(rhs.spec))))&&((this.status == rhs.status)||((this.status!= null)&&this.status.equals(rhs.status))));
     }
 

--- a/providers/jikkou-provider-kafka/src/main/java/io/jikkou/kafka/models/V1KafkaShareGroupMember.java
+++ b/providers/jikkou-provider-kafka/src/main/java/io/jikkou/kafka/models/V1KafkaShareGroupMember.java
@@ -1,0 +1,219 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.jikkou.kafka.models;
+
+import com.fasterxml.jackson.annotation.JsonClassDescription;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.jikkou.core.annotation.Description;
+import io.jikkou.core.annotation.Reflectable;
+import java.beans.ConstructorProperties;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.processing.Generated;
+import lombok.Builder;
+import lombok.Singular;
+import lombok.With;
+import lombok.extern.jackson.Jacksonized;
+
+
+/**
+ * V1KafkaShareGroupMember
+ * <p>
+ * Detailed description of a single share group member.
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Builder(builderMethodName = "builder", toBuilder = true, setterPrefix = "with")
+@With
+@Description("Detailed description of a single share group member.")
+@JsonClassDescription("Detailed description of a single share group member.")
+@JsonPropertyOrder({
+    "memberId",
+    "clientId",
+    "host",
+    "rackId",
+    "assignments"
+})
+@Jacksonized
+@Reflectable
+@Generated("jsonschema2pojo")
+public class V1KafkaShareGroupMember {
+
+    /**
+     * The member ID.
+     * (Required)
+     * 
+     */
+    @JsonProperty("memberId")
+    @JsonPropertyDescription("The member ID.")
+    private String memberId;
+    /**
+     * The client ID.
+     * 
+     */
+    @JsonProperty("clientId")
+    @JsonPropertyDescription("The client ID.")
+    private String clientId;
+    /**
+     * The member host.
+     * 
+     */
+    @JsonProperty("host")
+    @JsonPropertyDescription("The member host.")
+    private String host;
+    /**
+     * The rack ID of the member.
+     * 
+     */
+    @JsonProperty("rackId")
+    @JsonPropertyDescription("The rack ID of the member.")
+    private String rackId;
+    /**
+     * List of topic-partitions assigned to the member.
+     * 
+     */
+    @JsonProperty("assignments")
+    @JsonPropertyDescription("List of topic-partitions assigned to the member.")
+    @Singular
+    private List<String> assignments = new ArrayList<String>();
+
+    /**
+     * No args constructor for use in serialization
+     * 
+     */
+    public V1KafkaShareGroupMember() {
+    }
+
+    /**
+     * 
+     * @param clientId
+     * @param assignments
+     * @param host
+     * @param memberId
+     * @param rackId
+     */
+    @ConstructorProperties({
+        "memberId",
+        "clientId",
+        "host",
+        "rackId",
+        "assignments"
+    })
+    public V1KafkaShareGroupMember(String memberId, String clientId, String host, String rackId, List<String> assignments) {
+        super();
+        this.memberId = memberId;
+        this.clientId = clientId;
+        this.host = host;
+        this.rackId = rackId;
+        this.assignments = assignments;
+    }
+
+    /**
+     * The member ID.
+     * (Required)
+     * 
+     */
+    @JsonProperty("memberId")
+    public String getMemberId() {
+        return memberId;
+    }
+
+    /**
+     * The client ID.
+     * 
+     */
+    @JsonProperty("clientId")
+    public String getClientId() {
+        return clientId;
+    }
+
+    /**
+     * The member host.
+     * 
+     */
+    @JsonProperty("host")
+    public String getHost() {
+        return host;
+    }
+
+    /**
+     * The rack ID of the member.
+     * 
+     */
+    @JsonProperty("rackId")
+    public String getRackId() {
+        return rackId;
+    }
+
+    /**
+     * List of topic-partitions assigned to the member.
+     * 
+     */
+    @JsonProperty("assignments")
+    public List<String> getAssignments() {
+        return assignments;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(V1KafkaShareGroupMember.class.getName()).append('@').append(Integer.toHexString(System.identityHashCode(this))).append('[');
+        sb.append("memberId");
+        sb.append('=');
+        sb.append(((this.memberId == null)?"<null>":this.memberId));
+        sb.append(',');
+        sb.append("clientId");
+        sb.append('=');
+        sb.append(((this.clientId == null)?"<null>":this.clientId));
+        sb.append(',');
+        sb.append("host");
+        sb.append('=');
+        sb.append(((this.host == null)?"<null>":this.host));
+        sb.append(',');
+        sb.append("rackId");
+        sb.append('=');
+        sb.append(((this.rackId == null)?"<null>":this.rackId));
+        sb.append(',');
+        sb.append("assignments");
+        sb.append('=');
+        sb.append(((this.assignments == null)?"<null>":this.assignments));
+        sb.append(',');
+        if (sb.charAt((sb.length()- 1)) == ',') {
+            sb.setCharAt((sb.length()- 1), ']');
+        } else {
+            sb.append(']');
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.host == null)? 0 :this.host.hashCode()));
+        result = ((result* 31)+((this.clientId == null)? 0 :this.clientId.hashCode()));
+        result = ((result* 31)+((this.assignments == null)? 0 :this.assignments.hashCode()));
+        result = ((result* 31)+((this.memberId == null)? 0 :this.memberId.hashCode()));
+        result = ((result* 31)+((this.rackId == null)? 0 :this.rackId.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof V1KafkaShareGroupMember) == false) {
+            return false;
+        }
+        V1KafkaShareGroupMember rhs = ((V1KafkaShareGroupMember) other);
+        return ((((((this.host == rhs.host)||((this.host!= null)&&this.host.equals(rhs.host)))&&((this.clientId == rhs.clientId)||((this.clientId!= null)&&this.clientId.equals(rhs.clientId))))&&((this.assignments == rhs.assignments)||((this.assignments!= null)&&this.assignments.equals(rhs.assignments))))&&((this.memberId == rhs.memberId)||((this.memberId!= null)&&this.memberId.equals(rhs.memberId))))&&((this.rackId == rhs.rackId)||((this.rackId!= null)&&this.rackId.equals(rhs.rackId))));
+    }
+
+}

--- a/providers/jikkou-provider-kafka/src/main/java/io/jikkou/kafka/models/V1KafkaShareGroupSpec.java
+++ b/providers/jikkou-provider-kafka/src/main/java/io/jikkou/kafka/models/V1KafkaShareGroupSpec.java
@@ -1,0 +1,145 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.jikkou.kafka.models;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.jikkou.core.annotation.Reflectable;
+import io.jikkou.core.models.Configs;
+import io.jikkou.core.models.HasConfigRefs;
+import java.beans.ConstructorProperties;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import javax.annotation.processing.Generated;
+import lombok.Builder;
+import lombok.Setter;
+import lombok.Singular;
+import lombok.With;
+import lombok.extern.jackson.Jacksonized;
+
+
+/**
+ * V1KafkaShareGroupSpec
+ * <p>
+ * 
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Builder(builderMethodName = "builder", toBuilder = true, setterPrefix = "with")
+@With
+@Setter
+@JsonPropertyOrder({
+    "configs",
+    "configMapRefs"
+})
+@Jacksonized
+@Reflectable
+@Generated("jsonschema2pojo")
+public class V1KafkaShareGroupSpec implements HasConfigRefs
+{
+
+    /**
+     * The share group dynamic configuration properties.
+     * 
+     */
+    @JsonProperty("configs")
+    @JsonPropertyDescription("The share group dynamic configuration properties.")
+    private Configs configs;
+    /**
+     * The list of ConfigMap names from which to resolve share group configuration.
+     * 
+     */
+    @JsonProperty("configMapRefs")
+    @JsonDeserialize(as = java.util.LinkedHashSet.class)
+    @JsonPropertyDescription("The list of ConfigMap names from which to resolve share group configuration.")
+    @Singular
+    private Set<String> configMapRefs = new LinkedHashSet<String>();
+
+    /**
+     * No args constructor for use in serialization
+     * 
+     */
+    public V1KafkaShareGroupSpec() {
+    }
+
+    /**
+     * 
+     * @param configs
+     * @param configMapRefs
+     */
+    @ConstructorProperties({
+        "configs",
+        "configMapRefs"
+    })
+    public V1KafkaShareGroupSpec(Configs configs, Set<String> configMapRefs) {
+        super();
+        this.configs = configs;
+        this.configMapRefs = configMapRefs;
+    }
+
+    /**
+     * The share group dynamic configuration properties.
+     * 
+     */
+    @JsonProperty("configs")
+    public Configs getConfigs() {
+        return configs;
+    }
+
+    /**
+     * The list of ConfigMap names from which to resolve share group configuration.
+     * 
+     */
+    @JsonProperty("configMapRefs")
+    public Set<String> getConfigMapRefs() {
+        return configMapRefs;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(V1KafkaShareGroupSpec.class.getName()).append('@').append(Integer.toHexString(System.identityHashCode(this))).append('[');
+        sb.append("configs");
+        sb.append('=');
+        sb.append(((this.configs == null)?"<null>":this.configs));
+        sb.append(',');
+        sb.append("configMapRefs");
+        sb.append('=');
+        sb.append(((this.configMapRefs == null)?"<null>":this.configMapRefs));
+        sb.append(',');
+        if (sb.charAt((sb.length()- 1)) == ',') {
+            sb.setCharAt((sb.length()- 1), ']');
+        } else {
+            sb.append(']');
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.configs == null)? 0 :this.configs.hashCode()));
+        result = ((result* 31)+((this.configMapRefs == null)? 0 :this.configMapRefs.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof V1KafkaShareGroupSpec) == false) {
+            return false;
+        }
+        V1KafkaShareGroupSpec rhs = ((V1KafkaShareGroupSpec) other);
+        return (((this.configs == rhs.configs)||((this.configs!= null)&&this.configs.equals(rhs.configs)))&&((this.configMapRefs == rhs.configMapRefs)||((this.configMapRefs!= null)&&this.configMapRefs.equals(rhs.configMapRefs))));
+    }
+
+}

--- a/providers/jikkou-provider-kafka/src/main/java/io/jikkou/kafka/models/V1KafkaShareGroupStatus.java
+++ b/providers/jikkou-provider-kafka/src/main/java/io/jikkou/kafka/models/V1KafkaShareGroupStatus.java
@@ -1,0 +1,193 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.jikkou.kafka.models;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.jikkou.core.annotation.Reflectable;
+import java.beans.ConstructorProperties;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.processing.Generated;
+import lombok.Builder;
+import lombok.Singular;
+import lombok.With;
+import lombok.extern.jackson.Jacksonized;
+
+
+/**
+ * V1KafkaShareGroupStatus
+ * <p>
+ * 
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Builder(builderMethodName = "builder", toBuilder = true, setterPrefix = "with")
+@With
+@JsonPropertyOrder({
+    "state",
+    "members",
+    "offsets",
+    "coordinator"
+})
+@Jacksonized
+@Reflectable
+@Generated("jsonschema2pojo")
+public class V1KafkaShareGroupStatus {
+
+    /**
+     * The share group state.
+     * 
+     */
+    @JsonProperty("state")
+    @JsonPropertyDescription("The share group state.")
+    private String state;
+    /**
+     * List of share group members.
+     * 
+     */
+    @JsonProperty("members")
+    @JsonPropertyDescription("List of share group members.")
+    @Singular
+    private List<V1KafkaShareGroupMember> members = new ArrayList<V1KafkaShareGroupMember>();
+    /**
+     * List of share-partition start offsets.
+     * 
+     */
+    @JsonProperty("offsets")
+    @JsonPropertyDescription("List of share-partition start offsets.")
+    @Singular
+    private List<V1KafkaConsumerOffset> offsets = new ArrayList<V1KafkaConsumerOffset>();
+    /**
+     * V1KafkaNode
+     * <p>
+     * Information about a Kafka node.
+     * 
+     */
+    @JsonProperty("coordinator")
+    @JsonPropertyDescription("Information about a Kafka node.")
+    private V1KafkaNode coordinator;
+
+    /**
+     * No args constructor for use in serialization
+     * 
+     */
+    public V1KafkaShareGroupStatus() {
+    }
+
+    /**
+     * 
+     * @param coordinator
+     * @param offsets
+     * @param members
+     * @param state
+     */
+    @ConstructorProperties({
+        "state",
+        "members",
+        "offsets",
+        "coordinator"
+    })
+    public V1KafkaShareGroupStatus(String state, List<V1KafkaShareGroupMember> members, List<V1KafkaConsumerOffset> offsets, V1KafkaNode coordinator) {
+        super();
+        this.state = state;
+        this.members = members;
+        this.offsets = offsets;
+        this.coordinator = coordinator;
+    }
+
+    /**
+     * The share group state.
+     * 
+     */
+    @JsonProperty("state")
+    public String getState() {
+        return state;
+    }
+
+    /**
+     * List of share group members.
+     * 
+     */
+    @JsonProperty("members")
+    public List<V1KafkaShareGroupMember> getMembers() {
+        return members;
+    }
+
+    /**
+     * List of share-partition start offsets.
+     * 
+     */
+    @JsonProperty("offsets")
+    public List<V1KafkaConsumerOffset> getOffsets() {
+        return offsets;
+    }
+
+    /**
+     * V1KafkaNode
+     * <p>
+     * Information about a Kafka node.
+     * 
+     */
+    @JsonProperty("coordinator")
+    public V1KafkaNode getCoordinator() {
+        return coordinator;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(V1KafkaShareGroupStatus.class.getName()).append('@').append(Integer.toHexString(System.identityHashCode(this))).append('[');
+        sb.append("state");
+        sb.append('=');
+        sb.append(((this.state == null)?"<null>":this.state));
+        sb.append(',');
+        sb.append("members");
+        sb.append('=');
+        sb.append(((this.members == null)?"<null>":this.members));
+        sb.append(',');
+        sb.append("offsets");
+        sb.append('=');
+        sb.append(((this.offsets == null)?"<null>":this.offsets));
+        sb.append(',');
+        sb.append("coordinator");
+        sb.append('=');
+        sb.append(((this.coordinator == null)?"<null>":this.coordinator));
+        sb.append(',');
+        if (sb.charAt((sb.length()- 1)) == ',') {
+            sb.setCharAt((sb.length()- 1), ']');
+        } else {
+            sb.append(']');
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.state == null)? 0 :this.state.hashCode()));
+        result = ((result* 31)+((this.coordinator == null)? 0 :this.coordinator.hashCode()));
+        result = ((result* 31)+((this.offsets == null)? 0 :this.offsets.hashCode()));
+        result = ((result* 31)+((this.members == null)? 0 :this.members.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof V1KafkaShareGroupStatus) == false) {
+            return false;
+        }
+        V1KafkaShareGroupStatus rhs = ((V1KafkaShareGroupStatus) other);
+        return (((((this.state == rhs.state)||((this.state!= null)&&this.state.equals(rhs.state)))&&((this.coordinator == rhs.coordinator)||((this.coordinator!= null)&&this.coordinator.equals(rhs.coordinator))))&&((this.offsets == rhs.offsets)||((this.offsets!= null)&&this.offsets.equals(rhs.offsets))))&&((this.members == rhs.members)||((this.members!= null)&&this.members.equals(rhs.members))));
+    }
+
+}

--- a/providers/jikkou-provider-kafka/src/main/java/io/jikkou/kafka/reconciler/AdminClientConsumerGroupCollector.java
+++ b/providers/jikkou-provider-kafka/src/main/java/io/jikkou/kafka/reconciler/AdminClientConsumerGroupCollector.java
@@ -14,15 +14,19 @@ import io.jikkou.core.config.Configuration;
 import io.jikkou.core.data.TypeConverter;
 import io.jikkou.core.extension.ContextualExtension;
 import io.jikkou.core.extension.ExtensionContext;
+import io.jikkou.core.models.Configs;
 import io.jikkou.core.models.ResourceList;
 import io.jikkou.core.reconciler.Collector;
 import io.jikkou.core.selector.Selector;
 import io.jikkou.kafka.KafkaExtensionProvider;
+import io.jikkou.kafka.collections.V1KafkaConsumerGroupList;
 import io.jikkou.kafka.internals.admin.AdminClientContext;
 import io.jikkou.kafka.internals.admin.AdminClientContextFactory;
 import io.jikkou.kafka.models.V1KafkaConsumerGroup;
+import io.jikkou.kafka.models.V1KafkaConsumerGroupSpec;
 import io.jikkou.kafka.reconciler.service.KafkaAdminService;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.apache.kafka.common.ConsumerGroupState;
 import org.jetbrains.annotations.NotNull;
@@ -91,7 +95,20 @@ public final class AdminClientConsumerGroupCollector extends ContextualExtension
                                                       @NotNull Selector selector) {
         try (AdminClientContext clientContext = adminClientContextFactory.createAdminClientContext()) {
             KafkaAdminService service = new KafkaAdminService(clientContext.getAdminClient());
-            return service.listConsumerGroups(Config.IN_STATES.get(configuration), Config.OFFSETS.get(configuration));
+            V1KafkaConsumerGroupList groups = service.listConsumerGroups(
+                Config.IN_STATES.get(configuration), Config.OFFSETS.get(configuration));
+
+            List<String> ids = groups.getItems().stream()
+                .map(g -> g.getMetadata().getName())
+                .toList();
+            Map<String, Configs> configsByGroup = service.describeGroupConfigs(ids);
+
+            List<V1KafkaConsumerGroup> items = groups.getItems().stream()
+                .map(g -> g.withSpec(V1KafkaConsumerGroupSpec.builder()
+                    .withConfigs(configsByGroup.getOrDefault(g.getMetadata().getName(), Configs.empty()))
+                    .build()))
+                .toList();
+            return new V1KafkaConsumerGroupList.Builder().withItems(items).build();
         }
     }
 

--- a/providers/jikkou-provider-kafka/src/main/java/io/jikkou/kafka/reconciler/AdminClientShareGroupCollector.java
+++ b/providers/jikkou-provider-kafka/src/main/java/io/jikkou/kafka/reconciler/AdminClientShareGroupCollector.java
@@ -1,0 +1,102 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.jikkou.kafka.reconciler;
+
+import io.jikkou.core.annotation.Description;
+import io.jikkou.core.annotation.SupportedResource;
+import io.jikkou.core.annotation.Title;
+import io.jikkou.core.config.ConfigProperty;
+import io.jikkou.core.config.Configuration;
+import io.jikkou.core.data.TypeConverter;
+import io.jikkou.core.extension.ContextualExtension;
+import io.jikkou.core.extension.ExtensionContext;
+import io.jikkou.core.models.ResourceList;
+import io.jikkou.core.reconciler.Collector;
+import io.jikkou.core.selector.Selector;
+import io.jikkou.kafka.KafkaExtensionProvider;
+import io.jikkou.kafka.internals.admin.AdminClientContext;
+import io.jikkou.kafka.internals.admin.AdminClientContextFactory;
+import io.jikkou.kafka.models.V1KafkaShareGroup;
+import io.jikkou.kafka.reconciler.service.KafkaAdminService;
+import java.util.List;
+import java.util.Set;
+import org.apache.kafka.common.GroupState;
+import org.jetbrains.annotations.NotNull;
+
+@Title("Collect Kafka share groups")
+@Description("Collects all Kafka share group resources from a Kafka cluster using the AdminClient API.")
+@SupportedResource(type = V1KafkaShareGroup.class)
+public final class AdminClientShareGroupCollector extends ContextualExtension implements Collector<V1KafkaShareGroup> {
+
+    /**
+     * The extension config.
+     */
+    public interface Config {
+        ConfigProperty<Boolean> OFFSETS = ConfigProperty
+            .ofBoolean("offsets")
+            .displayName("Offsets")
+            .description("Specify whether share group offsets (SPSO) should be described.")
+            .defaultValue(false);
+
+        ConfigProperty<Set<GroupState>> IN_STATES = ConfigProperty
+            .ofAny("in-states")
+            .displayName("In States")
+            .convert(TypeConverter.ofSet(GroupState.class))
+            .description("If set, only share groups in these states are returned. Otherwise, all groups are returned.")
+            .defaultValue(Set.of());
+    }
+
+    private AdminClientContextFactory adminClientContextFactory;
+
+    /**
+     * Creates a new {@link AdminClientShareGroupCollector} instance.
+     * CLI requires any empty constructor.
+     */
+    public AdminClientShareGroupCollector() {
+        super();
+    }
+
+    /**
+     * Creates a new {@link AdminClientShareGroupCollector} instance with the specified {@link AdminClientContextFactory}.
+     *
+     * @param adminClientContextFactory the {@link AdminClientContextFactory} to use.
+     */
+    public AdminClientShareGroupCollector(final @NotNull AdminClientContextFactory adminClientContextFactory) {
+        this.adminClientContextFactory = adminClientContextFactory;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void init(@NotNull ExtensionContext context) {
+        super.init(context);
+        if (adminClientContextFactory == null) {
+            adminClientContextFactory = context.<KafkaExtensionProvider>provider().newAdminClientContextFactory();
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ResourceList<V1KafkaShareGroup> listAll(@NotNull Configuration configuration,
+                                                   @NotNull Selector selector) {
+        try (AdminClientContext clientContext = adminClientContextFactory.createAdminClientContext()) {
+            KafkaAdminService service = new KafkaAdminService(clientContext.getAdminClient());
+            return service.listShareGroups(Config.IN_STATES.get(configuration), Config.OFFSETS.get(configuration));
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<ConfigProperty<?>> configProperties() {
+        return List.of(Config.IN_STATES, Config.OFFSETS);
+    }
+}

--- a/providers/jikkou-provider-kafka/src/main/java/io/jikkou/kafka/reconciler/AdminClientShareGroupController.java
+++ b/providers/jikkou-provider-kafka/src/main/java/io/jikkou/kafka/reconciler/AdminClientShareGroupController.java
@@ -26,16 +26,17 @@ import io.jikkou.core.reconciler.ChangeHandler;
 import io.jikkou.core.reconciler.ChangeResult;
 import io.jikkou.core.reconciler.Controller;
 import io.jikkou.core.reconciler.annotations.ControllerConfiguration;
+import io.jikkou.core.selector.Selector;
 import io.jikkou.kafka.ApiVersions;
 import io.jikkou.kafka.KafkaExtensionProvider;
-import io.jikkou.kafka.change.consumer.ConsumerGroupChangeComputer;
-import io.jikkou.kafka.change.consumer.ConsumerGroupChangeDescription;
-import io.jikkou.kafka.change.consumer.DeleteConsumerGroupHandler;
 import io.jikkou.kafka.change.group.UpdateGroupConfigsHandler;
+import io.jikkou.kafka.change.share.DeleteShareGroupHandler;
+import io.jikkou.kafka.change.share.ShareGroupChangeComputer;
+import io.jikkou.kafka.change.share.ShareGroupChangeDescription;
 import io.jikkou.kafka.internals.admin.AdminClientContext;
 import io.jikkou.kafka.internals.admin.AdminClientContextFactory;
-import io.jikkou.kafka.models.V1KafkaConsumerGroup;
-import io.jikkou.kafka.models.V1KafkaConsumerGroupSpec;
+import io.jikkou.kafka.models.V1KafkaShareGroup;
+import io.jikkou.kafka.models.V1KafkaShareGroupSpec;
 import io.jikkou.kafka.reconciler.service.KafkaAdminService;
 import java.util.Collection;
 import java.util.List;
@@ -43,16 +44,13 @@ import java.util.Map;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.jetbrains.annotations.NotNull;
 
-@Title("Reconcile Kafka consumer groups")
-@Description("Reconciles Kafka consumer group resources to ensure they match the desired state.")
-@SupportedResource(type = V1KafkaConsumerGroup.class)
-@SupportedResource(apiVersion = ApiVersions.KAFKA_V1BETA1, kind = "KafkaConsumerGroupChange")
-@ControllerConfiguration(
-        supportedModes = {CREATE, UPDATE, FULL, DELETE}
-)
-public final class AdminClientConsumerGroupController
-        extends ContextualExtension
-        implements Controller<V1KafkaConsumerGroup> {
+@Title("Reconcile Kafka share groups")
+@Description("Reconciles Kafka share group resources to ensure they match the desired state.")
+@SupportedResource(type = V1KafkaShareGroup.class)
+@SupportedResource(apiVersion = ApiVersions.KAFKA_V1, kind = "KafkaShareGroupChange")
+@ControllerConfiguration(supportedModes = {CREATE, UPDATE, FULL, DELETE})
+public final class AdminClientShareGroupController
+        extends ContextualExtension implements Controller<V1KafkaShareGroup> {
 
     /**
      * The Extension config.
@@ -61,26 +59,26 @@ public final class AdminClientConsumerGroupController
         ConfigProperty<Boolean> IS_CONFIG_DELETE_ORPHANS_ENABLED = ConfigProperty
             .ofBoolean("config-delete-orphans")
             .displayName("Delete Orphan Configs")
-            .description("Specify whether to delete consumer group configs that exist on the cluster but are not defined in the resource.")
+            .description("Specify whether to delete group configs that exist on the cluster but are not defined in the resource.")
             .defaultValue(true);
     }
 
     private AdminClientContextFactory adminClientContextFactory;
 
     /**
-     * Creates a new {@link AdminClientConsumerGroupController} instance.
+     * Creates a new {@link AdminClientShareGroupController} instance.
      * CLI requires any empty constructor.
      */
-    public AdminClientConsumerGroupController() {
+    public AdminClientShareGroupController() {
         super();
     }
 
     /**
-     * Creates a new {@link AdminClientConsumerGroupController} instance with the specified {@link AdminClientContextFactory}.
+     * Creates a new {@link AdminClientShareGroupController} instance with the specified {@link AdminClientContextFactory}.
      *
-     * @param adminClientContextFactory the {@link AdminClientContextFactory} to use for acquiring a new {@link AdminClientContext}.
+     * @param adminClientContextFactory the {@link AdminClientContextFactory} to use.
      */
-    public AdminClientConsumerGroupController(final @NotNull AdminClientContextFactory adminClientContextFactory) {
+    public AdminClientShareGroupController(final @NotNull AdminClientContextFactory adminClientContextFactory) {
         this.adminClientContextFactory = adminClientContextFactory;
     }
 
@@ -101,13 +99,12 @@ public final class AdminClientConsumerGroupController
     @Override
     public List<ChangeResult> execute(@NotNull ChangeExecutor executor,
                                       @NotNull ReconciliationContext context) {
-
         try (AdminClientContext clientContext = adminClientContextFactory.createAdminClientContext()) {
             AdminClient adminClient = clientContext.getAdminClient();
             List<ChangeHandler> handlers = List.of(
-                    new UpdateGroupConfigsHandler(adminClient),
-                    new DeleteConsumerGroupHandler(adminClient),
-                    new ChangeHandler.None(ConsumerGroupChangeDescription::new)
+                new UpdateGroupConfigsHandler(adminClient),
+                new DeleteShareGroupHandler(adminClient),
+                new ChangeHandler.None(ShareGroupChangeDescription::new)
             );
             return executor.applyChanges(handlers);
         }
@@ -117,47 +114,45 @@ public final class AdminClientConsumerGroupController
      * {@inheritDoc}
      */
     @Override
-    public List<ResourceChange> plan(@NotNull Collection<V1KafkaConsumerGroup> resources,
+    public List<ResourceChange> plan(@NotNull Collection<V1KafkaShareGroup> resources,
                                      @NotNull ReconciliationContext context) {
+        Selector selector = context.selector();
 
-        // Get the expected Consumer Groups with flattened configs.
-        List<V1KafkaConsumerGroup> expectedState = resources
-                .stream()
-                .filter(context.selector()::apply)
-                .map(resource -> resource.withStatus(null))
-                .map(resource -> {
-                    V1KafkaConsumerGroupSpec spec = resource.getSpec();
-                    Configs configs = spec == null ? null : spec.getConfigs();
-                    return configs == null ? resource : resource.withSpec(spec.withConfigs(configs.flatten()));
-                })
-                .toList();
+        // Desired state with flattened configs.
+        List<V1KafkaShareGroup> expected = resources.stream()
+            .filter(selector::apply)
+            .map(resource -> resource.withStatus(null))
+            .map(resource -> {
+                V1KafkaShareGroupSpec spec = resource.getSpec();
+                Configs configs = spec == null ? null : spec.getConfigs();
+                return configs == null ? resource : resource.withSpec(spec.withConfigs(configs.flatten()));
+            })
+            .toList();
 
-        // Get the Consumer Group IDs.
-        List<String> consumerGroupsIds = expectedState.stream()
-                .map(resource -> resource.getMetadata().getName())
-                .distinct()
-                .toList();
+        List<String> ids = expected.stream()
+            .map(resource -> resource.getMetadata().getName())
+            .distinct()
+            .toList();
 
+        // Actual state is derived from the dynamic configs of the GROUP resource (which never
+        // fails for not-yet-existing groups), not from listing share groups (which omits
+        // config-only groups).
         try (AdminClientContext clientContext = adminClientContextFactory.createAdminClientContext()) {
             KafkaAdminService service = new KafkaAdminService(clientContext.getAdminClient());
+            Map<String, Configs> actualConfigs = service.describeGroupConfigs(ids);
 
-            // Actual state is derived from the dynamic configs of the GROUP resource. This never
-            // fails for not-yet-existing groups, unlike describeConsumerGroups which throws
-            // GroupIdNotFoundException on Kafka 4.x brokers.
-            Map<String, Configs> actualConfigs = service.describeGroupConfigs(consumerGroupsIds);
-
-            List<V1KafkaConsumerGroup> actualStates = consumerGroupsIds.stream()
-                    .map(id -> V1KafkaConsumerGroup.builder()
-                        .withMetadata(ObjectMeta.builder().withName(id).build())
-                        .withSpec(V1KafkaConsumerGroupSpec.builder()
-                            .withConfigs(actualConfigs.getOrDefault(id, Configs.empty()))
-                            .build())
+            List<V1KafkaShareGroup> actual = ids.stream()
+                .map(id -> V1KafkaShareGroup.builder()
+                    .withMetadata(ObjectMeta.builder().withName(id).build())
+                    .withSpec(V1KafkaShareGroupSpec.builder()
+                        .withConfigs(actualConfigs.getOrDefault(id, Configs.empty()))
                         .build())
-                    .toList();
+                    .build())
+                .toList();
 
-            ConsumerGroupChangeComputer changeComputer = new ConsumerGroupChangeComputer(
+            ShareGroupChangeComputer computer = new ShareGroupChangeComputer(
                 Config.IS_CONFIG_DELETE_ORPHANS_ENABLED.get(context.configuration()));
-            return changeComputer.computeChanges(actualStates, expectedState);
+            return computer.computeChanges(actual, expected);
         }
     }
 

--- a/providers/jikkou-provider-kafka/src/main/java/io/jikkou/kafka/reconciler/service/KafkaAdminService.java
+++ b/providers/jikkou-provider-kafka/src/main/java/io/jikkou/kafka/reconciler/service/KafkaAdminService.java
@@ -11,8 +11,11 @@ import static io.jikkou.kafka.KafkaLabelAndAnnotations.JIKKOU_IO_KAFKA_IS_SIMPLE
 import io.jikkou.common.utils.AsyncUtils;
 import io.jikkou.common.utils.Strings;
 import io.jikkou.core.exceptions.JikkouRuntimeException;
+import io.jikkou.core.models.ConfigValue;
+import io.jikkou.core.models.Configs;
 import io.jikkou.core.models.ObjectMeta;
 import io.jikkou.kafka.collections.V1KafkaConsumerGroupList;
+import io.jikkou.kafka.collections.V1KafkaShareGroupList;
 import io.jikkou.kafka.internals.Futures;
 import io.jikkou.kafka.models.*;
 import io.jikkou.kafka.reconciler.service.KafkaOffsetSpec.ToEarliest;
@@ -21,13 +24,17 @@ import io.jikkou.kafka.reconciler.service.KafkaOffsetSpec.ToOffset;
 import io.jikkou.kafka.reconciler.service.KafkaOffsetSpec.ToTimestamp;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.kafka.clients.admin.*;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.ConsumerGroupState;
+import org.apache.kafka.common.GroupState;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.config.ConfigResource;
+import org.apache.kafka.common.errors.GroupIdNotFoundException;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -398,5 +405,225 @@ public final class KafkaAdminService {
                     }
                 ).toList())
             .flatMapMany(Flux::fromIterable);
+    }
+
+    /**
+     * Lists share groups for the specified states.
+     *
+     * @param inStates        Set of GroupState to filter; empty means all.
+     * @param describeOffsets Specify whether SPSO offsets should be described.
+     * @return The {@link V1KafkaShareGroupList}.
+     */
+    @NotNull
+    public V1KafkaShareGroupList listShareGroups(@NotNull Set<GroupState> inStates,
+                                                 boolean describeOffsets) {
+        ListGroupsOptions options = ListGroupsOptions.forShareGroups();
+        if (!inStates.isEmpty()) {
+            options = options.inGroupStates(inStates);
+        }
+        final List<String> groupIds = AsyncUtils.getValueOrThrowException(
+                Futures.toCompletableFuture(client.listGroups(options).all()),
+                e -> new JikkouRuntimeException(String.format(
+                    "Failed to list share groups. Cause %s: %s.",
+                    e.getClass().getSimpleName(), e.getLocalizedMessage())))
+            .stream()
+            .map(GroupListing::groupId)
+            .toList();
+        return listShareGroups(groupIds, describeOffsets);
+    }
+
+    /**
+     * Lists the specified share groups.
+     *
+     * @param groups          The share group ids.
+     * @param describeOffsets Specify whether SPSO offsets should be described.
+     * @return The {@link V1KafkaShareGroupList}.
+     */
+    @NotNull
+    public V1KafkaShareGroupList listShareGroups(@NotNull List<String> groups,
+                                                 boolean describeOffsets) {
+        if (groups.isEmpty()) {
+            return new V1KafkaShareGroupList.Builder().withItems(List.of()).build();
+        }
+        Map<String, ShareGroupDescription> described = AsyncUtils.getValueOrThrowException(
+                Futures.toCompletableFuture(client.describeShareGroups(groups).all()),
+                e -> new JikkouRuntimeException(String.format(
+                    "Failed to describe share groups. Cause %s: %s.",
+                    e.getClass().getSimpleName(), e.getLocalizedMessage())));
+
+        Map<String, Configs> configsByGroup = describeGroupConfigs(groups);
+
+        List<V1KafkaShareGroup> items = described.values().stream()
+            .map(this::mapToResource)
+            .map(group -> {
+                Configs configs = configsByGroup.getOrDefault(group.getMetadata().getName(), Configs.empty());
+                return group.withSpec(V1KafkaShareGroupSpec.builder().withConfigs(configs).build());
+            })
+            .map(group -> describeOffsets ? withShareGroupOffsets(group) : group)
+            .toList();
+        return new V1KafkaShareGroupList.Builder().withItems(items).build();
+    }
+
+    private V1KafkaShareGroup withShareGroupOffsets(@NotNull V1KafkaShareGroup group) {
+        String groupId = group.getMetadata().getName();
+        ListShareGroupOffsetsSpec spec = new ListShareGroupOffsetsSpec();
+        Map<TopicPartition, SharePartitionOffsetInfo> offsets = AsyncUtils.getValueOrThrowException(
+            Futures.toCompletableFuture(
+                client.listShareGroupOffsets(Map.of(groupId, spec)).partitionsToOffsetInfo(groupId)),
+            e -> new JikkouRuntimeException(String.format(
+                "Failed to list share group offsets for '%s'. Cause %s: %s.",
+                groupId, e.getClass().getSimpleName(), e.getLocalizedMessage())));
+        List<V1KafkaConsumerOffset> mapped = offsets.entrySet().stream()
+            .map(e -> new V1KafkaConsumerOffset(
+                e.getKey().topic(), e.getKey().partition(),
+                e.getValue().startOffset(), e.getValue().lag().orElse(-1L)))
+            .toList();
+        return group.withStatus(group.getStatus().withOffsets(mapped));
+    }
+
+    /**
+     * Maps a {@link ShareGroupDescription} to a {@link V1KafkaShareGroup} (status only).
+     *
+     * @param description the share group description.
+     * @return the {@link V1KafkaShareGroup}.
+     */
+    public V1KafkaShareGroup mapToResource(@NotNull ShareGroupDescription description) {
+        List<V1KafkaShareGroupMember> members = description.members().stream()
+            .map(this::mapToShareMember)
+            .toList();
+
+        V1KafkaShareGroupStatus status = V1KafkaShareGroupStatus.builder()
+            .withState(description.groupState().name())
+            .withCoordinator(V1KafkaNode.builder()
+                .withId(description.coordinator().idString())
+                .withHost(description.coordinator().host())
+                .withPort(description.coordinator().port())
+                .withRack(description.coordinator().rack())
+                .build())
+            .withMembers(members)
+            .build();
+
+        return V1KafkaShareGroup.builder()
+            .withMetadata(ObjectMeta.builder().withName(description.groupId()).build())
+            .withStatus(status)
+            .build();
+    }
+
+    private V1KafkaShareGroupMember mapToShareMember(@NotNull ShareMemberDescription member) {
+        List<String> assignments = member.assignment().topicPartitions().stream()
+            .map(TopicPartition::toString)
+            .toList();
+        return V1KafkaShareGroupMember.builder()
+            .withMemberId(member.consumerId())
+            .withClientId(member.clientId())
+            .withHost(member.host())
+            .withRackId(member.rackId().orElse(null))
+            .withAssignments(assignments)
+            .build();
+    }
+
+    /**
+     * Reads the user-set dynamic configs for the given group ids (GROUP resource type),
+     * filtered to {@code DYNAMIC_GROUP_CONFIG} so broker defaults are not treated as drift.
+     *
+     * @param groupIds the group ids.
+     * @return a map of group id to its dynamic {@link Configs}.
+     */
+    @NotNull
+    public Map<String, Configs> describeGroupConfigs(@NotNull List<String> groupIds) {
+        if (groupIds.isEmpty()) {
+            return Map.of();
+        }
+        List<ConfigResource> resources = groupIds.stream()
+            .map(id -> new ConfigResource(ConfigResource.Type.GROUP, id))
+            .toList();
+
+        // Resolve each resource individually so that a group with no dynamic config (which some
+        // brokers surface as GroupIdNotFoundException) is treated as having empty configs rather
+        // than failing the whole describe.
+        Map<ConfigResource, KafkaFuture<Config>> futures = client.describeConfigs(resources).values();
+        Map<String, Configs> result = new HashMap<>();
+        for (Map.Entry<ConfigResource, KafkaFuture<Config>> entry : futures.entrySet()) {
+            String groupId = entry.getKey().name();
+            try {
+                Config config = entry.getValue().get();
+                Set<ConfigValue> values = config.entries().stream()
+                    .filter(e -> e.source() == ConfigEntry.ConfigSource.DYNAMIC_GROUP_CONFIG)
+                    .map(e -> new ConfigValue(e.name(), e.value()))
+                    .collect(Collectors.toSet());
+                result.put(groupId, new Configs(values));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new JikkouRuntimeException(String.format(
+                    "Interrupted while describing configs for group '%s'.", groupId), e);
+            } catch (ExecutionException e) {
+                if (e.getCause() instanceof GroupIdNotFoundException) {
+                    result.put(groupId, Configs.empty());
+                } else {
+                    throw new JikkouRuntimeException(String.format(
+                        "Failed to describe configs for group '%s'. Cause %s: %s.",
+                        groupId, e.getCause().getClass().getSimpleName(), e.getCause().getLocalizedMessage()),
+                        e.getCause());
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Resets share-group offsets (SPSO) for the specified group and topics.
+     *
+     * @param groupId    The share group id.
+     * @param topics     The topics (each "topic" or "topic:partition").
+     * @param offsetSpec The offset specification (ToEarliest, ToLatest, ToOffset, ToTimestamp), or {@code null} to delete offsets.
+     * @param dryRun     Whether to run in dry-run.
+     * @return The refreshed {@link V1KafkaShareGroup}.
+     */
+    public V1KafkaShareGroup resetShareGroupOffsets(@NotNull String groupId,
+                                                    @NotNull List<String> topics,
+                                                    KafkaOffsetSpec offsetSpec,
+                                                    boolean dryRun) {
+        if (Strings.isNullOrEmpty(groupId)) {
+            throw new IllegalArgumentException("groupId cannot be null");
+        }
+
+        // delete offsets when no spec provided
+        if (offsetSpec == null) {
+            if (!dryRun) {
+                Set<String> topicNames = topics.stream()
+                    .map(TopicPartitionSelector::parse)
+                    .map(TopicPartitionSelector::topic)
+                    .collect(Collectors.toSet());
+                AsyncUtils.getValueOrThrowException(
+                    Futures.toCompletableFuture(client.deleteShareGroupOffsets(groupId, topicNames).all()),
+                    JikkouRuntimeException::new);
+            }
+            return listShareGroups(List.of(groupId), true).first();
+        }
+
+        Map<TopicPartition, Long> offsets;
+        if (offsetSpec instanceof ToOffset to) {
+            offsets = AsyncUtils.getValueOrThrowException(
+                    resolveTopicPartitions(parseSelectors(topics)), JikkouRuntimeException::new)
+                .stream()
+                .collect(Collectors.toMap(Function.identity(), tp -> to.offset()));
+        } else {
+            OffsetSpec spec = switch (offsetSpec) {
+                case ToEarliest ignored -> OffsetSpec.earliest();
+                case ToLatest ignored -> OffsetSpec.latest();
+                case ToTimestamp t -> OffsetSpec.forTimestamp(t.timestamp());
+                default -> throw new IllegalArgumentException("Unsupported offset specification: " + offsetSpec);
+            };
+            offsets = AsyncUtils.getValueOrThrowException(listOffsets(topics, spec), JikkouRuntimeException::new)
+                .entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().offset()));
+        }
+
+        if (!dryRun) {
+            AsyncUtils.getValueOrThrowException(
+                Futures.toCompletableFuture(client.alterShareGroupOffsets(groupId, offsets).all()),
+                JikkouRuntimeException::new);
+        }
+        return listShareGroups(List.of(groupId), true).first();
     }
 }

--- a/providers/jikkou-provider-kafka/src/main/json/V1KafkaConsumerGroup.json
+++ b/providers/jikkou-provider-kafka/src/main/json/V1KafkaConsumerGroup.json
@@ -4,7 +4,8 @@
   "description": "Manage consumer groups in a Kafka cluster.",
   "javaInterfaces": [
     "io.jikkou.core.models.Resource",
-    "io.jikkou.core.models.HasMetadata"
+    "io.jikkou.core.models.HasMetadata",
+    "io.jikkou.core.models.HasSpec<V1KafkaConsumerGroupSpec>"
   ],
   "additionalProperties": {
     "lombok-builder": true,
@@ -20,7 +21,11 @@
         ]
       },
       "verbs": [
-        "list"
+        "list",
+        "create",
+        "update",
+        "apply",
+        "delete"
       ]
     }
   },
@@ -45,11 +50,42 @@
     "template": {
       "$ref": "./Template.json"
     },
+    "spec": {
+      "$ref": "#/$defs/V1KafkaConsumerGroupSpec"
+    },
     "status": {
       "$ref": "#/$defs/V1KafkaConsumerGroupStatus"
     }
   },
   "$defs": {
+    "V1KafkaConsumerGroupSpec": {
+      "title": "V1KafkaConsumerGroupSpec",
+      "type": "object",
+      "javaInterfaces": [
+        "io.jikkou.core.models.HasConfigRefs"
+      ],
+      "additionalProperties": {
+        "lombok-builder": true,
+        "lombok-with": true,
+        "lombok-setter": true,
+        "all-args-constructor": false
+      },
+      "properties": {
+        "configs": {
+          "existingJavaType": "io.jikkou.core.models.Configs",
+          "description": "The consumer group dynamic configuration properties.",
+          "type": "object"
+        },
+        "configMapRefs": {
+          "type": "array",
+          "description": "The list of ConfigMap names from which to resolve consumer group configuration.",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        }
+      }
+    },
     "V1KafkaConsumerGroupStatus": {
       "title": "V1KafkaConsumerGroupStatus",
       "type": "object",

--- a/providers/jikkou-provider-kafka/src/main/json/V1KafkaShareGroup.json
+++ b/providers/jikkou-provider-kafka/src/main/json/V1KafkaShareGroup.json
@@ -1,0 +1,162 @@
+{
+  "type": "object",
+  "title": "V1KafkaShareGroup",
+  "description": "Manage share groups (queues) in a Kafka cluster.",
+  "javaInterfaces": [
+    "io.jikkou.core.models.Resource",
+    "io.jikkou.core.models.HasMetadata",
+    "io.jikkou.core.models.HasSpec<V1KafkaShareGroupSpec>"
+  ],
+  "additionalProperties": {
+    "lombok-builder": true,
+    "lombok-with": true,
+    "all-args-constructor": false,
+    "spec": {
+      "names": {
+        "singular": "kafkasharegroup",
+        "plural": "kafkasharegroups",
+        "local": "share-groups",
+        "shortNames": [
+          "ksg"
+        ]
+      },
+      "verbs": [
+        "list",
+        "create",
+        "update",
+        "apply",
+        "delete"
+      ]
+    }
+  },
+  "required": [
+    "apiVersion",
+    "kind",
+    "metadata"
+  ],
+  "properties": {
+    "apiVersion": {
+      "type": "string",
+      "default": "kafka.jikkou.io/v1"
+    },
+    "kind": {
+      "type": "string",
+      "default": "KafkaShareGroup"
+    },
+    "metadata": {
+      "$ref": "./Metadata.json"
+    },
+    "template": {
+      "$ref": "./Template.json"
+    },
+    "spec": {
+      "$ref": "#/$defs/V1KafkaShareGroupSpec"
+    },
+    "status": {
+      "$ref": "#/$defs/V1KafkaShareGroupStatus"
+    }
+  },
+  "$defs": {
+    "V1KafkaShareGroupSpec": {
+      "title": "V1KafkaShareGroupSpec",
+      "type": "object",
+      "javaInterfaces": [
+        "io.jikkou.core.models.HasConfigRefs"
+      ],
+      "additionalProperties": {
+        "lombok-builder": true,
+        "lombok-with": true,
+        "lombok-setter": true,
+        "all-args-constructor": false
+      },
+      "properties": {
+        "configs": {
+          "existingJavaType": "io.jikkou.core.models.Configs",
+          "description": "The share group dynamic configuration properties.",
+          "type": "object"
+        },
+        "configMapRefs": {
+          "type": "array",
+          "description": "The list of ConfigMap names from which to resolve share group configuration.",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        }
+      }
+    },
+    "V1KafkaShareGroupStatus": {
+      "title": "V1KafkaShareGroupStatus",
+      "type": "object",
+      "additionalProperties": {
+        "lombok-builder": true,
+        "lombok-with": true,
+        "all-args-constructor": false
+      },
+      "properties": {
+        "state": {
+          "type": "string",
+          "description": "The share group state."
+        },
+        "members": {
+          "type": "array",
+          "description": "List of share group members.",
+          "items": {
+            "$ref": "#/$defs/V1KafkaShareGroupMember"
+          }
+        },
+        "offsets": {
+          "type": "array",
+          "description": "List of share-partition start offsets.",
+          "items": {
+            "type": "object",
+            "$ref": "./V1KafkaConsumerGroup.json#/$defs/V1KafkaConsumerOffset"
+          }
+        },
+        "coordinator": {
+          "type": "object",
+          "description": "The broker node responsible for coordinating this group.",
+          "$ref": "./V1KafkaConsumerGroup.json#/$defs/V1KafkaNode"
+        }
+      }
+    },
+    "V1KafkaShareGroupMember": {
+      "title": "V1KafkaShareGroupMember",
+      "type": "object",
+      "description": "Detailed description of a single share group member.",
+      "additionalProperties": {
+        "lombok-builder": true,
+        "lombok-with": true,
+        "all-args-constructor": false
+      },
+      "required": [
+        "memberId"
+      ],
+      "properties": {
+        "memberId": {
+          "type": "string",
+          "description": "The member ID."
+        },
+        "clientId": {
+          "type": "string",
+          "description": "The client ID."
+        },
+        "host": {
+          "type": "string",
+          "description": "The member host."
+        },
+        "rackId": {
+          "type": "string",
+          "description": "The rack ID of the member."
+        },
+        "assignments": {
+          "description": "List of topic-partitions assigned to the member.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/providers/jikkou-provider-kafka/src/test/java/io/jikkou/kafka/change/consumer/ConsumerGroupChangeComputerTest.java
+++ b/providers/jikkou-provider-kafka/src/test/java/io/jikkou/kafka/change/consumer/ConsumerGroupChangeComputerTest.java
@@ -1,0 +1,44 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.jikkou.kafka.change.consumer;
+
+import io.jikkou.core.models.Configs;
+import io.jikkou.core.models.ObjectMeta;
+import io.jikkou.core.models.change.ResourceChange;
+import io.jikkou.core.reconciler.Operation;
+import io.jikkou.kafka.models.V1KafkaConsumerGroup;
+import io.jikkou.kafka.models.V1KafkaConsumerGroupSpec;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class ConsumerGroupChangeComputerTest {
+
+    private static V1KafkaConsumerGroup group(String name, Configs configs) {
+        return V1KafkaConsumerGroup.builder()
+            .withMetadata(ObjectMeta.builder().withName(name).build())
+            .withSpec(V1KafkaConsumerGroupSpec.builder().withConfigs(configs).build())
+            .build();
+    }
+
+    @Test
+    void shouldComputeUpdateWhenConfigDrifts() {
+        V1KafkaConsumerGroup actual = group("g1", Configs.of("consumer.session.timeout.ms", "45000"));
+        V1KafkaConsumerGroup desired = group("g1", Configs.of("consumer.session.timeout.ms", "30000"));
+        List<ResourceChange> changes = new ConsumerGroupChangeComputer(false)
+            .computeChanges(List.of(actual), List.of(desired));
+        Assertions.assertEquals(Operation.UPDATE, changes.get(0).getSpec().getOp());
+    }
+
+    @Test
+    void shouldComputeNoneWhenConfigMatches() {
+        V1KafkaConsumerGroup same = group("g1", Configs.of("consumer.session.timeout.ms", "30000"));
+        List<ResourceChange> changes = new ConsumerGroupChangeComputer(false)
+            .computeChanges(List.of(same), List.of(same));
+        Assertions.assertEquals(Operation.NONE, changes.get(0).getSpec().getOp());
+    }
+}

--- a/providers/jikkou-provider-kafka/src/test/java/io/jikkou/kafka/change/group/GroupConfigsTest.java
+++ b/providers/jikkou-provider-kafka/src/test/java/io/jikkou/kafka/change/group/GroupConfigsTest.java
@@ -1,0 +1,50 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.jikkou.kafka.change.group;
+
+import io.jikkou.core.models.Configs;
+import io.jikkou.core.models.change.StateChange;
+import io.jikkou.core.reconciler.Operation;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class GroupConfigsTest {
+
+    @Test
+    void shouldComputeSetChangeForNewConfig() {
+        Configs after = Configs.of("share.auto.offset.reset", "earliest");
+        List<StateChange> changes = GroupConfigs.getConfigChanges(null, after, false);
+        Assertions.assertEquals(1, changes.size());
+        StateChange change = changes.get(0);
+        Assertions.assertEquals("config.share.auto.offset.reset", change.getName());
+        Assertions.assertEquals(Operation.CREATE, change.getOp());
+        Assertions.assertEquals("earliest", change.getAfter());
+    }
+
+    @Test
+    void shouldComputeUpdateChangeForChangedConfig() {
+        Configs before = Configs.of("share.record.lock.duration.ms", "15000");
+        Configs after = Configs.of("share.record.lock.duration.ms", "30000");
+        List<StateChange> changes = GroupConfigs.getConfigChanges(before, after, false);
+        Assertions.assertEquals(Operation.UPDATE, changes.get(0).getOp());
+    }
+
+    @Test
+    void shouldNotDeleteOrphanWhenDeletionDisabled() {
+        Configs before = Configs.of("share.auto.offset.reset", "earliest");
+        List<StateChange> changes = GroupConfigs.getConfigChanges(before, null, false);
+        Assertions.assertTrue(changes.stream().noneMatch(c -> c.getOp() == Operation.DELETE));
+    }
+
+    @Test
+    void shouldDeleteOrphanWhenDeletionEnabled() {
+        Configs before = Configs.of("share.auto.offset.reset", "earliest");
+        List<StateChange> changes = GroupConfigs.getConfigChanges(before, null, true);
+        Assertions.assertEquals(Operation.DELETE, changes.get(0).getOp());
+    }
+}

--- a/providers/jikkou-provider-kafka/src/test/java/io/jikkou/kafka/change/group/UpdateGroupConfigsHandlerTest.java
+++ b/providers/jikkou-provider-kafka/src/test/java/io/jikkou/kafka/change/group/UpdateGroupConfigsHandlerTest.java
@@ -1,0 +1,66 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.jikkou.kafka.change.group;
+
+import io.jikkou.core.models.ObjectMeta;
+import io.jikkou.core.models.change.GenericResourceChange;
+import io.jikkou.core.models.change.ResourceChange;
+import io.jikkou.core.models.change.ResourceChangeSpec;
+import io.jikkou.core.models.change.StateChange;
+import io.jikkou.core.reconciler.ChangeResponse;
+import io.jikkou.core.reconciler.Operation;
+import io.jikkou.kafka.models.V1KafkaConsumerGroup;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AlterConfigOp;
+import org.apache.kafka.clients.admin.AlterConfigsResult;
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.config.ConfigResource;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+class UpdateGroupConfigsHandlerTest {
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldAlterGroupConfigsWithGroupResourceType() {
+        AdminClient client = Mockito.mock(AdminClient.class);
+        AlterConfigsResult result = Mockito.mock(AlterConfigsResult.class);
+        Mockito.when(result.values()).thenReturn(Map.of(
+            new ConfigResource(ConfigResource.Type.GROUP, "g1"), KafkaFuture.completedFuture(null)));
+        ArgumentCaptor<Map<ConfigResource, Collection<AlterConfigOp>>> captor =
+            ArgumentCaptor.forClass(Map.class);
+        Mockito.when(client.incrementalAlterConfigs(captor.capture())).thenReturn(result);
+
+        ResourceChange change = GenericResourceChange.builder(V1KafkaConsumerGroup.class)
+            .withMetadata(ObjectMeta.builder().withName("g1").build())
+            .withSpec(ResourceChangeSpec.builder()
+                .withOperation(Operation.UPDATE)
+                .withChanges(List.of(StateChange.builder()
+                    .withName("config.share.auto.offset.reset")
+                    .withOp(Operation.CREATE)
+                    .withAfter("earliest")
+                    .build()))
+                .build())
+            .build();
+
+        UpdateGroupConfigsHandler handler = new UpdateGroupConfigsHandler(client);
+        List<ChangeResponse> responses = handler.handleChanges(List.of(change));
+
+        Assertions.assertEquals(1, responses.size());
+        ConfigResource resource = captor.getValue().keySet().iterator().next();
+        Assertions.assertEquals(ConfigResource.Type.GROUP, resource.type());
+        Assertions.assertEquals("g1", resource.name());
+        AlterConfigOp op = captor.getValue().values().iterator().next().iterator().next();
+        Assertions.assertEquals(AlterConfigOp.OpType.SET, op.opType());
+        Assertions.assertEquals("share.auto.offset.reset", op.configEntry().name());
+    }
+}

--- a/providers/jikkou-provider-kafka/src/test/java/io/jikkou/kafka/change/share/ShareGroupChangeComputerTest.java
+++ b/providers/jikkou-provider-kafka/src/test/java/io/jikkou/kafka/change/share/ShareGroupChangeComputerTest.java
@@ -1,0 +1,53 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.jikkou.kafka.change.share;
+
+import io.jikkou.core.models.Configs;
+import io.jikkou.core.models.ObjectMeta;
+import io.jikkou.core.models.change.ResourceChange;
+import io.jikkou.core.reconciler.Operation;
+import io.jikkou.kafka.models.V1KafkaShareGroup;
+import io.jikkou.kafka.models.V1KafkaShareGroupSpec;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class ShareGroupChangeComputerTest {
+
+    private static V1KafkaShareGroup group(String name, Configs configs) {
+        return V1KafkaShareGroup.builder()
+            .withMetadata(ObjectMeta.builder().withName(name).build())
+            .withSpec(V1KafkaShareGroupSpec.builder().withConfigs(configs).build())
+            .build();
+    }
+
+    @Test
+    void shouldComputeCreateWhenGroupAbsent() {
+        V1KafkaShareGroup desired = group("g1", Configs.of("share.auto.offset.reset", "earliest"));
+        List<ResourceChange> changes = new ShareGroupChangeComputer(false)
+            .computeChanges(List.of(), List.of(desired));
+        Assertions.assertEquals(1, changes.size());
+        Assertions.assertEquals(Operation.CREATE, changes.get(0).getSpec().getOp());
+    }
+
+    @Test
+    void shouldComputeUpdateWhenConfigDrifts() {
+        V1KafkaShareGroup actual = group("g1", Configs.of("share.auto.offset.reset", "latest"));
+        V1KafkaShareGroup desired = group("g1", Configs.of("share.auto.offset.reset", "earliest"));
+        List<ResourceChange> changes = new ShareGroupChangeComputer(false)
+            .computeChanges(List.of(actual), List.of(desired));
+        Assertions.assertEquals(Operation.UPDATE, changes.get(0).getSpec().getOp());
+    }
+
+    @Test
+    void shouldComputeNoneWhenConfigMatches() {
+        V1KafkaShareGroup same = group("g1", Configs.of("share.auto.offset.reset", "earliest"));
+        List<ResourceChange> changes = new ShareGroupChangeComputer(false)
+            .computeChanges(List.of(same), List.of(same));
+        Assertions.assertEquals(Operation.NONE, changes.get(0).getSpec().getOp());
+    }
+}

--- a/providers/jikkou-provider-kafka/src/test/java/io/jikkou/kafka/reconciler/service/KafkaAdminServiceShareGroupTest.java
+++ b/providers/jikkou-provider-kafka/src/test/java/io/jikkou/kafka/reconciler/service/KafkaAdminServiceShareGroupTest.java
@@ -1,0 +1,55 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.jikkou.kafka.reconciler.service;
+
+import io.jikkou.kafka.models.V1KafkaShareGroup;
+import io.jikkou.kafka.models.V1KafkaShareGroupMember;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.ShareGroupDescription;
+import org.apache.kafka.clients.admin.ShareMemberAssignment;
+import org.apache.kafka.clients.admin.ShareMemberDescription;
+import org.apache.kafka.common.GroupState;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class KafkaAdminServiceShareGroupTest {
+
+    @Test
+    void shouldMapShareGroupDescriptionToResource() {
+        ShareMemberDescription member = new ShareMemberDescription(
+            "member-1",
+            Optional.of("rack-1"),
+            "client-1",
+            "host-1",
+            new ShareMemberAssignment(Set.of(new TopicPartition("orders", 0))),
+            5);
+        ShareGroupDescription description = new ShareGroupDescription(
+            "orders-queue",
+            List.of(member),
+            GroupState.STABLE,
+            new Node(1, "broker-1", 9092),
+            1,
+            1);
+
+        KafkaAdminService service = new KafkaAdminService(Mockito.mock(AdminClient.class));
+        V1KafkaShareGroup group = service.mapToResource(description);
+
+        Assertions.assertEquals("orders-queue", group.getMetadata().getName());
+        Assertions.assertEquals("STABLE", group.getStatus().getState());
+        List<V1KafkaShareGroupMember> members = group.getStatus().getMembers();
+        Assertions.assertEquals(1, members.size());
+        Assertions.assertEquals("member-1", members.get(0).getMemberId());
+        Assertions.assertEquals("rack-1", members.get(0).getRackId());
+        Assertions.assertEquals(List.of("orders-0"), members.get(0).getAssignments());
+    }
+}


### PR DESCRIPTION
## Summary

Adds support for **Apache Kafka 4.x Share Groups (Queues, KIP-932)** and **declarative dynamic group configuration** for both share groups and consumer groups.

- **New `V1KafkaShareGroup` resource** (`kind: KafkaShareGroup`, short name `ksg`): collect/describe (state, members incl. rackId, SPSO offsets, coordinator), declarative `spec.configs`, delete, and a `KafkaShareGroupsResetOffsets` action (to-earliest/latest/offset, delete-offsets).
- **Declarative `spec.configs` on `V1KafkaConsumerGroup`** — consumer groups gained dynamic group-level configuration in Kafka 4.x; now reconciled like topic configs.
- **Shared `change/group/` helper** (`GroupConfigs` + `UpdateGroupConfigsHandler`) diffs and applies configs against `ConfigResource.Type.GROUP`, reused by both group types; reads filter to `DYNAMIC_GROUP_CONFIG` so broker defaults aren't treated as drift.
- Built on the AdminClient share-group APIs already present in the bundled Kafka 4.3.0 client (`listGroups`, `describeShareGroups`, `alter/list/deleteShareGroupOffsets`, `deleteShareGroups`).

No dependency bump required.

## Test Plan

- [x] Unit tests (172 pass), incl. new `GroupConfigsTest`, `UpdateGroupConfigsHandlerTest`, `ShareGroupChangeComputerTest`, `ConsumerGroupChangeComputerTest`, `KafkaAdminServiceShareGroupTest`
- [x] Integration test `AdminClientShareGroupIT` (gated by `-Dit.kafka.shareGroups=true`) passes against a share-group-enabled `apache/kafka:4.3.0` broker
- [x] e2e manifests + `run-tests.sh` scenarios added; e2e Confluent stack bumped to `8.2.0` (AK 4.x) with `group.share.enable=true`. Broker boots healthy and GROUP config alter / share-group listing verified manually.
- [ ] Full native `make e2e-test` run to confirm the existing 25 e2e tests on the 8.2.0 stack (not run in this environment — needs GraalVM native build)
- [x] `spotless:check` and the bound `spotbugs:spotbugs` goal pass

## Notes

- The independent SASL e2e broker is intentionally left on `cp-kafka:7.5.0` (unrelated to share groups).
- Share group operations require a Kafka 4.x broker with `group.share.enable=true`; documented on the new resource/action pages.