### PR TITLE
feat: ci drift detection, fleet reporting, and governance policy pack

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,22 @@
+# Jikkou Adopters
+
+This page lists organizations that use Jikkou in production or in significant evaluation.
+Being listed here helps the project: it guides the roadmap, and it helps other teams adopt
+Jikkou with confidence.
+
+## Adding your organization
+
+We would love to have you on this list. Two easy ways:
+
+- Open a pull request adding a row to the table below (keep it alphabetical).
+- Or tell us your story in [GitHub Discussions](https://github.com/streamthoughts/jikkou/discussions)
+  and we will add you.
+
+You decide what to share: a one-line use case is already valuable. Logos are welcome but
+optional.
+
+## Adopters
+
+| Organization | Use case | Source |
+|--------------|----------|--------|
+| _Your organization here_ | | |

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Want to see your name here? Check out the [contribution guide](./CONTRIBUTING.md
 
 If you find Jikkou useful, please consider:
 
-- **Using Jikkou in production?** [Tell us in GitHub Discussions](https://github.com/streamthoughts/jikkou/discussions): real-world usage reports help the project more than anything else
+- **Using Jikkou in production?** Add your organization to [ADOPTERS.md](./ADOPTERS.md) or [tell us in GitHub Discussions](https://github.com/streamthoughts/jikkou/discussions): real-world usage reports help the project more than anything else
 - Giving it a **[star on GitHub](https://github.com/streamthoughts/jikkou)** to help others discover it
 - Joining the **[Slack community](https://join.slack.com/t/jikkou-io/shared_invite/zt-27c0pt61j-F10NN7d7ZEppQeMMyvy3VA)** to ask questions and share feedback
 - **[Contributing](./CONTRIBUTING.md)** code, documentation, or bug reports

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are applied to the latest minor release line.
+
+| Version | Supported |
+|---------|-----------|
+| 1.x (latest minor) | Yes |
+| Older releases | No |
+
+## Reporting a Vulnerability
+
+Please do NOT report security vulnerabilities through public GitHub issues.
+
+Instead, report them privately using
+[GitHub Security Advisories](https://github.com/streamthoughts/jikkou/security/advisories/new).
+
+Include as much of the following as you can:
+
+- A description of the vulnerability and its impact.
+- Steps to reproduce, or a proof of concept.
+- Affected version(s) and configuration.
+
+## What to expect
+
+- An acknowledgement within 7 days.
+- A status update once the report has been triaged, including whether it is accepted.
+- Credit in the release notes for accepted reports, unless you prefer to stay anonymous.
+
+Thank you for helping keep Jikkou and its users safe.

--- a/cli/src/main/java/io/jikkou/client/command/DiffCommand.java
+++ b/cli/src/main/java/io/jikkou/client/command/DiffCommand.java
@@ -14,6 +14,7 @@ import io.jikkou.core.exceptions.ValidationException;
 import io.jikkou.core.io.writer.ResourceWriter;
 import io.jikkou.core.models.ApiResourceChangeList;
 import io.jikkou.core.models.HasItems;
+import io.jikkou.core.models.change.ResourceChange;
 import io.jikkou.core.reconciler.Operation;
 import io.jikkou.core.reconciler.SimpleResourceChangeFilter;
 import io.jikkou.core.repository.LocalResourceRepository;
@@ -21,9 +22,14 @@ import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.EnumMap;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.jetbrains.annotations.NotNull;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
@@ -38,6 +44,14 @@ import picocli.CommandLine.Option;
         """)
 @Singleton
 public class DiffCommand extends CLIBaseCommand implements Callable<Integer> {
+
+    /**
+     * Exit code returned when {@code --fail-on-changes} is set and the diff contains at least one change.
+     * Distinct from {@code 1} (validation/execution error) and {@code 2} (usage error).
+     *
+     * @since 1.1.0
+     */
+    public static final int EXIT_CODE_CHANGES_DETECTED = 3;
 
     // COMMAND OPTIONS
     @Mixin
@@ -68,6 +82,13 @@ public class DiffCommand extends CLIBaseCommand implements Callable<Integer> {
         description = "Get resources as ApiResourceChangeList (default: ${DEFAULT-VALUE})."
     )
     private boolean list;
+
+    @Option(names = {"--fail-on-changes"},
+        defaultValue = "false",
+        description = "Exit with code 3 when the diff contains at least one change, i.e., any operation" +
+            " other than NONE. Useful for detecting configuration drift in CI (default: ${DEFAULT-VALUE})."
+    )
+    private boolean failOnChanges;
 
     // API
     @Inject
@@ -100,12 +121,38 @@ public class DiffCommand extends CLIBaseCommand implements Callable<Integer> {
                     writer.write(formatOptions.format(), result.getItems(), baos);
                 }
                 System.out.println(baos);
+                if (failOnChanges) {
+                    List<ResourceChange> changes = result.getItems();
+                    System.err.println(summarize(changes));
+                    return hasChanges(changes) ? EXIT_CODE_CHANGES_DETECTED : CommandLine.ExitCode.OK;
+                }
                 return CommandLine.ExitCode.OK;
             }
         } catch (ValidationException exception) {
             System.out.println(ValidationErrorsWriter.write(exception.errors()));
             return CommandLine.ExitCode.SOFTWARE;
         }
+    }
+
+    static boolean hasChanges(final List<ResourceChange> changes) {
+        return changes.stream().anyMatch(change -> change.getSpec().getOp().isChanged());
+    }
+
+    static String summarize(final List<ResourceChange> changes) {
+        Map<Operation, Long> counts = changes.stream()
+            .map(change -> change.getSpec().getOp())
+            .filter(Operation::isChanged)
+            .collect(Collectors.groupingBy(op -> op, () -> new EnumMap<>(Operation.class), Collectors.counting()));
+
+        long total = counts.values().stream().mapToLong(Long::longValue).sum();
+        if (total == 0) {
+            return "No changes detected.";
+        }
+        String details = Stream.of(Operation.CREATE, Operation.UPDATE, Operation.DELETE, Operation.REPLACE)
+            .filter(counts::containsKey)
+            .map(op -> counts.get(op) + " " + op.name())
+            .collect(Collectors.joining(", "));
+        return "%d change%s detected: %s".formatted(total, total > 1 ? "s" : "", details);
     }
 
     @NotNull

--- a/cli/src/main/java/io/jikkou/client/printer/TextPrinter.java
+++ b/cli/src/main/java/io/jikkou/client/printer/TextPrinter.java
@@ -12,12 +12,17 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import io.jikkou.core.exceptions.JikkouRuntimeException;
 import io.jikkou.core.io.Jackson;
 import io.jikkou.core.models.ApiChangeResultList;
+import io.jikkou.core.models.CoreAnnotations;
 import io.jikkou.core.reconciler.ChangeResult;
 import io.jikkou.core.reconciler.Operation;
 import io.jikkou.core.reconciler.TextDescription;
 import java.io.PrintStream;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 /**
  * Helper class pretty print execution results.
@@ -25,8 +30,6 @@ import java.util.concurrent.TimeUnit;
 public class TextPrinter implements Printer {
 
     private static final String PADDING = "********************************************************************************";
-
-    private static final PrintStream PS = System.out;
 
     private final boolean printChangeDetail;
 
@@ -39,59 +42,88 @@ public class TextPrinter implements Printer {
         this.printChangeDetail = printChangeDetail;
     }
 
+    // Resolved at call time so that tests can capture output through System.setOut().
+    private static PrintStream out() {
+        return System.out;
+    }
+
     /**
      * {@inheritDoc}
      **/
     @Override
     public int print(ApiChangeResultList result, long executionTimeMs, boolean pretty) {
-        int ok = 0;
-        int created = 0;
-        int changed = 0;
-        int deleted = 0;
-        int failed = 0;
-        for (ChangeResult change : result.results()) {
-            final String json;
-            try {
-                json = Jackson.JSON_OBJECT_MAPPER
-                        .writerWithDefaultPrettyPrinter()
-                        .writeValueAsString(change);
-            } catch (JsonProcessingException e) {
-                throw new JikkouRuntimeException(e);
-            }
+        Counts counts = new Counts();
 
-            String color = Ansi.Color.WHITE;
-            Operation operation = change.change().getSpec().getOp();
-            if (change.isChanged()) {
-                switch (operation) {
-                    case CREATE -> {
-                        color = Ansi.Color.GREEN;
-                        created++;
-                    }
-                    case UPDATE -> {
-                        color = Ansi.Color.YELLOW;
-                        changed++;
-                    }
-                    case DELETE -> {
-                        color = Ansi.Color.RED;
-                        deleted++;
-                    }
-                }
-            } else if (change.isFailed()) {
-                failed++;
-            } else {
-                color = Ansi.Color.BLUE;
-                ok++;
-            }
+        // Group results by the provider that executed them (multi-provider operations
+        // annotate each change with jikkou.io/provider). A single unnamed group keeps
+        // the flat single-provider output unchanged.
+        Map<String, List<ChangeResult>> byProvider = result.results().stream()
+                .collect(Collectors.groupingBy(
+                        r -> Optional.ofNullable(r.change())
+                                .map(CoreAnnotations::getProvider)
+                                .orElse(""),
+                        LinkedHashMap::new,
+                        Collectors.toList()));
 
-            TextPrinter.printTask(change.change().getSpec().getOp(), change.description(), change.status().name());
-            if (printChangeDetail) {
-                TextPrinter.PS.printf("%s%s%n", isColor() ? color : "", json);
+        for (Map.Entry<String, List<ChangeResult>> group : byProvider.entrySet()) {
+            String providerName = group.getKey();
+            if (!providerName.isEmpty()) {
+                printProviderHeader(providerName);
+            }
+            for (ChangeResult change : group.getValue()) {
+                printResult(change, counts);
             }
         }
 
-        TextPrinter.PS.printf("%sEXECUTION in %s %s%n", isColor() ? Ansi.Color.WHITE : "", formatExecutionTime(executionTimeMs), result.dryRun() ? "(DRY_RUN)" : "");
-        TextPrinter.PS.printf("%sok : %d, created : %d, altered : %d, deleted : %d failed : %d%n", isColor() ? Ansi.Color.WHITE : "", ok, created, changed, deleted, failed);
-        return failed > 0 ? 1 : 0;
+        out().printf("%sEXECUTION in %s %s%n", isColor() ? Ansi.Color.WHITE : "", formatExecutionTime(executionTimeMs), result.dryRun() ? "(DRY_RUN)" : "");
+        out().printf("%sok : %d, created : %d, altered : %d, deleted : %d failed : %d%n", isColor() ? Ansi.Color.WHITE : "", counts.ok, counts.created, counts.changed, counts.deleted, counts.failed);
+        return counts.failed > 0 ? 1 : 0;
+    }
+
+    private void printResult(final ChangeResult change, final Counts counts) {
+        final String json;
+        try {
+            json = Jackson.JSON_OBJECT_MAPPER
+                    .writerWithDefaultPrettyPrinter()
+                    .writeValueAsString(change);
+        } catch (JsonProcessingException e) {
+            throw new JikkouRuntimeException(e);
+        }
+
+        String color = Ansi.Color.WHITE;
+        Operation operation = change.change().getSpec().getOp();
+        if (change.isChanged()) {
+            switch (operation) {
+                case CREATE -> {
+                    color = Ansi.Color.GREEN;
+                    counts.created++;
+                }
+                case UPDATE -> {
+                    color = Ansi.Color.YELLOW;
+                    counts.changed++;
+                }
+                case DELETE -> {
+                    color = Ansi.Color.RED;
+                    counts.deleted++;
+                }
+            }
+        } else if (change.isFailed()) {
+            counts.failed++;
+        } else {
+            color = Ansi.Color.BLUE;
+            counts.ok++;
+        }
+
+        printTask(change.change().getSpec().getOp(), change.description(), change.status().name());
+        if (printChangeDetail) {
+            out().printf("%s%s%n", isColor() ? color : "", json);
+        }
+    }
+
+    private static void printProviderHeader(final String providerName) {
+        String text = "PROVIDER [%s] ".formatted(providerName);
+        String padding = (text.length() < PADDING.length()) ? PADDING.substring(text.length()) : "";
+        out().printf("%s%s%s%n", isColor() ? Ansi.Color.WHITE : "", text, padding);
     }
 
     private static void printTask(final Operation operation,
@@ -99,7 +131,7 @@ public class TextPrinter implements Printer {
                                   final String status) {
         String text = Optional.ofNullable(description).map(TextDescription::textual).orElse("");
         String padding = (text.length() < PADDING.length()) ? PADDING.substring(text.length()) : "";
-        PS.printf("%sTASK [%s] %s - %s %s%n", isColor() ? Ansi.Color.WHITE : "", operation, text, status, padding);
+        out().printf("%sTASK [%s] %s - %s %s%n", isColor() ? Ansi.Color.WHITE : "", operation, text, status, padding);
     }
 
     private String formatExecutionTime(long execTimeInMillis) {
@@ -113,5 +145,13 @@ public class TextPrinter implements Printer {
                     String.format("%ds %dms", seconds, milliseconds);
         }
         return String.format("%dmin %ds %dms", minutes, seconds, milliseconds);
+    }
+
+    private static final class Counts {
+        private int ok;
+        private int created;
+        private int changed;
+        private int deleted;
+        private int failed;
     }
 }

--- a/cli/src/test/java/io/jikkou/client/command/DiffCommandTest.java
+++ b/cli/src/test/java/io/jikkou/client/command/DiffCommandTest.java
@@ -1,0 +1,78 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.jikkou.client.command;
+
+import io.jikkou.core.models.change.GenericResourceChange;
+import io.jikkou.core.models.change.ResourceChange;
+import io.jikkou.core.models.change.ResourceChangeSpec;
+import io.jikkou.core.reconciler.Operation;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class DiffCommandTest {
+
+    @Test
+    void shouldDetectChanges_whenAnyOperationIsNotNone() {
+        List<ResourceChange> changes = List.of(
+                changeWithOp(Operation.NONE),
+                changeWithOp(Operation.UPDATE)
+        );
+        Assertions.assertTrue(DiffCommand.hasChanges(changes));
+    }
+
+    @Test
+    void shouldDetectNoChanges_whenAllOperationsAreNone() {
+        List<ResourceChange> changes = List.of(
+                changeWithOp(Operation.NONE),
+                changeWithOp(Operation.NONE)
+        );
+        Assertions.assertFalse(DiffCommand.hasChanges(changes));
+    }
+
+    @Test
+    void shouldCountDeleteAsChange() {
+        Assertions.assertTrue(DiffCommand.hasChanges(List.of(changeWithOp(Operation.DELETE))));
+    }
+
+    @Test
+    void shouldCountReplaceAsChange() {
+        Assertions.assertTrue(DiffCommand.hasChanges(List.of(changeWithOp(Operation.REPLACE))));
+    }
+
+    @Test
+    void shouldSummarizeChangesByOperation() {
+        List<ResourceChange> changes = List.of(
+                changeWithOp(Operation.CREATE),
+                changeWithOp(Operation.UPDATE),
+                changeWithOp(Operation.UPDATE),
+                changeWithOp(Operation.NONE)
+        );
+        Assertions.assertEquals("3 changes detected: 1 CREATE, 2 UPDATE", DiffCommand.summarize(changes));
+    }
+
+    @Test
+    void shouldSummarizeSingleChange() {
+        List<ResourceChange> changes = List.of(changeWithOp(Operation.DELETE));
+        Assertions.assertEquals("1 change detected: 1 DELETE", DiffCommand.summarize(changes));
+    }
+
+    @Test
+    void shouldSummarizeNoChanges() {
+        List<ResourceChange> changes = List.of(changeWithOp(Operation.NONE));
+        Assertions.assertEquals("No changes detected.", DiffCommand.summarize(changes));
+    }
+
+    private static ResourceChange changeWithOp(Operation op) {
+        return GenericResourceChange.builder()
+                .withSpec(ResourceChangeSpec.builder()
+                        .withOperation(op)
+                        .build()
+                )
+                .build();
+    }
+}

--- a/cli/src/test/java/io/jikkou/client/printer/TextPrinterTest.java
+++ b/cli/src/test/java/io/jikkou/client/printer/TextPrinterTest.java
@@ -1,0 +1,97 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.jikkou.client.printer;
+
+import io.jikkou.core.models.ApiChangeResultList;
+import io.jikkou.core.models.CoreAnnotations;
+import io.jikkou.core.models.ObjectMeta;
+import io.jikkou.core.models.change.GenericResourceChange;
+import io.jikkou.core.models.change.ResourceChange;
+import io.jikkou.core.models.change.ResourceChangeSpec;
+import io.jikkou.core.reconciler.ChangeResult;
+import io.jikkou.core.reconciler.Operation;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TextPrinterTest {
+
+    private final ByteArrayOutputStream captured = new ByteArrayOutputStream();
+    private PrintStream originalOut;
+
+    @BeforeEach
+    void setUp() {
+        originalOut = System.out;
+        System.setOut(new PrintStream(captured, true, StandardCharsets.UTF_8));
+    }
+
+    @AfterEach
+    void tearDown() {
+        System.setOut(originalOut);
+    }
+
+    @Test
+    void shouldGroupResultsByProvider_whenProviderAnnotationPresent() {
+        ApiChangeResultList results = new ApiChangeResultList(false, new ObjectMeta(), List.of(
+                ChangeResult.changed(changeWithOp(Operation.CREATE, "kafka-prod"), () -> "create topic on prod"),
+                ChangeResult.changed(changeWithOp(Operation.UPDATE, "kafka-dev"), () -> "update topic on dev")
+        ));
+
+        int code = new TextPrinter(false).print(results, 100L, false);
+
+        String output = captured.toString(StandardCharsets.UTF_8);
+        Assertions.assertEquals(0, code);
+        Assertions.assertTrue(output.contains("PROVIDER [kafka-prod]"), output);
+        Assertions.assertTrue(output.contains("PROVIDER [kafka-dev]"), output);
+        Assertions.assertTrue(output.indexOf("create topic on prod") > output.indexOf("PROVIDER [kafka-prod]"), output);
+    }
+
+    @Test
+    void shouldPrintFlatOutput_whenNoProviderAnnotation() {
+        ApiChangeResultList results = new ApiChangeResultList(false, new ObjectMeta(), List.of(
+                ChangeResult.changed(changeWithOp(Operation.CREATE, null), () -> "create topic")
+        ));
+
+        int code = new TextPrinter(false).print(results, 100L, false);
+
+        String output = captured.toString(StandardCharsets.UTF_8);
+        Assertions.assertEquals(0, code);
+        Assertions.assertFalse(output.contains("PROVIDER ["), output);
+        Assertions.assertTrue(output.contains("create topic"), output);
+        Assertions.assertTrue(output.contains("ok : 0, created : 1"), output);
+    }
+
+    @Test
+    void shouldReturnNonZero_whenAnyChangeFailed() {
+        ApiChangeResultList results = new ApiChangeResultList(false, new ObjectMeta(), List.of(
+                ChangeResult.failed(changeWithOp(Operation.UPDATE, null), () -> "update topic", List.of())
+        ));
+
+        int code = new TextPrinter(false).print(results, 100L, false);
+
+        Assertions.assertEquals(1, code);
+    }
+
+    private static ResourceChange changeWithOp(Operation op, String provider) {
+        ObjectMeta.ObjectMetaBuilder meta = ObjectMeta.builder();
+        if (provider != null) {
+            meta = meta.withAnnotation(CoreAnnotations.JIKKOU_IO_PROVIDER, provider);
+        }
+        return GenericResourceChange.builder()
+                .withMetadata(meta.build())
+                .withSpec(ResourceChangeSpec.builder()
+                        .withOperation(op)
+                        .build()
+                )
+                .build();
+    }
+}

--- a/core/src/main/java/io/jikkou/core/DefaultApi.java
+++ b/core/src/main/java/io/jikkou/core/DefaultApi.java
@@ -63,6 +63,7 @@ import io.jikkou.core.policy.model.ValidatingResourcePolicy;
 import io.jikkou.core.reconciler.ChangeResult;
 import io.jikkou.core.reconciler.Collector;
 import io.jikkou.core.reconciler.Controller;
+import io.jikkou.core.reconciler.DefaultChangeResult;
 import io.jikkou.core.reconciler.Operation;
 import io.jikkou.core.reconciler.Reconciler;
 import io.jikkou.core.reconciler.ResourceChangeFilter;
@@ -634,7 +635,9 @@ public final class DefaultApi extends BaseApi implements AutoCloseable, JikkouAp
 
             try {
                 ApiChangeResultList result = operation.execute(resources, singleContext);
-                aggregatedResults.addAll(result.results());
+                result.results().stream()
+                    .map(r -> tagChangeResultWithProvider(r, providerName))
+                    .forEach(aggregatedResults::add);
             } catch (Exception e) {
                 LOG.error("{} failed for provider '{}': {}", operationName, providerName, e.getMessage(), e);
                 failedProviders.add(providerName);
@@ -657,6 +660,49 @@ public final class DefaultApi extends BaseApi implements AutoCloseable, JikkouAp
     @FunctionalInterface
     private interface MultiProviderOperation {
         ApiChangeResultList execute(@NotNull HasItems resources, @NotNull ReconciliationContext context);
+    }
+
+    /**
+     * Tags the given change with the provider it was computed for, using the
+     * {@link CoreAnnotations#JIKKOU_IO_PROVIDER} metadata annotation. An annotation already
+     * set upstream is never overridden.
+     *
+     * @param change       the resource change.
+     * @param providerName the provider name.
+     * @return the annotated change.
+     * @since 1.1.0
+     */
+    static ResourceChange tagChangeWithProvider(@NotNull ResourceChange change,
+                                                @NotNull String providerName) {
+        // getMetadata() returns a detached copy when the metadata field is null:
+        // the metadata must be re-attached through withMetadata().
+        ObjectMeta meta = change.getMetadata();
+        meta.addAnnotationIfAbsent(CoreAnnotations.JIKKOU_IO_PROVIDER, providerName);
+        return (ResourceChange) change.withMetadata(meta);
+    }
+
+    /**
+     * Tags the change carried by the given result with the provider it was executed for.
+     *
+     * @param result       the change result.
+     * @param providerName the provider name.
+     * @return the annotated result.
+     * @since 1.1.0
+     */
+    static ChangeResult tagChangeResultWithProvider(@NotNull ChangeResult result,
+                                                    @NotNull String providerName) {
+        if (result.change() == null) {
+            return result;
+        }
+        // Custom ChangeResult implementations are normalized to DefaultChangeResult, the
+        // single declared deserialization target.
+        return new DefaultChangeResult(
+            result.end(),
+            result.status(),
+            tagChangeWithProvider(result.change(), providerName),
+            result.description(),
+            result.errors()
+        );
     }
 
     @NotNull
@@ -915,7 +961,9 @@ public final class DefaultApi extends BaseApi implements AutoCloseable, JikkouAp
             try {
                 ResourceList<HasMetadata> all = addAllResourcesFromRepositories(resources);
                 ApiResourceChangeList result = doDiff(all, filter, singleContext);
-                aggregatedChanges.addAll(result.getItems());
+                result.getItems().stream()
+                    .map(change -> tagChangeWithProvider(change, providerName))
+                    .forEach(aggregatedChanges::add);
             } catch (Exception e) {
                 LOG.error("Diff failed for provider '{}': {}", providerName, e.getMessage(), e);
                 if (!context.continueOnError()) {
@@ -956,13 +1004,6 @@ public final class DefaultApi extends BaseApi implements AutoCloseable, JikkouAp
                 .toList();
         }
 
-        // Tag resources with provider annotation for audit trail
-        if (providerName != null) {
-            for (HasMetadata resource : list) {
-                resource.getMetadata().addAnnotationIfAbsent(CoreAnnotations.JIKKOU_IO_PROVIDER, providerName);
-            }
-        }
-
         ResourceList filtered = ResourceList.of(list);
 
         // Validate resources.
@@ -989,6 +1030,11 @@ public final class DefaultApi extends BaseApi implements AutoCloseable, JikkouAp
                 return filter.filter(changes);
             })
             .flatMap(Collection::stream)
+            // Tag planned changes with the provider for audit trail. The input resources
+            // are deliberately left untouched: multi-provider runs reuse the same resource
+            // instances for every provider, and a mutated provider annotation would exclude
+            // them from the provider filter above on the next iteration.
+            .map(change -> providerName != null ? tagChangeWithProvider(change, providerName) : change)
             .collect(Collectors.toList());
         return new ApiResourceChangeList(results);
     }

--- a/core/src/main/java/io/jikkou/core/policy/CelExpressionFactory.java
+++ b/core/src/main/java/io/jikkou/core/policy/CelExpressionFactory.java
@@ -113,7 +113,16 @@ public final class CelExpressionFactory<T> {
         // Evaluate the program
         return resource -> {
             try {
-                Map<String, Object> json = Jackson.json().convertValue(resource, Map.class);
+                // Serialize through JSON (not convertValue) so that every scalar is
+                // normalized to a JSON-native Java type: convertValue would preserve
+                // POJO field types such as Short (e.g. KafkaTopic spec.replicas) that
+                // the CEL runtime cannot adapt, breaking numeric expressions.
+                final Map<String, Object> json;
+                try {
+                    json = Jackson.json().readValue(Jackson.json().writeValueAsBytes(resource), Map.class);
+                } catch (java.io.IOException e) {
+                    throw new IllegalArgumentException("Failed to serialize resource for CEL evaluation", e);
+                }
 
                 // Plan the program
                 final CelRuntime.Program program;

--- a/core/src/main/java/io/jikkou/core/reconciler/Operation.java
+++ b/core/src/main/java/io/jikkou/core/reconciler/Operation.java
@@ -47,4 +47,14 @@ public enum Operation {
         return UPDATE == this || CREATE == this;
     }
 
+    /**
+     * Checks whether this operation results in a state change, i.e., any operation other than {@link #NONE}.
+     *
+     * @return {@code true} if this operation is {@link #CREATE}, {@link #UPDATE}, {@link #DELETE}, or {@link #REPLACE}.
+     * @since 1.1.0
+     */
+    public boolean isChanged() {
+        return this != NONE;
+    }
+
 }

--- a/core/src/test/java/io/jikkou/core/DefaultApiMultiProviderTest.java
+++ b/core/src/test/java/io/jikkou/core/DefaultApiMultiProviderTest.java
@@ -6,6 +6,8 @@
  */
 package io.jikkou.core;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -17,9 +19,18 @@ import io.jikkou.core.extension.DefaultExtensionFactory;
 import io.jikkou.core.extension.DefaultExtensionRegistry;
 import io.jikkou.core.extension.DefaultProviderConfigurationRegistry;
 import io.jikkou.core.models.ApiResourceChangeList;
+import io.jikkou.core.models.CoreAnnotations;
+import io.jikkou.core.models.ObjectMeta;
 import io.jikkou.core.models.ResourceList;
+import io.jikkou.core.models.change.GenericResourceChange;
+import io.jikkou.core.models.change.ResourceChange;
+import io.jikkou.core.models.change.ResourceChangeSpec;
+import io.jikkou.core.reconciler.ChangeResult;
+import io.jikkou.core.reconciler.DefaultChangeResult;
+import io.jikkou.core.reconciler.Operation;
 import io.jikkou.core.reconciler.ResourceChangeFilter;
 import io.jikkou.core.resource.DefaultResourceRegistry;
+import java.time.Instant;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -188,5 +199,76 @@ class DefaultApiMultiProviderTest {
 
         ApiResourceChangeList result = api.getDiff(ResourceList.empty(), new ResourceChangeFilter.Noop(), context);
         assertTrue(result.getItems().isEmpty());
+    }
+
+    @Test
+    void shouldNotMutateInputResourcesAcrossProviders() {
+        providerConfigRegistry.registerProviderConfiguration("provider-a", PROVIDER_TYPE, Configuration.empty(), false);
+        providerConfigRegistry.registerProviderConfiguration("provider-b", PROVIDER_TYPE, Configuration.empty(), false);
+        DefaultApi api = buildApi();
+
+        TestResource resource = new TestResource().withMetadata(new ObjectMeta("test"));
+        ReconciliationContext context = ReconciliationContext.builder()
+            .dryRun(true)
+            .providerNames(List.of("provider-a", "provider-b"))
+            .continueOnError(true)
+            .build();
+
+        api.getDiff(ResourceList.of(List.of(resource)), new ResourceChangeFilter.Noop(), context);
+
+        // The provider annotation must never leak onto the shared input resource: it would
+        // exclude the resource from the provider filter of every provider after the first.
+        assertTrue(resource.getMetadata().getAnnotations().isEmpty());
+    }
+
+    @Test
+    void shouldTagChangeWithProviderAnnotation() {
+        // Change with no metadata: exercises the copy-on-null behavior of GenericResourceChange.getMetadata()
+        ResourceChange change = changeWithOp(Operation.CREATE);
+
+        ResourceChange tagged = DefaultApi.tagChangeWithProvider(change, "kafka-prod");
+
+        assertEquals("kafka-prod", CoreAnnotations.getProvider(tagged));
+    }
+
+    @Test
+    void shouldNotOverrideExistingProviderAnnotationOnChanges() {
+        ObjectMeta meta = ObjectMeta.builder()
+            .withAnnotation(CoreAnnotations.JIKKOU_IO_PROVIDER, "upstream-provider")
+            .build();
+        ResourceChange change = (ResourceChange) changeWithOp(Operation.UPDATE).withMetadata(meta);
+
+        ResourceChange tagged = DefaultApi.tagChangeWithProvider(change, "kafka-prod");
+
+        assertEquals("upstream-provider", CoreAnnotations.getProvider(tagged));
+    }
+
+    @Test
+    void shouldTagChangeResultWithProviderAnnotation() {
+        ChangeResult result = ChangeResult.changed(changeWithOp(Operation.UPDATE), () -> "update topic");
+
+        ChangeResult tagged = DefaultApi.tagChangeResultWithProvider(result, "kafka-dev");
+
+        assertEquals("kafka-dev", CoreAnnotations.getProvider(tagged.change()));
+        assertEquals(result.status(), tagged.status());
+        assertEquals(result.description().textual(), tagged.description().textual());
+    }
+
+    @Test
+    void shouldKeepChangeResultUntouched_whenChangeIsNull() {
+        ChangeResult result = new DefaultChangeResult(Instant.now(), ChangeResult.Status.OK, null, () -> "noop", null);
+
+        ChangeResult tagged = DefaultApi.tagChangeResultWithProvider(result, "kafka-prod");
+
+        assertSame(result, tagged);
+    }
+
+    private static ResourceChange changeWithOp(Operation op) {
+        return GenericResourceChange.builder()
+            .withSpec(ResourceChangeSpec.builder()
+                .withOperation(op)
+                .build()
+            )
+            .build();
     }
 }

--- a/core/src/test/java/io/jikkou/core/policy/CelExpressionFactoryTest.java
+++ b/core/src/test/java/io/jikkou/core/policy/CelExpressionFactoryTest.java
@@ -70,6 +70,30 @@ class CelExpressionFactoryTest {
     }
 
     @Test
+    void shouldEvaluateNumericExpressionOnNonJsonNativeTypes() {
+        // Given: a resource carrying values typed as Short/Float, like V1KafkaTopic.spec.replicas.
+        var resource = new GenericResource(
+            "io.jikkou/v1",
+            "Test",
+            new ObjectMeta("TestName"),
+            null,
+            Map.of(
+                "spec", Map.of(
+                    "replicas", (short) 3,
+                    "ratio", 0.5f
+                )
+            )
+        );
+
+        // When
+        CelExpression<Boolean> compiled = CelExpressionFactory.bool()
+            .compile("resource.spec.replicas >= 3 && resource.spec.ratio < 1.0");
+
+        // Then
+        Assertions.assertTrue(compiled.eval(resource));
+    }
+
+    @Test
     void shouldCompileExpressionEvaluatingToFalse() {
         // Given
         var resource = new GenericResource(

--- a/core/src/test/java/io/jikkou/core/reconciler/OperationTest.java
+++ b/core/src/test/java/io/jikkou/core/reconciler/OperationTest.java
@@ -18,4 +18,13 @@ class OperationTest {
         Assertions.assertEquals("Update", Operation.UPDATE.humanize());
         Assertions.assertEquals("Unchanged", Operation.NONE.humanize());
     }
+
+    @Test
+    void shouldReturnChangedForAllOperationsExceptNone() {
+        Assertions.assertFalse(Operation.NONE.isChanged());
+        Assertions.assertTrue(Operation.CREATE.isChanged());
+        Assertions.assertTrue(Operation.UPDATE.isChanged());
+        Assertions.assertTrue(Operation.DELETE.isChanged());
+        Assertions.assertTrue(Operation.REPLACE.isChanged());
+    }
 }

--- a/docs/content/en/docs/Comparisons/jikkou-vs-terraform.md
+++ b/docs/content/en/docs/Comparisons/jikkou-vs-terraform.md
@@ -31,7 +31,8 @@ $ jikkou diff --files ./topics/
 ```
 
 Out-of-band changes show up immediately as a diff. Reverting them is `jikkou apply`. Detecting them
-continuously is a scheduled CI job.
+continuously is a [scheduled CI job](/docs/how-to-guides/automating/detect-configuration-drift/)
+using `jikkou diff --fail-on-changes`.
 
 ## Managing 300 topics
 

--- a/docs/content/en/docs/How-to Guides/Automating/Detect-Configuration-Drift.md
+++ b/docs/content/en/docs/How-to Guides/Automating/Detect-Configuration-Drift.md
@@ -1,0 +1,121 @@
+---
+title: "Detect Configuration Drift"
+linkTitle: "Detect Drift"
+weight: 4
+description: >
+  Run jikkou diff on a schedule to detect when your clusters no longer match what is in Git.
+---
+
+Configuration drift happens to every Kafka platform: someone bumps `retention.ms` during an
+incident with a vendor UI, a topic gets created by hand, an ACL is "temporarily" widened.
+Because Jikkou is stateless and always compares your Git-versioned definitions against the
+**actual cluster state**, detecting drift is a single command:
+
+```bash
+jikkou diff --files ./resources --fail-on-changes
+```
+
+## Exit codes
+
+With `--fail-on-changes`, `jikkou diff` uses distinct exit codes so CI can react precisely:
+
+| Code | Meaning |
+|------|---------|
+| `0` | No changes: cluster matches Git |
+| `1` | Validation or execution error |
+| `2` | Usage error (invalid flags or arguments) |
+| `3` | **Drift detected**: at least one pending change |
+
+A one-line summary is printed to stderr (for example, `3 changes detected: 1 CREATE, 2 UPDATE`),
+while stdout carries the full machine-readable diff (YAML by default, `-o JSON` available).
+
+{{% alert title="Scoping the check" color="info" %}}
+The drift check is evaluated on the filtered result. For example,
+`--fail-on-changes --filter-change-op UPDATE` only counts updates as drift and ignores
+creations and deletions. Without filters, every operation other than `NONE` counts.
+{{% /alert %}}
+
+## Scheduled drift check with GitHub Actions
+
+The workflow below runs every hour using the
+[`streamthoughts/setup-jikkou`](https://github.com/streamthoughts/setup-jikkou) action, uploads
+the diff as an artifact, and opens an issue when drift is detected:
+
+```yaml
+name: Kafka Drift Detection
+
+on:
+  schedule:
+    - cron: '0 * * * *'   # every hour
+  workflow_dispatch: {}
+
+jobs:
+  drift:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: streamthoughts/setup-jikkou@v1
+        with:
+          jikkou_config: ${{ github.workspace }}/.jikkou/config
+
+      - name: Check for drift
+        id: diff
+        run: |
+          set +e
+          jikkou diff --files ./resources --fail-on-changes -o YAML > drift.yaml
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+
+      - name: Upload diff
+        if: steps.diff.outputs.exit_code == '3'
+        uses: actions/upload-artifact@v4
+        with:
+          name: drift-report
+          path: drift.yaml
+
+      - name: Open an issue on drift
+        if: steps.diff.outputs.exit_code == '3'
+        run: |
+          gh issue create \
+            --title "Kafka configuration drift detected ($(date -u +%F))" \
+            --body "jikkou diff found pending changes. Download the drift-report artifact from run ${{ github.run_id }}."
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Fail on error
+        if: steps.diff.outputs.exit_code == '1' || steps.diff.outputs.exit_code == '2'
+        run: exit 1
+```
+
+Instead of opening an issue, the same gate (`exit_code == '3'`) can post to Slack, page an
+on-call rotation, or even trigger a `jikkou apply` job to revert the drift automatically.
+
+## Running without cluster credentials
+
+CI runners do not need direct access to your Kafka clusters. Run the
+[Jikkou API server](/docs/how-to-guides/install/api-server/) inside your platform, and point
+the CLI at it with [proxy mode](/docs/reference/api-server/configuration/cli_proxy_mode/):
+
+```hocon
+jikkou {
+  proxy {
+    enabled = true
+    url = "https://jikkou.my-platform.internal"
+    security {
+      access-token = ${?JIKKOU_API_TOKEN}
+    }
+  }
+}
+```
+
+With this configuration, the workflow above only needs an API token: cluster credentials stay
+on the server side.
+
+## Related
+
+* [jikkou diff command reference](/docs/reference/cli/commands/jikkou-diff/)
+* [Automate Jikkou with GitHub Actions](/docs/how-to-guides/automating/githubactions/)
+* [Jikkou vs Terraform](/docs/comparisons/jikkou-vs-terraform/): why stateless reconciliation
+  catches drift that state files miss

--- a/docs/content/en/docs/How-to Guides/Automating/GitHubActions.md
+++ b/docs/content/en/docs/How-to Guides/Automating/GitHubActions.md
@@ -52,3 +52,8 @@ This Action additionally supports the following inputs :
 |------------------|----------|--------------------------------------------------------------------------------------------------------------------------------|
 | `jikkou_version` | `latest` | The version of Jikkou CLI to install. A value of `latest` will install the latest version of Jikkou CLI.                       |
 | `jikkou_config`  |          | The path to the Jikkou CLI config file. If set, Jikkou CLI will be configured through the `JIKKOUCONFIG` environment variable. |
+
+## See also
+
+* [Detect configuration drift](/docs/how-to-guides/automating/detect-configuration-drift/): a
+  scheduled workflow that alerts when your clusters no longer match Git.

--- a/docs/content/en/docs/How-to Guides/Enforce-Policies.md
+++ b/docs/content/en/docs/How-to Guides/Enforce-Policies.md
@@ -20,11 +20,15 @@ For the broader picture, see [Validations]({{% relref "/docs/Concepts/validation
 
 ## 1. Write a policy
 
-A policy selects the resources it applies to and defines rules. Each rule's `expression` fails when it
-evaluates to `true`. The `failurePolicy` decides what happens on failure:
+A policy selects the resources it applies to and defines rules. Each rule's `expression` is a CEL
+assertion that must hold for the resource to be valid: the rule fails when the expression evaluates
+to `false` (the same convention as Kubernetes ValidatingAdmissionPolicy). The `failurePolicy` decides
+what happens on failure:
 
-* `FAIL` — abort the operation with an error.
-* `FILTER` — silently drop the invalid resource(s) and continue.
+* `FAIL`: abort the operation with an error.
+* `FILTER`: silently drop the invalid resource(s) and continue.
+* `CONTINUE`: report the violation but let the resource proceed. Useful to introduce a new rule in
+  "warning mode" before making it blocking.
 
 _`file: policy-topics.yaml`_
 
@@ -41,10 +45,10 @@ spec:
       - kind: KafkaTopic
   rules:
     - name: MaxTopicPartitions
-      expression: "resource.spec.partitions > 50"
+      expression: "resource.spec.partitions <= 50"
       messageExpression: "'Topic partitions MUST be <= 50, but was: ' + string(resource.spec.partitions)"
     - name: MinTopicPartitions
-      expression: "resource.spec.partitions < 3"
+      expression: "resource.spec.partitions >= 3"
       message: "Topic must have at least 3 partitions"
 ```
 
@@ -77,7 +81,7 @@ spec:
       - kind: KafkaTopicChange
   rules:
     - name: FilterDeleteOperation
-      expression: "resource.spec.op == 'DELETE'"
+      expression: "resource.spec.op != 'DELETE'"
       messageExpression: "'Operation ' + resource.spec.op + ' on topics is not authorized'"
 ```
 
@@ -97,10 +101,49 @@ selector:
       values: ["prod"]
 ```
 
-## Reuse policies across environments
+## Policy library
 
-Store policies in a [resource repository]({{% relref "/docs/Concepts/repositories.md" %}}) so they are injected
-automatically and shared across teams and environments, instead of passing them on every command.
+Ready-made policies you can copy and adapt live in
+[`examples/policies/`](https://github.com/streamthoughts/jikkou/tree/main/examples/policies):
+
+| Policy | What it enforces |
+|--------|------------------|
+| `topic-naming-convention.yaml` | Topic names follow a convention (kebab-case by default; adapt the regex) |
+| `topic-min-insync-replicas.yaml` | `min.insync.replicas` is set explicitly and is at least 2 |
+| `topic-min-replication-factor.yaml` | Replication factor is declared and at least 3 |
+| `topic-partition-limits.yaml` | Partition count stays within platform bounds (3 to 50 by default) |
+| `require-owner-label.yaml` | Every topic carries an `owner` label |
+| `block-topic-deletes.yaml` | Reconciliation may never delete a topic (matches change resources) |
+
+## Centrally enforce policies for all teams
+
+Passing policy files on every command works for one team, but a platform team usually wants policies
+applied to **every** run, no matter which files an application team passes. Configure a
+[resource repository]({{% relref "/docs/Concepts/repositories.md" %}}) in the shared Jikkou context:
+repository resources are injected automatically into each execution.
+
+```hocon
+jikkou {
+  repositories = [
+    {
+      name = "platform-policies"
+      type = io.jikkou.core.repository.GitHubResourceRepository
+      config {
+        repository = "my-org/kafka-platform-policies"
+        branch = "main"
+        paths = [ "policies/" ]
+        # Access token for private repositories
+        token = ${?GITHUB_TOKEN}
+      }
+    }
+  ]
+}
+```
+
+With this configuration in the context used by CI (or by the Jikkou API server), an application
+team running `jikkou apply -f ./my-topics.yaml` gets the platform policies evaluated on every
+resource and every change, without ever seeing the policy files. Updating a rule is a pull
+request on the central policies repository, immediately effective for all teams.
 
 ## Related
 

--- a/docs/content/en/docs/How-to Guides/Manage-Kafka-Fleet.md
+++ b/docs/content/en/docs/How-to Guides/Manage-Kafka-Fleet.md
@@ -1,0 +1,118 @@
+---
+title: "Manage a Fleet of Kafka Clusters"
+linkTitle: "Manage a Kafka Fleet"
+weight: 65
+description: >
+  Apply the same resource definitions across multiple Kafka clusters and providers in one command, with per-cluster results.
+---
+
+Most Kafka estates are fleets: a production cluster per region, staging, and often a mix of
+on-premises and managed services. Jikkou applies one declarative model across all of them:
+define each cluster as a named provider instance, group them, and target the group in one
+command.
+
+## Before you begin
+
+* A Jikkou context configured for your platform. See [Getting Started](/docs/tutorials/get_started/).
+
+## 1. Declare one provider instance per cluster
+
+Each cluster is a named entry under `provider`, all sharing the same provider type:
+
+```hocon
+jikkou {
+  provider.kafka-prod-eu {
+    type = io.jikkou.kafka.KafkaExtensionProvider
+    config {
+      client {
+        bootstrap.servers = "kafka-eu.internal:9092"
+      }
+    }
+  }
+  provider.kafka-prod-us {
+    type = io.jikkou.kafka.KafkaExtensionProvider
+    config {
+      client {
+        bootstrap.servers = "kafka-us.internal:9092"
+      }
+    }
+  }
+  provider.kafka-staging {
+    type = io.jikkou.kafka.KafkaExtensionProvider
+    config {
+      client {
+        bootstrap.servers = "kafka-staging.internal:9092"
+      }
+    }
+  }
+
+  # Named groups for batch operations
+  provider-groups {
+    prod = ["kafka-prod-eu", "kafka-prod-us"]
+  }
+}
+```
+
+## 2. Target the fleet
+
+The three selection flags are mutually exclusive:
+
+```bash
+# One cluster
+jikkou apply -f ./resources --provider kafka-prod-eu
+
+# A named group
+jikkou apply -f ./resources --provider-group prod
+
+# Every registered instance
+jikkou apply -f ./resources --provider-all
+```
+
+Multi-provider runs are **fail-fast** by default: the first failing cluster aborts the run.
+Add `--continue-on-error` to keep going and get results for the remaining clusters.
+
+## 3. Read per-cluster results
+
+Results are reported per provider. In TEXT output, tasks are grouped under a provider header:
+
+```
+PROVIDER [kafka-prod-eu] *******************************************************
+TASK [CREATE] Create a new topic orders-events (partitions=6, replicas=3) - CHANGED
+PROVIDER [kafka-prod-us] *******************************************************
+TASK [CREATE] Create a new topic orders-events (partitions=6, replicas=3) - CHANGED
+EXECUTION in 3s 421ms
+ok : 0, created : 2, altered : 0, deleted : 0 failed : 0
+```
+
+In JSON or YAML output, every change carries the `jikkou.io/provider` annotation, so results
+stay attributable when piped into other tools:
+
+```json
+{
+  "change": {
+    "metadata": {
+      "annotations": {
+        "jikkou.io/provider": "kafka-prod-eu"
+      }
+    }
+  }
+}
+```
+
+## Fleet-wide drift detection
+
+`jikkou diff` accepts the same provider flags, so a scheduled CI job can check the whole
+fleet at once and tell you **which** cluster drifted:
+
+```bash
+jikkou diff -f ./resources --provider-group prod --fail-on-changes
+```
+
+See [Detect configuration drift](/docs/how-to-guides/automating/detect-configuration-drift/)
+for the full CI setup.
+
+## Related
+
+* [jikkou apply command reference](/docs/reference/cli/commands/jikkou-apply/)
+* [Enforce governance policies](/docs/how-to-guides/enforce-policies/): the same policies can
+  guard every cluster in the fleet

--- a/docs/content/en/docs/How-to Guides/Migration/migrate-to-1.0.md
+++ b/docs/content/en/docs/How-to Guides/Migration/migrate-to-1.0.md
@@ -137,6 +137,9 @@ Existing scripts that call the old flat form (`jikkou get topics`, `jikkou get k
 
 `--provider`, `--provider-all`, and `--provider-group` are mutually exclusive. None of them are required: if you have a single provider of each type, your existing commands keep working unchanged.
 
+For a complete walkthrough (configuration, per-cluster results, fleet-wide drift checks), see
+[Manage a fleet of Kafka clusters](/docs/how-to-guides/manage-kafka-fleet/).
+
 ### Output format options
 
 `-o/--output` now accepts `JSON`, `YAML`, or `TABLE` on list and get commands.

--- a/docs/content/en/docs/Reference/CLI/Commands/jikkou-apply.md
+++ b/docs/content/en/docs/Reference/CLI/Commands/jikkou-apply.md
@@ -47,6 +47,12 @@ jikkou apply -f my-resources.yaml --options delete-orphans=true
 # Apply targeting a specific provider
 jikkou apply -f my-resources.yaml --provider kafka-prod
 
+# Apply to a named group of providers (a fleet of clusters) in one command
+jikkou apply -f my-resources.yaml --provider-group kafka-prod-fleet
+
+# Apply to all provider instances, continuing when one fails
+jikkou apply -f my-resources.yaml --provider-all --continue-on-error
+
 # Apply with JSON output format
 jikkou apply -f my-resources.yaml -o JSON --pretty
 ```
@@ -66,6 +72,9 @@ jikkou apply -f my-resources.yaml -o JSON --pretty
 | `--selector-match` | | `ALL` | Selector matching strategy. Valid values: ALL, ANY, NONE |
 | `--options` | | | Controller configuration options (key=value, repeatable) |
 | `--provider` | | | Select a specific provider instance |
+| `--provider-group` | | | Target a named group of providers (see `provider-groups` config). Mutually exclusive with `--provider` and `--provider-all` |
+| `--provider-all` | | `false` | Target all registered provider instances. Mutually exclusive with `--provider` and `--provider-group` |
+| `--continue-on-error` | | `false` | In multi-provider runs, continue with remaining providers when one fails (default is fail-fast) |
 | `--output` | `-o` | `TEXT` | Output format. Valid values: TEXT, COMPACT, JSON, YAML |
 | `--pretty` | | `false` | Pretty print JSON output |
 | `--dry-run` | | `false` | Execute command in dry-run mode (preview changes without applying) |

--- a/docs/content/en/docs/Reference/CLI/Commands/jikkou-diff.md
+++ b/docs/content/en/docs/Reference/CLI/Commands/jikkou-diff.md
@@ -44,6 +44,9 @@ jikkou diff -f my-resources.yaml --provider kafka-prod
 
 # Diff with selector
 jikkou diff -f my-resources.yaml -s 'metadata.name MATCHES (my-topic-.*)'
+
+# Detect configuration drift in CI: exit with code 3 when any change is pending
+jikkou diff -f my-resources.yaml --fail-on-changes
 ```
 
 ## Options
@@ -65,6 +68,21 @@ jikkou diff -f my-resources.yaml -s 'metadata.name MATCHES (my-topic-.*)'
 | `--filter-resource-op` | | | Filter resources by operation (comma-separated). Valid values: NONE, CREATE, DELETE, REPLACE, UPDATE |
 | `--filter-change-op` | | | Filter state changes by operation (comma-separated). Valid values: NONE, CREATE, DELETE, REPLACE, UPDATE |
 | `--list` | | `false` | Output resources as an ApiResourceChangeList |
+| `--fail-on-changes` | | `false` | Exit with code 3 when the diff contains at least one change. Prints a one-line summary to stderr; stdout stays machine-readable |
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Success. With `--fail-on-changes`: no changes detected |
+| `1` | Validation or execution error |
+| `2` | Usage error (invalid flags or arguments) |
+| `3` | Changes detected (only with `--fail-on-changes`) |
+
+The drift check is evaluated on the filtered result: combining `--fail-on-changes` with
+`--filter-change-op` or `--filter-resource-op` scopes which operations count as drift.
+See [Detect configuration drift](/docs/how-to-guides/automating/detect-configuration-drift/)
+for a complete CI setup.
 
 ## Options inherited from parent commands
 

--- a/docs/content/en/docs/Reference/Providers/Core/Resources/ValidatingResourcePolicy.md
+++ b/docs/content/en/docs/Reference/Providers/Core/Resources/ValidatingResourcePolicy.md
@@ -22,7 +22,7 @@ kind: ValidatingResourcePolicy
 metadata:
   name: <string> # Required. Unique policy name.
 spec:
-  failurePolicy: <string> # Required. One of: FAIL | FILTER
+  failurePolicy: <string> # Required. One of: FAIL | FILTER | CONTINUE
   selector:
     matchingStrategy: <string> # Optional. One of: ALL | ANY (default: ALL)
     matchResources:
@@ -36,7 +36,7 @@ spec:
       - <string> # CEL expression
   rules:
     - name: <string> # Required. Rule identifier.
-      expression: <string> # Required. A CEL expression evaluated against the resource.
+      expression: <string> # Required. A CEL assertion that must evaluate to true for the resource to be valid.
       message: <string> # Optional. Static message returned when the rule fails.
       messageExpression: <string> # Optional. CEL expression to generate a dynamic error message.
 ```
@@ -47,14 +47,14 @@ spec:
 
 | Field                            | Type     | Required | Description                                                                                                                                                                                         |
 |----------------------------------|----------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `spec.failurePolicy`             | `string` | Yes      | Defines the policy behavior when validation fails. Possible values:<br/>• `FAIL` → stop execution with an error.<br/>• `FILTER` → skip the invalid resource(s) but continue processing others.      |
+| `spec.failurePolicy`             | `string` | Yes      | Defines the policy behavior when validation fails. Possible values:<br/>• `FAIL` → stop execution with an error.<br/>• `FILTER` → skip the invalid resource(s) but continue processing others.<br/>• `CONTINUE` → report the violation but let the resource proceed (warning mode).      |
 | `spec.selector.matchingStrategy` | `string` | No       | Strategy for combining multiple selectors. Possible values:<br/>• `ALL` → resource must match **all** conditions.<br/>• `ANY` → resource must match **at least one** condition.<br/>Default: `ALL`. |
 | `spec.selector.matchResources`   | `list`   | No       | Selects resources by API version and kind.                                                                                                                                                          |
 | `spec.selector.matchLabels`      | `list`   | No       | Selects resources based on labels, using operators (`In`, `NotIn`, `Exists`, `DoesNotExist`).                                                                                                       |
 | `spec.selector.matchExpressions` | `list`   | No       | Selects resources using CEL expressions for advanced filtering.                                                                                                                                     |
 | `spec.rules`                     | `list`   | Yes      | A list of validation rules.                                                                                                                                                                         |
 | `spec.rules[].name`              | `string` | Yes      | A unique identifier for the rule.                                                                                                                                                                   |
-| `spec.rules[].expression`        | `string` | Yes      | A CEL expression evaluated against the resource. The rule fails when the expression evaluates to `true`.                                                                                            |
+| `spec.rules[].expression`        | `string` | Yes      | A CEL assertion evaluated against the resource. The rule fails when the expression evaluates to `false`, i.e., the expression states what must hold for the resource to be valid.                    |
 | `spec.rules[].message`           | `string` | No       | Static error message returned when validation fails.                                                                                                                                                |
 | `spec.rules[].messageExpression` | `string` | No       | CEL expression returning a dynamic error message string.                                                                                                                                            |
 
@@ -154,7 +154,7 @@ spec:
       - kind: KafkaTopicChange
   rules:
     - name: FilterDeleteOperation
-      expression: "size(resource.spec.changes) > 0 && resource.spec.op == 'DELETE'"
+      expression: "resource.spec.op != 'DELETE'"
       messageExpression: "'Operation ' + resource.spec.op + ' on topics is not authorized'"
 ```
 
@@ -176,11 +176,11 @@ spec:
       - kind: KafkaTopic
   rules:
     - name: MaxTopicPartitions
-      expression: "resource.spec.partitions >= 50"
+      expression: "resource.spec.partitions < 50"
       messageExpression: "'Topic partition MUST be inferior to 50, but was: ' + string(resource.spec.partitions)"
 
     - name: MinTopicPartitions
-      expression: "resource.spec.partitions < 3"
+      expression: "resource.spec.partitions >= 3"
       message: "Topic must have at-least 3 partitions"
 ```
 

--- a/docs/content/en/docs/Reference/Providers/Kafka/Transformations/KafkaTopicMaxReplicas.md
+++ b/docs/content/en/docs/Reference/Providers/Kafka/Transformations/KafkaTopicMaxReplicas.md
@@ -1,0 +1,33 @@
+---
+title: "KafkaTopicMaxReplicas"
+linkTitle: "KafkaTopicMaxReplicas"
+description: "Enforce a maximum replication factor for Kafka topics using this Jikkou transformation."
+aliases:
+  - /docs/providers/kafka/transformations/kafkatopicmaxreplicas/
+---
+
+{{% pageinfo color="info" %}}
+This transformation can be used to enforce a maximum value for the replication factor of kafka topics.
+{{% /pageinfo %}}
+
+## Configuration
+
+| Name                   | Type | Description                                                     | Default |
+|------------------------|------|-----------------------------------------------------------------|---------|
+| `maxReplicationFactor` | Int  | Maximum value of replication factor to be used for Kafka Topics |         |
+
+## Example
+
+```hocon
+jikkou {
+  transformations: [
+    {
+      type = io.jikkou.kafka.transform.KafkaTopicMaxReplicasTransformation
+      priority = 100
+      config = {
+        maxReplicationFactor = 5
+      }
+    }
+  ]
+}
+```

--- a/examples/policies/block-topic-deletes.yaml
+++ b/examples/policies/block-topic-deletes.yaml
@@ -1,0 +1,22 @@
+---
+# Abort any reconciliation that would DELETE a Kafka topic.
+#
+# This policy matches change resources (KafkaTopicChange), not topic
+# definitions: it inspects the operations Jikkou is about to execute.
+# With failurePolicy FAIL the whole run is aborted with an error; change
+# it to FILTER to silently skip deletions and apply everything else.
+#
+# Usage: jikkou apply -f <resources> -f block-topic-deletes.yaml
+apiVersion: core.jikkou.io/v1
+kind: ValidatingResourcePolicy
+metadata:
+  name: BlockTopicDeletes
+spec:
+  failurePolicy: FAIL
+  selector:
+    matchResources:
+      - kind: KafkaTopicChange
+  rules:
+    - name: DenyDeleteOperation
+      expression: "resource.spec.op != 'DELETE'"
+      messageExpression: "'Deleting topics through reconciliation is not authorized (topic: ' + resource.metadata.name + ')'"

--- a/examples/policies/kafka-topic-filtering-polices.yaml
+++ b/examples/policies/kafka-topic-filtering-polices.yaml
@@ -9,8 +9,8 @@ spec:
   failurePolicy: FILTER
   selector:
     matchResources:
-      - kinds: KafkaTopicChange
+      - kind: KafkaTopicChange
   rules:
     - name: FilterDeleteOperation
-      expression: "size(resource.spec.changes) > 0 && resource.spec.op == 'DELETE'"
-      messageExpression: "'Operation ' + resource.spec.op + '  on topics is not authorized'"
+      expression: "resource.spec.op != 'DELETE'"
+      messageExpression: "'Operation ' + resource.spec.op + ' on topics is not authorized'"

--- a/examples/policies/kafka-topic-validating-polices.yaml
+++ b/examples/policies/kafka-topic-validating-polices.yaml
@@ -12,7 +12,7 @@ spec:
       - kind: KafkaTopic
   rules:
     - name: MaxTopicPartitions
-      expression: "resource.spec.partitions >= 50"
+      expression: "resource.spec.partitions < 50"
       messageExpression: "'Topic partition MUST be inferior to 50, but was: ' +  string(resource.spec.partitions)"
 
     - name: MinTopicPartitions

--- a/examples/policies/require-owner-label.yaml
+++ b/examples/policies/require-owner-label.yaml
@@ -1,0 +1,21 @@
+---
+# Require every KafkaTopic to carry an 'owner' label.
+#
+# Ownership metadata is what turns an incident ("who do we page about this
+# topic?") into a lookup. Combine with labels like 'team' or 'cost-center'
+# as needed.
+#
+# Usage: jikkou validate -f <resources> -f require-owner-label.yaml
+apiVersion: core.jikkou.io/v1
+kind: ValidatingResourcePolicy
+metadata:
+  name: RequireOwnerLabel
+spec:
+  failurePolicy: FAIL
+  selector:
+    matchResources:
+      - kind: KafkaTopic
+  rules:
+    - name: OwnerLabelMustBePresent
+      expression: "has(resource.metadata.labels) && 'owner' in resource.metadata.labels"
+      messageExpression: "'Topic ' + resource.metadata.name + ' must declare an owner label'"

--- a/examples/policies/topic-min-insync-replicas.yaml
+++ b/examples/policies/topic-min-insync-replicas.yaml
@@ -1,0 +1,23 @@
+---
+# Require every KafkaTopic to explicitly set min.insync.replicas >= 2.
+#
+# Protects against data loss on broker failure: with acks=all, producers get an
+# error instead of silently writing to a single in-sync replica.
+#
+# Usage: jikkou validate -f <resources> -f topic-min-insync-replicas.yaml
+apiVersion: core.jikkou.io/v1
+kind: ValidatingResourcePolicy
+metadata:
+  name: TopicMinInSyncReplicas
+spec:
+  failurePolicy: FAIL
+  selector:
+    matchResources:
+      - kind: KafkaTopic
+  rules:
+    - name: MinInSyncReplicasMustBeSet
+      expression: "has(resource.spec.configs) && 'min.insync.replicas' in resource.spec.configs"
+      message: "Topic must explicitly set the min.insync.replicas config"
+    - name: MinInSyncReplicasMustBeAtLeastTwo
+      expression: "!has(resource.spec.configs) || !('min.insync.replicas' in resource.spec.configs) || int(resource.spec.configs['min.insync.replicas']) >= 2"
+      messageExpression: "'min.insync.replicas must be >= 2, but was: ' + string(resource.spec.configs['min.insync.replicas'])"

--- a/examples/policies/topic-min-replication-factor.yaml
+++ b/examples/policies/topic-min-replication-factor.yaml
@@ -1,0 +1,24 @@
+---
+# Require every KafkaTopic to declare a replication factor of at least 3.
+#
+# A replication factor below 3 cannot tolerate a broker failure during a
+# rolling restart. The rule also fails when replicas is not set explicitly,
+# so topics cannot silently fall back to a weaker cluster default.
+#
+# Usage: jikkou validate -f <resources> -f topic-min-replication-factor.yaml
+apiVersion: core.jikkou.io/v1
+kind: ValidatingResourcePolicy
+metadata:
+  name: TopicMinReplicationFactor
+spec:
+  failurePolicy: FAIL
+  selector:
+    matchResources:
+      - kind: KafkaTopic
+  rules:
+    - name: ReplicationFactorMustBeSet
+      expression: "has(resource.spec.replicas)"
+      message: "Topic must explicitly declare spec.replicas"
+    - name: ReplicationFactorMustBeAtLeastThree
+      expression: "!has(resource.spec.replicas) || int(resource.spec.replicas) >= 3"
+      messageExpression: "'Topic replication factor must be >= 3, but was: ' + string(resource.spec.replicas)"

--- a/examples/policies/topic-naming-convention.yaml
+++ b/examples/policies/topic-naming-convention.yaml
@@ -1,0 +1,21 @@
+---
+# Enforce a naming convention on every KafkaTopic.
+#
+# This example requires kebab-case names (e.g. 'orders-events', 'payment-refunds').
+# Adjust the regex to your own convention, e.g. '^(europe|us|asia)-.+' to require
+# a region prefix, or '^[a-z]+\\.[a-z]+\\..+' for dot-separated domains.
+#
+# Usage: jikkou validate -f <resources> -f topic-naming-convention.yaml
+apiVersion: core.jikkou.io/v1
+kind: ValidatingResourcePolicy
+metadata:
+  name: TopicNamingConvention
+spec:
+  failurePolicy: FAIL
+  selector:
+    matchResources:
+      - kind: KafkaTopic
+  rules:
+    - name: TopicNameMustBeKebabCase
+      expression: "resource.metadata.name.matches('^[a-z0-9]+(-[a-z0-9]+)*$')"
+      messageExpression: "'Topic name must be kebab-case (lowercase alphanumerics and dashes), but was: ' + resource.metadata.name"

--- a/examples/policies/topic-partition-limits.yaml
+++ b/examples/policies/topic-partition-limits.yaml
@@ -1,0 +1,23 @@
+---
+# Keep KafkaTopic partition counts within platform limits.
+#
+# Too few partitions limits consumer parallelism; too many wastes broker
+# resources and slows recovery. Adjust the bounds to your platform sizing.
+#
+# Usage: jikkou validate -f <resources> -f topic-partition-limits.yaml
+apiVersion: core.jikkou.io/v1
+kind: ValidatingResourcePolicy
+metadata:
+  name: TopicPartitionLimits
+spec:
+  failurePolicy: FAIL
+  selector:
+    matchResources:
+      - kind: KafkaTopic
+  rules:
+    - name: MinTopicPartitions
+      expression: "resource.spec.partitions >= 3"
+      messageExpression: "'Topic must have at least 3 partitions, but was: ' + string(resource.spec.partitions)"
+    - name: MaxTopicPartitions
+      expression: "resource.spec.partitions <= 50"
+      messageExpression: "'Topic must have at most 50 partitions, but was: ' + string(resource.spec.partitions)"

--- a/jikkou_completion
+++ b/jikkou_completion
@@ -829,7 +829,7 @@ function _picocli_jikkou_diff() {
   local prev_word=${COMP_WORDS[COMP_CWORD-1]}
 
   local commands=""
-  local flag_opts="'--provider-all' '--continue-on-error' '--list' '-h' '--help' '-V' '--version'"
+  local flag_opts="'--provider-all' '--continue-on-error' '--list' '--fail-on-changes' '-h' '--help' '-V' '--version'"
   local arg_opts="'--logger-level' '--files' '-f' '--file-name' '-n' '--values-files' '--values-file-name' '--set-label' '-l' '--set-annotation' '--set-value' '-v' '--selector' '-s' '--selector-match' '--output' '-o' '--options' '--provider' '--provider-group' '--filter-resource-op' '--filter-change-op'"
   local selectorMatchingStrategy_option_args=("NONE" "ALL" "ANY") # --selector-match values
   local format_option_args=("JSON" "YAML") # --output values

--- a/pom.xml
+++ b/pom.xml
@@ -424,6 +424,10 @@
                                         <manifestEntries>
                                             <Implementation-Title>Jikkou</Implementation-Title>
                                             <Implementation-Version>${project.version}</Implementation-Version>
+                                            <!-- Required so multi-release dependencies (e.g. dnsjava's
+                                                 java.net.spi.InetAddressResolverProvider) stay loadable
+                                                 from the shaded jar. -->
+                                            <Multi-Release>true</Multi-Release>
                                         </manifestEntries>
                                     </transformer>
                                 </transformers>


### PR DESCRIPTION
- cli: add 'jikkou diff --fail-on-changes' exiting with code 3 when changes are detected, with a change-count summary on stderr for CI drift checks
- core: tag multi-provider change results with the jikkou.io/provider annotation; cli: group text printer output under PROVIDER [name] headers
- core: fix provider annotation leaking onto shared input resources, which made --provider-all/--provider-group skip every provider after the first
- core: fix CEL evaluation of non-JSON-native scalars (e.g. Short spec.replicas) by normalizing resources through a JSON round-trip
- policies: add ready-made policy pack under examples/policies and rewrite all examples/docs to assertion semantics (rule fails when expression is false, as the engine implements)
- docs: drift detection and fleet how-to guides, exit-code reference, central policy distribution, KafkaTopicMaxReplicas reference page
- build: restore Multi-Release manifest entry in the shaded runner jar
- add ADOPTERS.md and SECURITY.md