### PR TITLE
docs: expand how-to guides and tutorials per Diátaxis

### DIFF
--- a/docs/assets/scss/_styles_project.scss
+++ b/docs/assets/scss/_styles_project.scss
@@ -1077,7 +1077,7 @@ p > a, li > a {
 
 .td-sidebar-nav__section-title a {
     color: #1e293b !important;
-    font-weight: 600;
+    font-weight: 300;
     letter-spacing: -0.01em;
     &:hover {
         color: $purple !important;
@@ -1086,13 +1086,20 @@ p > a, li > a {
 
 // Left sidebar styling
 .td-sidebar-nav {
+    // Consistent menu weights: every entry is light regardless of whether it is
+    // a section (folder with _index.md) or a leaf page. Only the active item is
+    // emphasized. Overrides Docsy's __section / __page / tree-root weighting.
     .td-sidebar-link {
         color: #475569;
         font-size: 0.9375rem;
         letter-spacing: -0.01em;
         line-height: 1.5;
+        font-weight: 300;
         &:hover {
             color: $purple;
+        }
+        &.tree-root {
+            font-weight: 300;
         }
         &.active {
             color: $purple !important;

--- a/docs/content/en/docs/Community/Developer guide/_index.md
+++ b/docs/content/en/docs/Community/Developer guide/_index.md
@@ -1,13 +1,17 @@
 ---
-title: "Developer Guide"
-linkTitle: "Developer Guide"
+title: "Building from Source"
+linkTitle: "Building from Source"
 weight: 10
 description: >
-    How to set up your environment for developing on Jikkou.
+    How to set up your environment to build and test Jikkou itself.
 ---
 
+{{% pageinfo %}}
+This guide is for contributors who want to build and test the Jikkou project itself. If you are looking to develop your own Jikkou extensions or use the Java API, see the [Developer Guide]({{% relref "/docs/Developer Guide" %}}) instead.
+{{% /pageinfo %}}
+
 ## Prerequisites
-* Jdk 17 (see https://sdkman.io/ for installing java locally)
+* Java 25 (see https://sdkman.io/ for installing java locally)
 * Git
 * [Docker](https://docs.docker.com/get-docker/) and [Docker-Compose](https://docs.docker.com/compose/install/)
 * Your favorite IDE

--- a/docs/content/en/docs/Community/_index.md
+++ b/docs/content/en/docs/Community/_index.md
@@ -3,8 +3,13 @@ title: "Community"
 linkTitle: "Community"
 weight: 7
 description: >
-  What does your user need to know to try your project?
+  Get involved with the Jikkou community — contribute code or docs, build Jikkou from source, and find blog posts, talks, and other resources.
 ---
 
 {{% pageinfo %}}
+Jikkou is an open-source project. This section explains how to contribute, how to build Jikkou from source, and where to find community resources such as blog posts and talks.
 {{% /pageinfo %}}
+
+* [**Contribution Guidelines**]({{% relref "./Contribution guidelines" %}}) — how to report issues and submit pull requests.
+* [**Building from Source**]({{% relref "./Developer guide" %}}) — set up your environment to build and test Jikkou itself.
+* [**Resources**]({{% relref "./Resources" %}}) — blog posts, guides, and talks about GitOps for Apache Kafka with Jikkou.

--- a/docs/content/en/docs/How-to Guides/Backup-and-Restore.md
+++ b/docs/content/en/docs/How-to Guides/Backup-and-Restore.md
@@ -1,0 +1,72 @@
+---
+title: "Back Up and Restore Configuration"
+linkTitle: "Back Up & Restore"
+weight: 50
+description: >
+  Export the current state of a cluster to YAML for backup or replication, then restore it elsewhere.
+---
+
+Because Jikkou is stateless and uses your platform as the source of truth, you can export the live state
+of any managed resource to YAML. Those files can be version-controlled, used as a backup, or applied to
+another cluster to replicate its configuration.
+
+## Before you begin
+
+* A Jikkou context configured for the source cluster — see [Getting Started]({{% relref "/docs/Tutorials/get_started.md" %}}).
+
+## 1. Export resources to a file
+
+Use `jikkou get <kind>` with YAML output and redirect it to a file:
+
+```bash
+jikkou get kafkatopics -o yaml > topics-backup.yaml
+```
+
+The same pattern works for any managed resource kind. List the kinds available in your context — and
+the exact names accepted by `get` — with:
+
+```bash
+jikkou api-resources
+```
+
+Then export each kind to build a full snapshot, for example:
+
+```bash
+jikkou get kafkatopics -o yaml > topics-backup.yaml
+jikkou get kafkaprincipalauthorizations -o yaml > acls-backup.yaml
+```
+
+{{% alert title="Tip" color="info" %}}
+Add `--default-configs` to `jikkou get kafkatopics` to include built-in default config values in the
+export. Use `--selector` to back up only a subset of resources.
+{{% /alert %}}
+
+## 2. Restore or replicate
+
+Point Jikkou at the target cluster (e.g. switch context with `jikkou config use-context <name>`), then
+preview and apply the exported files:
+
+```bash
+jikkou apply --files ./topics-backup.yaml --dry-run   # review
+jikkou apply --files ./topics-backup.yaml             # apply
+```
+
+This same flow lets you **replicate** configuration from one cluster to another: export from the source,
+switch context, and apply to the target.
+
+{{% alert title="Recommendation" color="warning" %}}
+When restoring with `apply`, Jikkou reconciles the target to the declared state — resources present on
+the target but absent from your files may be altered or deleted. Always run with `--dry-run` first and
+scope changes with `--selector`.
+{{% /alert %}}
+
+## Automate periodic backups
+
+Run the export commands on a schedule (e.g. a cron job or a CI pipeline) and commit the output to a Git
+repository to keep a versioned history of your cluster configuration. See
+[Automating]({{% relref "Automating" %}}) for running Jikkou in CI/CD.
+
+## Related
+
+* [`jikkou get` command reference]({{% relref "/docs/Reference/CLI/Commands/jikkou-get.md" %}})
+* [Automating Jikkou in CI/CD]({{% relref "Automating" %}})

--- a/docs/content/en/docs/How-to Guides/Enforce-Policies.md
+++ b/docs/content/en/docs/How-to Guides/Enforce-Policies.md
@@ -1,0 +1,109 @@
+---
+title: "Enforce Governance Policies"
+linkTitle: "Enforce Policies"
+weight: 60
+description: >
+  Use ValidatingResourcePolicy to enforce organizational rules on resources and changes with CEL.
+---
+
+A `ValidatingResourcePolicy` is a declarative, reusable way to enforce governance rules across *any*
+resource using [Google CEL](https://cel.dev/) expressions. Use it to block destructive operations,
+enforce limits (partitions, replication factor), or require naming and metadata conventions.
+
+For the full specification, see the
+[ValidatingResourcePolicy reference]({{% relref "/docs/Reference/Providers/Core/Resources/ValidatingResourcePolicy.md" %}}).
+For the broader picture, see [Validations]({{% relref "/docs/Concepts/validations.md" %}}).
+
+## Before you begin
+
+* A Jikkou context configured for your platform — see [Getting Started]({{% relref "/docs/Tutorials/get_started.md" %}}).
+
+## 1. Write a policy
+
+A policy selects the resources it applies to and defines rules. Each rule's `expression` fails when it
+evaluates to `true`. The `failurePolicy` decides what happens on failure:
+
+* `FAIL` — abort the operation with an error.
+* `FILTER` — silently drop the invalid resource(s) and continue.
+
+_`file: policy-topics.yaml`_
+
+```yaml
+---
+apiVersion: core.jikkou.io/v1
+kind: ValidatingResourcePolicy
+metadata:
+  name: KafkaTopicPolicy
+spec:
+  failurePolicy: FAIL
+  selector:
+    matchResources:
+      - kind: KafkaTopic
+  rules:
+    - name: MaxTopicPartitions
+      expression: "resource.spec.partitions > 50"
+      messageExpression: "'Topic partitions MUST be <= 50, but was: ' + string(resource.spec.partitions)"
+    - name: MinTopicPartitions
+      expression: "resource.spec.partitions < 3"
+      message: "Topic must have at least 3 partitions"
+```
+
+## 2. Apply resources with the policy
+
+Policies are transient resources: pass the policy file alongside the resources being validated. Jikkou
+evaluates the policy during reconciliation.
+
+```bash
+jikkou apply --files ./kafka-topics.yaml --files ./policy-topics.yaml --dry-run
+```
+
+If a topic violates a rule, a `FAIL` policy stops the run and prints the rule's message.
+
+## Block destructive operations
+
+Policies can match **change** resources (e.g. `KafkaTopicChange`) to control operations. This example
+filters out delete operations on topics so they are never executed:
+
+```yaml
+---
+apiVersion: core.jikkou.io/v1
+kind: ValidatingResourcePolicy
+metadata:
+  name: BlockTopicDeletes
+spec:
+  failurePolicy: FILTER
+  selector:
+    matchResources:
+      - kind: KafkaTopicChange
+  rules:
+    - name: FilterDeleteOperation
+      expression: "resource.spec.op == 'DELETE'"
+      messageExpression: "'Operation ' + resource.spec.op + ' on topics is not authorized'"
+```
+
+## Target a subset of resources
+
+Combine `matchResources`, `matchLabels`, and `matchExpressions` (with `matchingStrategy: ALL` or `ANY`)
+to scope a policy. For example, apply it only to topics in the `prod` environment:
+
+```yaml
+selector:
+  matchingStrategy: ALL
+  matchResources:
+    - kind: KafkaTopic
+  matchLabels:
+    - key: environment
+      operator: In
+      values: ["prod"]
+```
+
+## Reuse policies across environments
+
+Store policies in a [resource repository]({{% relref "/docs/Concepts/repositories.md" %}}) so they are injected
+automatically and shared across teams and environments, instead of passing them on every command.
+
+## Related
+
+* [ValidatingResourcePolicy reference]({{% relref "/docs/Reference/Providers/Core/Resources/ValidatingResourcePolicy.md" %}})
+* [Validations concept]({{% relref "/docs/Concepts/validations.md" %}})
+* [Manage Kafka ACLs]({{% relref "Manage-Kafka-ACLs.md" %}})

--- a/docs/content/en/docs/How-to Guides/Install/_index.md
+++ b/docs/content/en/docs/How-to Guides/Install/_index.md
@@ -9,7 +9,7 @@ aliases:
 ---
 
 {{% pageinfo %}}
-Jikkou can be installed either from source, or from releases.
+This guide covers installing the **Jikkou CLI**, either from source or from releases. To install the REST server, see [Install API Server]({{% relref "api-server.md" %}}).
 {{% /pageinfo %}}
 
 ## From SDKMan! (recommended)

--- a/docs/content/en/docs/How-to Guides/Install/api-server.md
+++ b/docs/content/en/docs/How-to Guides/Install/api-server.md
@@ -3,7 +3,7 @@ title: "Install Jikkou API Server"
 linkTitle: "Install API Server"
 weight: 2
 description: >
-  This guide shows how to install Jikkou API Server.
+  This guide shows how to install the Jikkou API Server.
 aliases:
   - /docs/jikkou-api-server/install/
 ---
@@ -21,7 +21,7 @@ Follow these few steps to download the latest stable versions and get started.
 
 #### Prerequisites
 
-To be able to run Jikkou API Server, the only requirement is to have a working Java 21 installation. 
+To be able to run Jikkou API Server, the only requirement is to have a working Java 25 installation.
 You can check the correct installation of Java by issuing the following command:
 
 ```bash
@@ -30,7 +30,7 @@ java -version
 
 #### Step 1: Download
 
-Download the latest Java binary distribution from the [GitHub Releases](https://github.com/streamthoughts/jikkou/releases) (e.g. `jikkou-api-server-0.36.0.zip`)
+Download the latest Java binary distribution from the [GitHub Releases](https://github.com/streamthoughts/jikkou/releases) (e.g. `jikkou-api-server-$LATEST_VERSION.zip`)
 
 Unpack the download distribution and move the unpacked directory to a desired destination
 
@@ -47,14 +47,14 @@ Launch the application with:
 ./bin/jikkou-api-server.sh
 ```
 
-#### Step 3: Test the API Server 
+#### Step 3: Test the API Server
 
 ```bash
 $ curl -sX GET http://localhost:28082 -H "Accept: application/json" | jq
 
 {
-  "version": "0.31.0",
-  "build_time": "2023-11-14T18:07:38+0000",
+  "version": "0.37.0",
+  "build_time": "2025-08-26T00:00:00+0000",
   "commit_id": "dae1be11c092256f36c18c8f1d90f16b0c951716",
   "_links": {
     "self": {
@@ -100,3 +100,8 @@ However, they offer the opportunity to test the cutting edge features.
 ```bash
 $ docker run -it streamthoughts/jikkou-api-server:main
 ```
+
+## Next Steps
+
+* Configure the server — see the [API Server reference]({{% relref "/docs/Reference/API Server" %}}).
+* Point the CLI at the server using [proxy mode]({{% relref "/docs/Reference/API Server/Configuration/cli_proxy_mode.md" %}}).

--- a/docs/content/en/docs/How-to Guides/Manage-Connectors.md
+++ b/docs/content/en/docs/How-to Guides/Manage-Connectors.md
@@ -1,0 +1,68 @@
+---
+title: "Manage Kafka Connect Connectors"
+linkTitle: "Manage Connectors"
+weight: 30
+description: >
+  Deploy, configure, and control the lifecycle of Kafka Connect connectors as code.
+---
+
+This guide shows how to manage Kafka Connect connectors with Jikkou. For the full resource
+specification, see the [KafkaConnector reference]({{% relref "/docs/Reference/Providers/Kafka Connect/Resources/connector.md" %}}).
+
+## Before you begin
+
+* One or more reachable Kafka Connect clusters.
+* Each cluster declared under the `kafkaConnect.clusters[]` setting in your Jikkou configuration —
+  see the [Kafka Connect provider configuration]({{% relref "/docs/Reference/Providers/Kafka Connect/Configuration" %}}).
+
+## 1. Describe a connector
+
+The `kafka.jikkou.io/connect-cluster` label selects which configured cluster the connector is created in.
+
+_`file: kafka-connector-filestream-sink.yaml`_
+
+```yaml
+---
+apiVersion: "kafka.jikkou.io/v1beta1"
+kind: "KafkaConnector"
+metadata:
+  name: "local-file-sink"
+  labels:
+    kafka.jikkou.io/connect-cluster: "my-connect-cluster"
+spec:
+  connectorClass: "FileStreamSink"
+  tasksMax: 1
+  config:
+    file: "/tmp/test.sink.txt"
+    topics: "connect-test"
+  state: "running"
+```
+
+## 2. Preview and apply
+
+```bash
+jikkou apply --files ./kafka-connector-filestream-sink.yaml --dry-run   # review
+jikkou apply --files ./kafka-connector-filestream-sink.yaml             # apply
+```
+
+## 3. Control the connector lifecycle
+
+Set `spec.state` and re-apply to change the runtime state of a connector:
+
+* `running` — connector and tasks are active (default).
+* `paused` — message processing is paused until resumed.
+* `stopped` — connector and tasks are shut down; the config is kept.
+
+## 4. Inspect connector status
+
+```bash
+jikkou get kafkaconnectors --expand-status
+```
+
+The `status.connectorStatus` block reports the live state of the connector and its tasks as returned
+by the Kafka Connect REST API.
+
+## Related
+
+* [KafkaConnector reference]({{% relref "/docs/Reference/Providers/Kafka Connect/Resources/connector.md" %}})
+* [Restart connectors action]({{% relref "/docs/Reference/Providers/Kafka Connect/Actions" %}})

--- a/docs/content/en/docs/How-to Guides/Manage-Iceberg-Tables.md
+++ b/docs/content/en/docs/How-to Guides/Manage-Iceberg-Tables.md
@@ -1,0 +1,110 @@
+---
+title: "Manage Apache Iceberg Tables"
+linkTitle: "Manage Iceberg Tables"
+weight: 40
+description: >
+  Create Iceberg namespaces and tables, and evolve table schemas safely, as code.
+---
+
+This guide shows how to manage Apache Iceberg namespaces and tables with Jikkou, including safe schema
+evolution. For the full resource specification, see the
+[Iceberg Table reference]({{% relref "/docs/Reference/Providers/ApacheIceberg/Resources/iceberg-table.md" %}}).
+
+## Before you begin
+
+* Access to an Iceberg catalog (REST, Hive, JDBC, Glue, …) and its backing storage.
+* A Jikkou context configured with the Iceberg provider — see the
+  [Apache Iceberg provider configuration]({{% relref "/docs/Reference/Providers/ApacheIceberg/Configuration" %}}).
+
+## 1. Create a namespace
+
+_`file: iceberg-namespace.yaml`_
+
+```yaml
+---
+apiVersion: "iceberg.jikkou.io/v1beta1"
+kind: "IcebergNamespace"
+metadata:
+  name: "analytics.events"
+```
+
+```bash
+jikkou apply --files ./iceberg-namespace.yaml --dry-run   # review
+jikkou apply --files ./iceberg-namespace.yaml             # apply
+```
+
+## 2. Create a table
+
+_`file: iceberg-page-views.yaml`_
+
+```yaml
+---
+apiVersion: "iceberg.jikkou.io/v1beta1"
+kind: "IcebergTable"
+metadata:
+  name: "analytics.events.page_views"
+spec:
+  schema:
+    columns:
+      - name: "event_id"
+        type: "uuid"
+        required: true
+      - name: "user_id"
+        type: "long"
+        required: true
+      - name: "page_url"
+        type: "string"
+        required: true
+      - name: "event_time"
+        type: "timestamptz"
+        required: true
+  partitionFields:
+    - sourceColumn: "event_time"
+      transform: "day"
+  sortFields:
+    - column: "event_time"
+      direction: "asc"
+  properties:
+    write.format.default: "parquet"
+    write.parquet.compression-codec: "zstd"
+```
+
+```bash
+jikkou apply --files ./iceberg-page-views.yaml
+```
+
+## 3. Evolve the schema safely
+
+To add, update, or drop columns, edit the resource and re-apply. Jikkou performs safe schema evolution
+and preserves Iceberg field IDs.
+
+To **rename** a column without breaking existing readers, set `previousName` to the old name instead of
+dropping and re-adding it:
+
+```yaml
+columns:
+  - name: "user_identifier"   # new name
+    previousName: "user_id"   # triggers a rename, not drop+add
+    type: "long"
+    required: true
+```
+
+By default Jikkou rejects unsafe type changes (e.g. `string → int`). Safe promotions such as
+`int → long` are allowed. To force an incompatible change on a single resource, set the annotation
+`iceberg.jikkou.io/allow-incompatible-changes: "true"`.
+
+{{% alert title="Warning" color="warning" %}}
+Incompatible schema changes may break existing data readers. Use the override annotation only when you
+are certain all consumers can handle the new schema.
+{{% /alert %}}
+
+## Manage many tables at once
+
+Use an `IcebergTableList` (handy with [templating]({{% relref "/docs/Concepts/template.md" %}})) to define multiple
+tables in a single file.
+
+## Related
+
+* [Iceberg Table reference]({{% relref "/docs/Reference/Providers/ApacheIceberg/Resources/iceberg-table.md" %}})
+* [Iceberg Namespace reference]({{% relref "/docs/Reference/Providers/ApacheIceberg/Resources/iceberg-namespace.md" %}})
+* [Iceberg View reference]({{% relref "/docs/Reference/Providers/ApacheIceberg/Resources/iceberg-view.md" %}})

--- a/docs/content/en/docs/How-to Guides/Manage-Kafka-ACLs.md
+++ b/docs/content/en/docs/How-to Guides/Manage-Kafka-ACLs.md
@@ -1,0 +1,109 @@
+---
+title: "Manage Kafka ACLs"
+linkTitle: "Manage Kafka ACLs"
+weight: 10
+description: >
+  Declare and apply Access Control Lists (ACLs) for principals on your Apache Kafka cluster.
+---
+
+This guide shows how to manage Kafka Access Control Lists (ACLs) as code with Jikkou. For the full
+resource specification, see the [Kafka Authorizations reference]({{% relref "/docs/Reference/Providers/Kafka/Resources/acls.md" %}}).
+
+## Before you begin
+
+* A running Apache Kafka cluster with an authorizer enabled (e.g. `StandardAuthorizer` or `AclAuthorizer`).
+* A configured Jikkou context pointing at your cluster — see [Getting Started]({{% relref "/docs/Tutorials/get_started.md" %}}).
+* A principal with permission to manage ACLs.
+
+## 1. Describe the ACLs you want
+
+Create a file describing the desired authorizations for each principal.
+
+_`file: kafka-acls.yaml`_
+
+```yaml
+---
+apiVersion: "kafka.jikkou.io/v1beta2"
+kind: "KafkaPrincipalAuthorization"
+metadata:
+  name: "User:Alice"
+spec:
+  acls:
+    - resource:
+        type: 'topic'
+        pattern: 'orders-'
+        patternType: 'PREFIXED'
+      type: "ALLOW"
+      operations: [ 'READ', 'WRITE' ]
+      host: "*"
+```
+
+## 2. Preview the changes
+
+Always run in `--dry-run` first to review what Jikkou will do:
+
+```bash
+jikkou apply --files ./kafka-acls.yaml --dry-run
+```
+
+## 3. Apply the ACLs
+
+```bash
+jikkou apply --files ./kafka-acls.yaml
+```
+
+## Reuse permissions with roles
+
+To avoid repeating the same ACLs for many principals, define a `KafkaPrincipalRole` once and reference
+it from several principals:
+
+```yaml
+---
+apiVersion: "kafka.jikkou.io/v1beta2"
+kind: "KafkaPrincipalRole"
+metadata:
+  name: "OrdersReadWrite"
+spec:
+  acls:
+    - type: "ALLOW"
+      operations: [ 'READ', 'WRITE' ]
+      resource:
+        type: 'topic'
+        pattern: 'orders-'
+        patternType: 'PREFIXED'
+      host: "*"
+---
+apiVersion: "kafka.jikkou.io/v1beta2"
+kind: "KafkaPrincipalAuthorization"
+metadata:
+  name: "User:Alice"
+spec:
+  roles:
+    - "OrdersReadWrite"
+```
+
+## Delete ACLs
+
+Jikkou reconciles to the declared state. With `apply`, any ACL that exists on the cluster but is **not**
+present in your resource files will be deleted for the principals you describe. To delete all ACLs for a
+principal, add the delete annotation:
+
+```yaml
+apiVersion: "kafka.jikkou.io/v1beta2"
+kind: "KafkaPrincipalAuthorization"
+metadata:
+  name: "User:Alice"
+  annotations:
+    jikkou.io/delete: true
+spec:
+  acls: []
+```
+
+{{% alert title="Recommendation" color="warning" %}}
+In production, scope changes with `--selector` and always review them with `--dry-run` before applying.
+{{% /alert %}}
+
+## Related
+
+* [Kafka Authorizations reference]({{% relref "/docs/Reference/Providers/Kafka/Resources/acls.md" %}})
+* [Enforce governance policies]({{% relref "Enforce-Policies.md" %}})

--- a/docs/content/en/docs/How-to Guides/Manage-Schemas.md
+++ b/docs/content/en/docs/How-to Guides/Manage-Schemas.md
@@ -1,0 +1,80 @@
+---
+title: "Manage Schema Registry Subjects"
+linkTitle: "Manage Schemas"
+weight: 20
+description: >
+  Register and evolve Avro, Protobuf, and JSON schemas in your Schema Registry as code.
+---
+
+This guide shows how to manage Schema Registry subjects with Jikkou. For the full resource
+specification, see the [Schema Registry Subjects reference]({{% relref "/docs/Reference/Providers/Schema Registry/Resources/subject.md" %}}).
+
+## Before you begin
+
+* A reachable Schema Registry (Confluent, Karapace, Apicurio, …).
+* A Jikkou context configured with the `schemaregistry` provider — see the
+  [Schema Registry provider configuration]({{% relref "/docs/Reference/Providers/Schema Registry/Configuration" %}}).
+
+## 1. Describe a subject
+
+Keep your schema in its own file and reference it from the resource with `$ref`.
+
+_`file: subject-user.yaml`_
+
+```yaml
+---
+apiVersion: "schemaregistry.jikkou.io/v1beta2"
+kind: "SchemaRegistrySubject"
+metadata:
+  name: "User"
+  annotations:
+    schemaregistry.jikkou.io/normalize-schema: true
+spec:
+  compatibilityLevel: "FULL_TRANSITIVE"
+  schemaType: "AVRO"
+  schema:
+    $ref: ./user-schema.avsc
+```
+
+_`file: user-schema.avsc`_
+
+```json
+{
+  "namespace": "example.avro",
+  "type": "record",
+  "name": "User",
+  "fields": [
+    { "name": "name", "type": ["null", "string"], "default": null },
+    { "name": "favorite_number", "type": ["null", "int"], "default": null }
+  ]
+}
+```
+
+## 2. Preview and apply
+
+```bash
+jikkou apply --files ./subject-user.yaml --dry-run   # review
+jikkou apply --files ./subject-user.yaml             # apply
+```
+
+## 3. Evolve the schema safely
+
+To evolve a schema, edit the `.avsc` file and re-apply. Jikkou registers a new version only when the
+schema actually changes, and the registry rejects changes that violate the subject's
+`compatibilityLevel`. Run with `--dry-run` first to confirm the diff is what you expect.
+
+## Manage many subjects at once
+
+Use a `SchemaRegistrySubjectList` (handy with [templating]({{% relref "/docs/Concepts/template.md" %}})) to manage
+multiple subjects in a single file:
+
+```yaml
+apiVersion: "schemaregistry.jikkou.io/v1beta2"
+kind: "SchemaRegistrySubjectList"
+items: []   # an array of SchemaRegistrySubject
+```
+
+## Related
+
+* [Schema Registry Subjects reference]({{% relref "/docs/Reference/Providers/Schema Registry/Resources/subject.md" %}})
+* [Back up and restore configuration]({{% relref "Backup-and-Restore.md" %}})

--- a/docs/content/en/docs/How-to Guides/_index.md
+++ b/docs/content/en/docs/How-to Guides/_index.md
@@ -11,5 +11,23 @@ menu:
 ---
 
 {{% pageinfo %}}
-These guides answer "how do I…?" — practical, step-by-step recipes for installing Jikkou, running the API server, automating Jikkou in CI/CD, and upgrading between versions. If you are learning Jikkou for the first time, start with the [Tutorials]({{% relref "../Tutorials" %}}). For exhaustive option-by-option detail, see the [Reference]({{% relref "../Reference" %}}).
+These guides answer "how do I…?" — practical, step-by-step recipes for getting specific tasks done with Jikkou. If you are learning Jikkou for the first time, start with the [Tutorials]({{% relref "../Tutorials" %}}). For exhaustive option-by-option detail, see the [Reference]({{% relref "../Reference" %}}).
 {{% /pageinfo %}}
+
+### Install & operate
+
+* [Install Jikkou]({{% relref "Install" %}}) — install the CLI and the API Server.
+* [Automating]({{% relref "Automating" %}}) — run Jikkou in CI/CD pipelines.
+* [Migration]({{% relref "Migration" %}}) — upgrade between Jikkou versions.
+
+### Manage resources
+
+* [Manage Kafka ACLs]({{% relref "Manage-Kafka-ACLs.md" %}})
+* [Manage Schema Registry Subjects]({{% relref "Manage-Schemas.md" %}})
+* [Manage Kafka Connect Connectors]({{% relref "Manage-Connectors.md" %}})
+* [Manage Apache Iceberg Tables]({{% relref "Manage-Iceberg-Tables.md" %}})
+
+### Govern & operate safely
+
+* [Enforce Governance Policies]({{% relref "Enforce-Policies.md" %}})
+* [Back Up and Restore Configuration]({{% relref "Backup-and-Restore.md" %}})

--- a/docs/content/en/docs/Reference/CLI/_index.md
+++ b/docs/content/en/docs/Reference/CLI/_index.md
@@ -9,7 +9,7 @@ aliases:
 ---
 
 {{% pageinfo %}}
-**Hands-on:** Try the Jikkou [Get Started tutorials]({{% relref "get_started.md" %}}).
+**Hands-on:** Try the Jikkou [Getting Started tutorial]({{% relref "/docs/Tutorials/get_started.md" %}}).
 {{% /pageinfo %}}
 
 The Jikkou CLI (`jikkou`) is the primary interface for managing infrastructure resources. This reference covers:

--- a/docs/content/en/docs/Tutorials/_index.md
+++ b/docs/content/en/docs/Tutorials/_index.md
@@ -11,6 +11,10 @@ menu:
 ---
 
 {{% pageinfo %}}
-Try the tutorials for common Jikkou tasks and use cases.
+These hands-on tutorials teach Jikkou by doing. Work through them in order — each one builds on the last. For solving a specific problem you already understand, see the [How-to Guides]({{% relref "../How-to Guides" %}}) instead.
 {{% /pageinfo %}}
+
+1. [**Getting Started**]({{% relref "get_started.md" %}}) — install Jikkou, connect to a cluster, and manage your first topics.
+2. [**Preview Changes and Detect Drift**]({{% relref "preview-and-drift.md" %}}) — learn how reconciliation works with `diff` and `--dry-run`.
+3. [**Generate Topics with Templates**]({{% relref "templating-topics.md" %}}) — produce many resources from a small values file using Jinja templating.
 

--- a/docs/content/en/docs/Tutorials/preview-and-drift.md
+++ b/docs/content/en/docs/Tutorials/preview-and-drift.md
@@ -1,0 +1,149 @@
+---
+title: "Preview Changes and Detect Drift"
+linkTitle: "Preview & Detect Drift"
+weight: 2
+description: >
+  Learn how Jikkou reconciles desired state with reality — preview changes with diff, apply safely with
+  dry-run, and detect configuration drift.
+---
+
+In this tutorial you'll learn the mental model at the heart of Jikkou: **reconciliation**. You declare
+the *desired state* of your resources, and Jikkou compares it with the *actual state* on your cluster and
+computes the changes needed to make them match.
+
+By the end you'll know how to preview changes, apply them safely, and detect when a cluster has *drifted*
+away from your declared configuration.
+
+## Prerequisites
+
+* You have completed the [Getting Started]({{% relref "get_started.md" %}}) tutorial.
+* You have a running Kafka cluster and a configured Jikkou context.
+
+## Step 1 — Declare a topic
+
+Create a resource file describing a single topic:
+
+_`file: orders.yaml`_
+
+```yaml
+apiVersion: "kafka.jikkou.io/v1beta2"
+kind: "KafkaTopic"
+metadata:
+  name: "orders"
+spec:
+  partitions: 3
+  replicationFactor: 1
+  configs:
+    cleanup.policy: "delete"
+    retention.ms: 86400000
+```
+
+## Step 2 — Preview the plan with `diff`
+
+Before changing anything, ask Jikkou what it *would* do. The `diff` command produces a speculative
+reconciliation plan without touching the cluster:
+
+```bash
+jikkou diff -f ./orders.yaml
+```
+
+Because the topic doesn't exist yet, the plan reports a `CREATE` operation. `diff` is your safety net —
+use it before every `apply`.
+
+## Step 3 — Apply the change
+
+Now create the topic:
+
+```bash
+jikkou apply -f ./orders.yaml
+```
+
+Run `diff` again:
+
+```bash
+jikkou diff -f ./orders.yaml
+```
+
+This time there are **no changes** — the actual state already matches your desired state. This is what
+reconciliation looks like when everything is in sync.
+
+## Step 4 — Detect drift
+
+"Drift" happens when the cluster changes outside of Jikkou. Let's simulate it by editing your desired
+state instead: change `retention.ms` to `3600000` and add a new config in `orders.yaml`:
+
+```yaml
+spec:
+  partitions: 3
+  replicationFactor: 1
+  configs:
+    cleanup.policy: "delete"
+    retention.ms: 3600000          # changed
+    max.message.bytes: 20971520    # added
+```
+
+Preview the drift:
+
+```bash
+jikkou diff -f ./orders.yaml
+```
+
+Jikkou now reports an `UPDATE` operation describing exactly which config keys differ. You can narrow the
+output to specific operations:
+
+```bash
+jikkou diff -f ./orders.yaml --filter-change-op UPDATE
+```
+
+## Step 5 — Apply safely with `--dry-run`
+
+`apply` also supports `--dry-run`, which runs the full plan without committing it — useful in scripts and
+CI where you want the apply command's exact behavior:
+
+```bash
+jikkou apply -f ./orders.yaml --dry-run   # preview, no changes
+jikkou apply -f ./orders.yaml             # commit the changes
+```
+
+## Step 6 — Understand deletion behavior
+
+`apply` reconciles to the declared state. By default it will not delete topics that are missing from your
+files unless you opt in. To delete the topic you created, add the delete annotation:
+
+```yaml
+apiVersion: "kafka.jikkou.io/v1beta2"
+kind: "KafkaTopic"
+metadata:
+  name: "orders"
+  annotations:
+    jikkou.io/delete: true
+spec:
+  partitions: 3
+  replicationFactor: 1
+```
+
+Preview, then apply:
+
+```bash
+jikkou diff -f ./orders.yaml          # shows a DELETE operation
+jikkou apply -f ./orders.yaml --dry-run
+jikkou apply -f ./orders.yaml
+```
+
+{{% alert title="Recommendation" color="warning" %}}
+In production, always preview with `diff` or `--dry-run`, and scope changes with `--selector` so you only
+affect the resources you intend to.
+{{% /alert %}}
+
+## What you learned
+
+* Jikkou reconciles **desired state** (your YAML) with **actual state** (the cluster).
+* `diff` previews the plan; `--dry-run` runs `apply` without committing.
+* Re-running with no changes is a no-op — that's how you confirm there's no drift.
+* Deletion is opt-in via the `jikkou.io/delete` annotation.
+
+## Next steps
+
+* Learn the [Reconciliation]({{% relref "/docs/Concepts/reconciliation.md" %}}) concept in depth.
+* Generate many resources at once in the [Generate Topics with Templates]({{% relref "templating-topics.md" %}}) tutorial.
+* Enforce rules automatically with [governance policies]({{% relref "/docs/How-to Guides/Enforce-Policies.md" %}}).

--- a/docs/content/en/docs/Tutorials/templating-topics.md
+++ b/docs/content/en/docs/Tutorials/templating-topics.md
@@ -1,0 +1,111 @@
+---
+title: "Generate Topics with Templates"
+linkTitle: "Generate Topics with Templates"
+weight: 3
+description: >
+  Learn Jikkou's Jinja templating by generating many Kafka topics from a small values file.
+---
+
+Declaring resources one by one gets tedious when you manage dozens of similar topics across teams or
+regions. In this tutorial you'll learn Jikkou's **templating** by generating a list of topics from a
+compact data file — a single template plus a few values produces many resources.
+
+By the end you'll understand the `values` variable, values files, and how to preview rendered output
+before applying it.
+
+## Prerequisites
+
+* You have completed the [Getting Started]({{% relref "get_started.md" %}}) tutorial.
+* You have a running Kafka cluster and a configured Jikkou context.
+
+## Step 1 — Define your values
+
+Templating separates *data* from *structure*. Put the data in a values file:
+
+_`file: values.yaml`_
+
+```yaml
+topicPrefix: "iot-events"
+partitions: 6
+replicas: 1
+countryCodes:
+  - fr
+  - be
+  - de
+  - es
+```
+
+## Step 2 — Write the template
+
+Now write a template that loops over the data. Templates use [Jinja](https://jinja.palletsprojects.com/)
+syntax, where `{{ ... }}` outputs a value and `{% ... %}` is a control statement. The values from your
+file are available under the top-level `values` variable.
+
+_`file: topics.tpl`_
+
+```yaml
+apiVersion: "kafka.jikkou.io/v1beta2"
+kind: "KafkaTopicList"
+items:
+{% for country in values.countryCodes %}
+  - metadata:
+      name: "{{ values.topicPrefix }}-{{ country }}"
+    spec:
+      partitions: {{ values.partitions }}
+      replicationFactor: {{ values.replicas }}
+      configs:
+        cleanup.policy: "delete"
+{% endfor %}
+```
+
+## Step 3 — Preview the rendered resources
+
+Always render and inspect the result before touching the cluster. The `validate` command renders the
+template and prints the resulting resources:
+
+```bash
+jikkou validate --files ./topics.tpl --values-files ./values.yaml
+```
+
+You should see four fully-rendered topics — `iot-events-fr`, `iot-events-be`, `iot-events-de`, and
+`iot-events-es` — each with 6 partitions.
+
+## Step 4 — Apply the generated topics
+
+Once you're happy with the output, preview the plan and apply it. The same `--values-files` flag is
+accepted by `diff`, `apply`, `create`, and `update`:
+
+```bash
+jikkou diff  --files ./topics.tpl --values-files ./values.yaml   # preview
+jikkou apply --files ./topics.tpl --values-files ./values.yaml   # apply
+```
+
+Add a country to `values.yaml`, re-run `diff`, and you'll see Jikkou plan a single new topic — without
+touching the template.
+
+## Step 5 — Override values from the command line
+
+You can pass or override individual values with `--set-value` (`-v`), which is handy in CI pipelines:
+
+```bash
+jikkou apply --files ./topics.tpl \
+  --values-files ./values.yaml \
+  --set-value partitions=12
+```
+
+You can also read values from the environment inside the template — for example
+`{{ system.env.TOPIC_PREFIX | default('iot-events', true) }}`.
+
+## What you learned
+
+* Templating separates **data** (values files) from **structure** (the template).
+* `values` exposes your data; `{{ }}` outputs values and `{% %}` drives loops and conditions.
+* Render and inspect with `validate` before applying.
+* `--values-files` and `--set-value` work with `diff`, `apply`, and the other reconciliation commands.
+
+## Next steps
+
+* Read the [Templates]({{% relref "/docs/Concepts/template.md" %}}) concept for two-phase rendering, `ConfigMap`
+  references, and advanced features.
+* Manage multiple schemas the same way using a `SchemaRegistrySubjectList` — see
+  [Manage Schemas]({{% relref "/docs/How-to Guides/Manage-Schemas.md" %}}).


### PR DESCRIPTION
## Summary

Follow-up to the recent Diátaxis restructure (#f98388c51). Reviews the reorganized docs for correct quadrant placement, fixes structural/content issues, and fills the biggest content gaps (how-to recipes and tutorials).

## Fixes

- **Disambiguate the two "Developer Guide" sections** — the contributor build instructions under Community are now titled **"Building from Source"**, clearly separate from the extension/API Developer Guide.
- **Replace the Community section placeholder** ("What does your user need to know to try your project?") with real content and links.
- **Move the API Server install page** out of the loose root of How-to Guides into `How-to Guides/Install/` (renamed to match its install content), preserving the old URL via a Hugo alias.
- **Fix outdated Java version references** (`Java 21` / `Jdk 17` → `Java 25`).
- **Use an explicit path** for the CLI → Getting Started cross-reference instead of the fragile filename-only relref.
- **Normalize the left sidebar menu font weights** so sections and leaf pages render consistently (only the active item is emphasized).

## New content

**How-to guides:** Manage Kafka ACLs · Manage Schema Registry Subjects · Manage Kafka Connect Connectors · Manage Apache Iceberg Tables · Enforce Governance Policies · Back Up and Restore Configuration

**Tutorials:** Preview Changes and Detect Drift · Generate Topics with Templates

All new pages are task/learning-oriented per Diátaxis, cross-linked to the relevant Reference and Concepts pages, and surfaced on their section landing pages.

## Verification

- `hugo build` parses cleanly — no shortcode or `REF_NOT_FOUND`/relref errors; all cross-reference targets verified.
- Ran `hugo server` and visually confirmed the sidebar now renders uniform menu weights.

_(The only `hugo build` non-zero exit is an environmental PostCSS/Node sandbox limitation, unrelated to content.)_
