### PR TITLE
feat(skills): add official Claude Code agent skills plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,11 @@
+{
+  "name": "jikkou",
+  "owner": { "name": "Jikkou" },
+  "plugins": [
+    {
+      "name": "jikkou",
+      "source": "./",
+      "description": "Official Jikkou skills for AI agents: manage Kafka topics, ACLs, quotas, schemas, and connectors declaratively with the Jikkou CLI."
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "jikkou",
+  "description": "Official Jikkou skills for AI agents: manage Kafka topics, ACLs, quotas, schemas, and connectors declaratively with the Jikkou CLI.",
+  "version": "0.1.0",
+  "author": { "name": "Jikkou" },
+  "homepage": "https://www.jikkou.io",
+  "repository": "https://github.com/streamthoughts/jikkou",
+  "license": "Apache-2.0",
+  "keywords": ["kafka", "gitops", "topics", "acls", "schema-registry", "kafka-connect"]
+}

--- a/README.md
+++ b/README.md
@@ -144,6 +144,23 @@ Jikkou follows a simple reconciliation loop:
 | **Docker**        | Available as container images on [Docker Hub](https://hub.docker.com/r/streamthoughts/jikkou) |
 | **Native Binary** | GraalVM-compiled native executables for instant startup                                       |
 
+## Use Jikkou with AI Agents
+
+Jikkou ships official [Agent Skills](https://agentskills.io) so coding agents can manage
+your Kafka resources through the CLI — with validation and dry-runs built into the workflow.
+
+**Claude Code:**
+
+```
+/plugin marketplace add streamthoughts/jikkou
+/plugin install jikkou
+```
+
+**Other agents:** copy [`skills/managing-kafka-resources`](./skills/managing-kafka-resources) into your agent's skills directory.
+
+The skill never applies changes without showing a diff or dry-run first, and asks before
+installing anything.
+
 ## Documentation
 
 Full documentation is available at **[jikkou.io](https://jikkou.io/)**.

--- a/skills/managing-kafka-resources/SKILL.md
+++ b/skills/managing-kafka-resources/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: managing-kafka-resources
+description: Use when managing Apache Kafka topics, ACLs, quotas, users, consumer groups, Schema Registry subjects, Kafka Connect connectors, or Aiven, Confluent Cloud, AWS Glue, and Apache Iceberg resources declaratively with the Jikkou CLI: creating, inspecting, or changing resources, previewing changes before apply, or diagnosing Kafka misconfigurations.
+---
+
+# Jikkou: Resource as Code for Apache Kafka
+
+Declarative management of Kafka-ecosystem resources: YAML in, reconciliation against the real cluster out. Stateless: `diff` compares against live cluster state, never a state file.
+
+## Setup check (always run first)
+
+1. `jikkou --version` confirms the CLI is on PATH. Missing? See "If jikkou is not installed".
+2. `jikkou health get kafka` verifies connectivity (`health get-indicators` only *lists* indicators; it doesn't check connectivity). For other providers use `jikkou health get <indicator>`; indicator names differ from provider names, see `references/diagnostics.md` for the exact list.
+3. No context configured? Run `jikkou config current-context` and `jikkou config view`; config lives in `~/.jikkou/config`. See the context safety rule below.
+
+## Core workflow
+
+Discover → author → validate → diff → apply. Never skip validate/diff.
+
+- Inspect current state: `jikkou get <provider> <kind> -o JSON` (providers: kafka, schemaregistry, kafkaconnect, aiven, confluent-cloud, aws, iceberg). Filter: `--name <name>` or `-s 'metadata.name IN (a,b)'`.
+- Discover kinds/schemas: `jikkou api-resources list`, then `jikkou api-resources schema --api-version=<v> --kind=<k>`. `list → schema → write YAML → validate → diff` is the canonical authoring chain.
+- Validate: `jikkou validate --files <file>` returns normalized resources or errors.
+- Preview: `jikkou diff --files <file>` shows the exact changes vs. the live cluster.
+- Apply: `jikkou apply --files <file> --dry-run` first; drop `--dry-run` only after the user confirms the diff.
+
+## Safety rules
+
+- Never run `apply` without first showing the user `diff` or `--dry-run` output.
+- Deleting a resource requires the annotation `jikkou.io/delete: true` on it — never delete another way.
+- Treat contexts named prod/production with extra confirmation before any non-dry-run apply.
+- Never run `jikkou config use-context` casually: jikkou eagerly loads the current context on every call, so a broken context bricks *every* command, not just the one you meant to try. Check `current-context`/`config view` first; if a switch is truly needed, verify the target, then switch back.
+
+## Provider references
+
+Before authoring resources for a provider, read the matching file:
+`references/kafka.md`, `references/schema-registry.md`, `references/kafka-connect.md`, `references/aiven.md`, `references/confluent-cloud.md`, `references/aws-glue.md`, `references/iceberg.md`.
+For misconfiguration checks, consumer lag, and ACL audits, use `references/diagnostics.md`.
+
+## If jikkou is not installed
+
+Confirm with the user first. In order of preference:
+- SDKMan: `sdk install jikkou`
+- Homebrew: `brew install streamthoughts/tap/jikkou`
+- No install rights: prefix every command with `docker run --rm -v $PWD:/work -w /work streamthoughts/jikkou`
+After install: `jikkou --version`, then `jikkou health get kafka` before proceeding.
+
+## Common mistakes
+
+- Guessing YAML fields instead of reading the provider reference or running `api-resources schema`; `validate` catches this, so run it.
+- Using `kafka-topics.sh`-style imperative commands — everything goes through resource files.
+- Editing a live resource without fetching it first: `jikkou get ... -o YAML` is the starting point.
+- Applying directly (e.g. `jikkou create -f file.yaml`) skipping `validate`/`diff`/`--dry-run`, even when the change looks trivial; it mutates the cluster with no preview.
+- Rediscovering commands via repeated `--help` calls instead of reading `references/<provider>.md` first (far more tool calls for the same answer).
+- Switching contexts to "just try" a different cluster — see the context safety rule above.

--- a/skills/managing-kafka-resources/evaluations.json
+++ b/skills/managing-kafka-resources/evaluations.json
@@ -1,0 +1,32 @@
+[
+  {
+    "skills": ["jikkou"],
+    "query": "Create a Kafka topic named 'orders' with 6 partitions, replication factor 3, and 7-day retention on the current cluster.",
+    "expected_behavior": [
+      "Runs the setup check first: jikkou --version, then jikkou health get kafka",
+      "Authors a KafkaTopic YAML matching references/kafka.md (apiVersion kafka.jikkou.io/v1, retention.ms for 7 days, min.insync.replicas <= replicas)",
+      "Runs jikkou validate and jikkou diff on the file before any apply",
+      "Runs jikkou apply --dry-run and shows the diff, waiting for user confirmation before applying without --dry-run"
+    ]
+  },
+  {
+    "skills": ["jikkou"],
+    "query": "Who can read the 'payments' topic on this cluster?",
+    "expected_behavior": [
+      "Reads references/diagnostics.md and fetches ACLs with jikkou get kafka acls -o JSON",
+      "Filters ACLs client-side on spec.acls[].resource.pattern, honoring patternType (literal vs prefixed)",
+      "Does not conclude 'nobody' from an empty ACL list; checks broker authorizer configuration via jikkou get kafka brokers --static-broker-configs -o JSON",
+      "Reports that allow.everyone.if.no.acl.found and super.users are absent from Admin API output and must be read from the broker's own configuration"
+    ]
+  },
+  {
+    "skills": ["jikkou"],
+    "query": "Consumers in group 'invoice-processor' seem stuck. Can you check?",
+    "expected_behavior": [
+      "Takes two snapshots roughly 30 seconds apart with jikkou get kafka consumer-groups -o JSON --offsets",
+      "Derives end offsets as offset + offset-lag and compares committed offsets across the two snapshots",
+      "Distinguishes a STABLE group with unchanged commits and advancing end offsets (stuck) from an EMPTY group with lag (no active members)",
+      "Passes at most one value to --in-states, running one command per state if several states are needed"
+    ]
+  }
+]

--- a/skills/managing-kafka-resources/references/aiven.md
+++ b/skills/managing-kafka-resources/references/aiven.md
@@ -1,0 +1,57 @@
+# Aiven provider
+
+## Kinds
+
+| Kind | Get command | apiVersion |
+|---|---|---|
+| KafkaTopic | `jikkou get aiven topics` | kafka.aiven.io/v1 |
+| KafkaTopicAclEntry | `jikkou get aiven kafka-acls` | kafka.aiven.io/v1 |
+| KafkaQuota | `jikkou get aiven kafka-quotas` | kafka.aiven.io/v1 |
+| SchemaRegistrySubject | `jikkou get aiven subjects` | kafka.aiven.io/v1 |
+| SchemaRegistryAclEntry | `jikkou get aiven schemaregistry-acls` | kafka.aiven.io/v1 |
+
+All get commands accept `-o JSON|YAML` and selectors `-s '<expr>'`. `topics` and `subjects` additionally accept `--name <name>`; the ACL and quota get commands do not.
+
+## Authoring examples
+
+Kafka topic ACL entries (one file, `---`-separated):
+```yaml
+apiVersion: 'kafka.aiven.io/v1'
+kind: 'KafkaTopicAclEntry'
+metadata:
+  labels: {}
+spec:
+  permission: 'ADMIN'
+  username: 'avnadmin'
+  topic: '*'
+---
+apiVersion: 'kafka.aiven.io/v1'
+kind: 'KafkaTopicAclEntry'
+metadata:
+  labels: {}
+spec:
+  permission: 'READWRITE'
+  username: 'alice'
+  topic: '*alice*'
+```
+
+`spec.permission` accepts `ADMIN`, `READ`, `READWRITE`, `WRITE`. The same enum applies to `SchemaRegistryAclEntry.spec.permission`.
+
+Kafka quota:
+```yaml
+apiVersion: 'kafka.aiven.io/v1'
+kind: 'KafkaQuota'
+spec:
+  user: 'default'
+  clientId: 'default'
+  consumerByteRate: 1048576
+  producerByteRate: 1048576
+  requestPercentage: 25
+```
+
+## Notes
+
+- Requires Aiven project/service and API token configured under `jikkou.provider.aiven.config`: `project`, `service`, `apiUrl` (default `https://api.aiven.io/v1/`), `tokenAuth` (Aiven Bearer Token from your Aiven profile page), plus optional proxy settings (`proxyUrl`, `proxyUsername`, `proxyPassword`, `nonProxyHosts`).
+- ACL entries are identified by an auto-assigned ID; Jikkou records it in the `kafka.aiven.io/acl-entry-id` annotation once created (source: `MetadataAnnotations.AIVEN_IO_KAFKA_ACL_ID` in `jikkou-provider-aiven` — some older docs pages show a different key, trust this one).
+- Deleting: add `jikkou.io/delete: true` under `metadata.annotations`, then `jikkou apply`.
+- `jikkou api-resources schema --api-version=kafka.aiven.io/v1 --kind=<Kind>` prints the JSON Schema for a kind's `spec`.

--- a/skills/managing-kafka-resources/references/aws-glue.md
+++ b/skills/managing-kafka-resources/references/aws-glue.md
@@ -1,0 +1,48 @@
+# AWS Glue provider
+
+## Kinds
+
+| Kind | Get command | apiVersion |
+|---|---|---|
+| AwsGlueSchema | `jikkou get aws glue-schemas` | aws.jikkou.io/v1 |
+
+All get commands accept `-o JSON|YAML`, `--name <name>`, and selectors `-s '<expr>'`.
+
+## Authoring examples
+
+Avro schema on the Glue Schema Registry:
+```yaml
+apiVersion: 'aws.jikkou.io/v1'
+kind: 'AwsGlueSchema'
+metadata:
+  name: 'PersonAvro'
+  labels:
+    glue.aws.amazon.com/registry-name: 'Test'
+  annotations:
+    glue.aws.amazon.com/use-canonical-fingerprint: true
+spec:
+  compatibility: 'BACKWARD'
+  dataFormat: 'AVRO'
+  schemaDefinition: |
+    {
+      "namespace": "example",
+      "type": "record",
+      "name": "Person",
+      "fields": [
+        { "name": "id", "type": "int", "doc": "The person's unique ID (required)" },
+        { "name": "firstname", "type": "string", "doc": "The person's legal firstname (required)" },
+        { "name": "lastname", "type": "string", "doc": "The person's legal lastname (required)" },
+        { "name": "age", "type": ["null", "int"], "default": null, "doc": "The person's age (optional)" }
+      ]
+    }
+```
+
+`spec.dataFormat` accepts `AVRO`, `PROTOBUF`, `JSON`. `spec.compatibility` accepts `NONE`, `DISABLED`, `BACKWARD`, `BACKWARD_ALL`, `FORWARD`, `FORWARD_ALL`, `FULL`, `FULL_ALL` (applies to all versions of the Glue schema).
+
+## Notes
+
+- Requires AWS credentials and region configured under `jikkou.provider.aws.config`: `aws.client.region`, `aws.client.accessKeyId`, `aws.client.secretAccessKey`, optional `aws.client.sessionToken`, and optional `aws.client.endpointOverride` (for S3-compatible/Glue-compatible endpoints). `aws.glue.registryNames` restricts lookups to a given set of registry names.
+- The Glue registry a schema belongs to is set via the `glue.aws.amazon.com/registry-name` label, not a spec field.
+- `glue.aws.amazon.com/created-time`, `updated-time`, `registry-arn`, `schema-arn`, `schema-version-id` are read-only annotations Jikkou attaches automatically. `glue.aws.amazon.com/use-canonical-fingerprint` compares schemas by canonical fingerprint (AVRO only).
+- Deleting: add `jikkou.io/delete: true` under `metadata.annotations`, then `jikkou apply`.
+- `jikkou api-resources schema --api-version=aws.jikkou.io/v1 --kind=AwsGlueSchema` prints the JSON Schema for the `spec` field.

--- a/skills/managing-kafka-resources/references/confluent-cloud.md
+++ b/skills/managing-kafka-resources/references/confluent-cloud.md
@@ -1,0 +1,33 @@
+# Confluent Cloud provider
+
+## Kinds
+
+| Kind | Get command | apiVersion |
+|---|---|---|
+| RoleBinding | `jikkou get confluent-cloud role-bindings` | iam.confluent.cloud/v1 |
+
+The `role-bindings` get command accepts `-o JSON|YAML` and selectors `-s '<expr>'`. It does not accept `--name` (role bindings are listed and filtered by selector, not fetched by name).
+
+## Authoring examples
+
+Role binding (one file, `---`-separated for multiple):
+```yaml
+apiVersion: 'iam.confluent.cloud/v1'
+kind: 'RoleBinding'
+metadata:
+  labels: {}
+  annotations: {}
+spec:
+  principal: 'User:sa-abc123'
+  roleName: 'CloudClusterAdmin'
+  crnPattern: 'crn://confluent.cloud/organization=org-123/environment=env-456/cloud-cluster=lkc-789'
+```
+
+`spec.principal` is `User:<id>` or `Group:<id>`. `spec.roleName` is any Confluent Cloud RBAC role name (e.g. `CloudClusterAdmin`, `EnvironmentAdmin`, `Operator`).
+
+## Notes
+
+- Requires `jikkou.provider.confluent-cloud.config`: `apiKey` and `apiSecret` (must be a **Cloud API Key**, not a Cluster API Key — a Cluster API Key fails with `401 Unauthorized`), and `crnPattern` (required — scopes role-binding list operations to an org/environment/cluster). `apiUrl` defaults to `https://api.confluent.cloud`. Optional proxy settings: `proxyUrl`, `proxyUsername`, `proxyPassword`, `nonProxyHosts`.
+- Create a Cloud API Key with: `confluent api-key create --resource cloud --description "Jikkou role binding management"`.
+- Deleting: add `jikkou.io/delete: true` under `metadata.annotations`, then `jikkou apply`.
+- `jikkou api-resources schema --api-version=iam.confluent.cloud/v1 --kind=RoleBinding` prints the JSON Schema for the `spec` field.

--- a/skills/managing-kafka-resources/references/diagnostics.md
+++ b/skills/managing-kafka-resources/references/diagnostics.md
@@ -1,0 +1,52 @@
+# Diagnostics with Jikkou
+
+Jikkou reads are snapshots of live cluster state — ideal for config audits, not a monitoring system. For lag *trends*, direct the user to their monitoring stack; for point-in-time answers, use the recipes below.
+
+## Connectivity / health checks
+
+Before diagnosing anything, confirm the target is reachable:
+```bash
+jikkou health get kafka           # or: schemaregistry | avnservice | kafkaconnect | iceberg
+```
+`jikkou health get-indicators` only lists the available indicator names — it does not report status; use `jikkou health get <name>` for the actual health check. There is no `confluent-cloud` or `aws` indicator.
+
+## Misconfiguration audit
+
+Fetch everything, then check each topic:
+```bash
+jikkou get kafka topics -o JSON --default-configs
+jikkou get kafka brokers -o JSON
+```
+Red flags to report:
+- `min.insync.replicas` >= `replicas` (producers with acks=all will fail)
+- `replicas: 1` on anything that looks production-critical
+- `retention.ms` extreme values (< 1h or > 30d) — confirm intent with the user
+- `cleanup.policy: compact` on topics whose producers don't use keys (can't verify from config alone — flag it as a question)
+- partitions = 1 on high-throughput topics
+
+## Who can access a topic
+
+```bash
+jikkou get kafka acls -o JSON
+```
+Filter client-side for the topic name in `spec.acls[].resource.pattern`, honoring `patternType` (literal vs prefixed). Report principal, operations, host.
+
+An empty (or non-matching) ACL result doesn't mean "nobody can access it" — check the broker authorizer configuration too:
+```bash
+jikkou get kafka brokers --static-broker-configs -o JSON
+```
+Look at `authorizer.class.name` (no authorizer configured means no ACL enforcement at all), `allow.everyone.if.no.acl.found` (true grants access to anyone when no ACL matches), and `super.users` (listed principals bypass ACL checks entirely). All three change the answer to "who can read topic X" independently of the ACL list itself.
+
+Caution: the Kafka Admin API does **not** return `allow.everyone.if.no.acl.found` or `super.users` — they are absent from `--static-broker-configs` output even when explicitly set on the broker. Absent means *unknown*, not "default false". So when the ACL list is empty but an authorizer is configured, do not conclude "nobody can access it": report that no ACLs are defined and that effective access depends on `allow.everyone.if.no.acl.found` and `super.users`, which must be read from the broker's server.properties or deployment config, not from Jikkou.
+
+## Stuck consumer snapshot
+
+Take two snapshots ~30s apart:
+```bash
+jikkou get kafka consumer-groups -o JSON --offsets
+sleep 30
+jikkou get kafka consumer-groups -o JSON --offsets
+```
+A group is likely stuck when: state is STABLE, committed offsets unchanged between snapshots, and end offsets advanced (the output has only `offset` and `offset-lag` per partition; end offset = offset + offset-lag). EMPTY state with lag means no active members — different problem, report it as such.
+
+To narrow the snapshot to specific states, use `--in-states`, but note it only accepts a **single** value (e.g. `--in-states=STABLE`) — a comma-separated list or a repeated flag both fail with an `IllegalArgumentException`/duplicate-option error. Run one command per state if you need more than one.

--- a/skills/managing-kafka-resources/references/iceberg.md
+++ b/skills/managing-kafka-resources/references/iceberg.md
@@ -1,0 +1,94 @@
+# Apache Iceberg provider
+
+## Kinds
+
+| Kind | Get command | apiVersion |
+|---|---|---|
+| IcebergNamespace | `jikkou get iceberg namespaces` | iceberg.jikkou.io/v1beta1 |
+| IcebergTable | `jikkou get iceberg tables` | iceberg.jikkou.io/v1beta1 |
+| IcebergView | `jikkou get iceberg views` | iceberg.jikkou.io/v1beta1 |
+
+All get commands accept `-o JSON|YAML`, `--name <name>`, and selectors `-s '<expr>'`.
+
+## Authoring examples
+
+Namespace (one file, `---`-separated for a nested namespace):
+```yaml
+apiVersion: 'iceberg.jikkou.io/v1beta1'
+kind: 'IcebergNamespace'
+metadata:
+  name: 'analytics'
+spec:
+  properties:
+    owner: 'data-team'
+    environment: 'production'
+---
+apiVersion: 'iceberg.jikkou.io/v1beta1'
+kind: 'IcebergNamespace'
+metadata:
+  name: 'analytics.events'
+spec:
+  properties:
+    owner: 'data-team'
+    team: 'platform'
+```
+
+Table:
+```yaml
+apiVersion: 'iceberg.jikkou.io/v1beta1'
+kind: 'IcebergTable'
+metadata:
+  name: 'analytics.events.page_views'
+spec:
+  schema:
+    columns:
+      - name: 'event_id'
+        type: 'uuid'
+        required: true
+        doc: 'Unique event identifier'
+      - name: 'user_id'
+        type: 'long'
+        required: true
+        doc: 'The user who triggered the event'
+      - name: 'event_time'
+        type: 'timestamptz'
+        required: true
+        doc: 'Timestamp when the event occurred (UTC)'
+  partitionFields:
+    - sourceColumn: 'event_time'
+      transform: 'day'
+  sortFields:
+    - column: 'event_time'
+      direction: 'asc'
+      nullOrder: 'last'
+  properties:
+    write.format.default: 'parquet'
+    write.parquet.compression-codec: 'zstd'
+```
+
+`spec.partitionFields[].transform` accepts `identity`, `year`, `month`, `day`, `hour`, `bucket[N]`, `truncate[W]`, `void`. `spec.sortFields[].nullOrder` accepts only `first` or `last`; anything else silently falls back to `last`.
+
+View (author `spec.queries`, not `spec.schema` — the view's `schema` is read-only, inferred by the engine on collect):
+```yaml
+apiVersion: 'iceberg.jikkou.io/v1beta1'
+kind: 'IcebergView'
+metadata:
+  name: 'analytics.events.daily_page_views'
+spec:
+  defaultCatalog: 'default'
+  defaultNamespace: 'analytics.events'
+  queries:
+    - dialect: 'spark'
+      sql: 'SELECT date(event_time) AS day, count(*) AS views FROM page_views GROUP BY date(event_time)'
+  properties:
+    comment: 'Daily page-view counts'
+```
+
+At least one `queries` entry is required; `defaultNamespace`/`defaultCatalog` resolve unqualified table references in the SQL.
+
+## Notes
+
+- Requires a catalog configured under `jikkou.provider.iceberg.config`: `catalogType` (required — `rest`, `hive`, `jdbc`, `glue`, `nessie`, `hadoop`), `catalogName` (default `default`), `catalogUri`, `warehouse`, and free-form `catalogProperties` forwarded to Iceberg's `CatalogUtil`. Nessie is best reached via `catalogType: 'rest'` pointed at its built-in Iceberg REST endpoint (`.../iceberg`), since the dedicated `nessie` catalog type needs an optional JAR not always bundled.
+- Table/view controller safety switches (also under the provider `config` block): `delete-orphans` (default `false`), `delete-orphan-columns` (default `false`), `delete-purge` (default `false`, irreversible), `tables.deletion.exclude` / `views.deletion.exclude` (regex allow-lists that are never deleted). The `IcebergNamespaceController` always uses `delete-orphans = false`; delete a namespace explicitly with the `DELETE` reconciliation mode instead.
+- Deleting a single resource: add `jikkou.io/delete: true` under `metadata.annotations`, then `jikkou apply`.
+- `jikkou api-resources schema --api-version=iceberg.jikkou.io/v1beta1 --kind=<Kind>` prints the JSON Schema for a kind's `spec`.

--- a/skills/managing-kafka-resources/references/kafka-connect.md
+++ b/skills/managing-kafka-resources/references/kafka-connect.md
@@ -1,0 +1,39 @@
+# Kafka Connect provider
+
+## Kinds
+
+| Kind | Get command | apiVersion |
+|---|---|---|
+| KafkaConnector | `jikkou get kafkaconnect connectors` | kafka.jikkou.io/v1 |
+
+All get commands accept `-o JSON|YAML`, `--name <name>`, and selectors `-s '<expr>'`.
+
+## Authoring examples
+
+File sink connector:
+```yaml
+apiVersion: 'kafka.jikkou.io/v1'
+kind: 'KafkaConnector'
+metadata:
+  name: 'local-file-sink'
+  labels:
+    # The name of the Kafka Connect cluster to connect to (must match a cluster
+    # configured under jikkou.provider.kafkaconnect.config.clusters)
+    kafka.jikkou.io/connect-cluster: 'my-connect-cluster'
+spec:
+  connectorClass: 'FileStreamSink'
+  tasksMax: 1
+  config:
+    file: '/tmp/test.sink.txt'
+    topics: 'connect-test'
+  state: 'RUNNING'
+```
+
+`spec.state` accepts `RUNNING`, `PAUSED`, `STOPPED` (also reported: `UNASSIGNED`, `RESTARTING`, `FAILED`).
+
+## Notes
+
+- Requires at least one Kafka Connect cluster configured under `jikkou.provider.kafkaconnect.config.clusters` (an array — each entry has `name`, `url`, `authMethod` [`none`, `basicauth`, `ssl`], and optional proxy settings `proxyUrl`, `proxyUsername`, `proxyPassword`, `nonProxyHosts`). The `kafka.jikkou.io/connect-cluster` label on the resource selects which configured cluster a connector targets.
+- Deleting: add `jikkou.io/delete: true` under `metadata.annotations`, then `jikkou apply`.
+- The `status.connectorStatus` field is read-only, reported by the Kafka Connect REST API — don't set it when authoring.
+- `jikkou api-resources schema --api-version=kafka.jikkou.io/v1 --kind=KafkaConnector` prints the JSON Schema for the `spec` field.

--- a/skills/managing-kafka-resources/references/kafka.md
+++ b/skills/managing-kafka-resources/references/kafka.md
@@ -1,0 +1,66 @@
+# Kafka provider
+
+## Kinds
+
+| Kind | Get command | apiVersion |
+|---|---|---|
+| KafkaTopic | `jikkou get kafka topics` | kafka.jikkou.io/v1 |
+| KafkaPrincipalAuthorization (ACLs) | `jikkou get kafka acls` | kafka.jikkou.io/v1 |
+| KafkaClientQuota | `jikkou get kafka client-quotas` | kafka.jikkou.io/v1 |
+| KafkaConsumerGroup | `jikkou get kafka consumer-groups` | kafka.jikkou.io/v1 |
+| KafkaUser | `jikkou get kafka users` | kafka.jikkou.io/v1 |
+| KafkaBroker | `jikkou get kafka brokers` | kafka.jikkou.io/v1 |
+| KafkaTableRecord | `jikkou get kafka table-records` | kafka.jikkou.io/v1 |
+
+All get commands accept `-o JSON|YAML` and selectors `-s '<expr>'`; only `topics`, `client-quotas`, and `users` also accept `--name <name>` (filter the others client-side or with `-s`). `table-records` additionally requires `--topic-name`, `--key-type`, and `--value-type`, and only works against compacted topics.
+
+## Authoring examples
+
+Topic:
+```yaml
+apiVersion: 'kafka.jikkou.io/v1'
+kind: 'KafkaTopic'
+metadata:
+  name: 'my-topic'
+  labels: { team: 'payments' }
+spec:
+  partitions: 6
+  replicas: 3
+  configs:
+    min.insync.replicas: 2
+    cleanup.policy: 'compact'
+    retention.ms: 604800000
+```
+
+User + ACL (one file, `---`-separated):
+```yaml
+apiVersion: 'kafka.jikkou.io/v1'
+kind: 'KafkaUser'
+metadata:
+  name: 'payment-service'
+spec:
+  authentications:
+    - type: 'scram-sha-512'
+      iterations: 4096
+---
+apiVersion: 'kafka.jikkou.io/v1'
+kind: 'KafkaPrincipalAuthorization'
+metadata:
+  name: 'User:payment-service'
+spec:
+  acls:
+    - resource:
+        type: 'topic'
+        pattern: 'my-topic'
+        patternType: 'literal'
+      operations: ['READ', 'DESCRIBE']
+      host: '*'
+```
+
+## Notes
+
+- Deleting: add `jikkou.io/delete: true` under `metadata.annotations`, then `jikkou apply`.
+- `min.insync.replicas` must be <= `replicas` or producers with acks=all fail.
+- Topic config values are plain Kafka broker/topic configs — anything `kafka-configs.sh` accepts.
+- All `kafka.jikkou.io` kinds share a single apiVersion (`v1`) in this CLI build; run `jikkou api-resources list` to confirm current versions before authoring, since this can change between releases.
+- `jikkou api-resources schema --api-version=<v> --kind=<k>` prints the JSON Schema for a kind's `spec`, useful for checking field names before writing a resource by hand.

--- a/skills/managing-kafka-resources/references/schema-registry.md
+++ b/skills/managing-kafka-resources/references/schema-registry.md
@@ -1,0 +1,49 @@
+# Schema Registry provider
+
+## Kinds
+
+| Kind | Get command | apiVersion |
+|---|---|---|
+| SchemaRegistrySubject | `jikkou get schemaregistry subjects` | schemaregistry.jikkou.io/v1 |
+
+All get commands accept `-o JSON|YAML`, `--name <name>`, and selectors `-s '<expr>'`.
+
+## Authoring examples
+
+Avro subject (schema loaded from a sibling file via `$ref`):
+```yaml
+apiVersion: 'schemaregistry.jikkou.io/v1'
+kind: 'SchemaRegistrySubject'
+metadata:
+  name: 'PersonAvro'
+  annotations:
+    schemaregistry.jikkou.io/normalize-schema: true
+spec:
+  compatibilityLevel: 'FULL_TRANSITIVE'
+  schemaType: 'AVRO'
+  schema:
+    $ref: '{{ resource.directoryPath }}/avro-schema.avsc'
+```
+
+Inline JSON schema:
+```yaml
+apiVersion: 'schemaregistry.jikkou.io/v1'
+kind: 'SchemaRegistrySubject'
+metadata:
+  name: 'order-value'
+spec:
+  compatibilityLevel: 'BACKWARD'
+  schemaType: 'JSON'
+  schema:
+    $ref: 'order.schema.json'
+```
+
+`spec.schemaType` accepts `AVRO`, `PROTOBUF`, `JSON`. `spec.compatibilityLevel` accepts `BACKWARD`, `BACKWARD_TRANSITIVE`, `FORWARD`, `FORWARD_TRANSITIVE`, `FULL`, `FULL_TRANSITIVE`, `NONE`. `spec.mode` (rarely set) accepts `IMPORT`, `READONLY`, `READWRITE`, `FORWARD`.
+
+## Notes
+
+- Requires a reachable Schema Registry endpoint configured under `jikkou.provider.schemaregistry.config.url` in the Jikkou client configuration (property key `jikkou.provider.schemaregistry`); `vendor` (default `generic`), `authMethod` (`none`, `basicauth`, `ssl`), and proxy (`proxyUrl`, `proxyUsername`, `proxyPassword`, `nonProxyHosts`) settings live under the same `config` block. Without a working endpoint, `get`/`apply` commands fail to connect.
+- Deleting: add `jikkou.io/delete: true` under `metadata.annotations`, then `jikkou apply`. The `schemaregistry.jikkou.io/permanante-delete` annotation forces a hard delete (must follow a prior soft delete).
+- `schemaregistry.jikkou.io/normalize-schema` normalizes AVRO/JSON schemas server-side; `schemaregistry.jikkou.io/use-canonical-fingerprint` compares schemas by canonical fingerprint (AVRO only).
+- `schemaregistry.jikkou.io/url`, `schemaregistry.jikkou.io/schema-version`, `schemaregistry.jikkou.io/schema-id` are read-only annotations that Jikkou attaches automatically when describing a subject.
+- `jikkou api-resources schema --api-version=schemaregistry.jikkou.io/v1 --kind=SchemaRegistrySubject` prints the JSON Schema for the `spec` field.


### PR DESCRIPTION
## Summary

Ships Jikkou as a Claude Code plugin so coding agents can manage Kafka-ecosystem resources declaratively through the CLI:

- `.claude-plugin/` manifests: install via `/plugin marketplace add streamthoughts/jikkou` + `/plugin install jikkou`
- `skills/jikkou/SKILL.md`: setup check, discover → author → validate → diff → apply workflow, and safety rules (never apply without showing diff or dry-run output, context-switch hazards, deletion annotations)
- Provider references for kafka, schema-registry, kafka-connect, aiven, confluent-cloud, aws-glue, and iceberg — kinds, apiVersions, flags, and authoring examples all verified against the live CLI (0.38.0-SNAPSHOT)
- Diagnostics reference: health indicator names, misconfiguration audit, topic-access audit (including which authorizer settings the Kafka Admin API cannot expose), stuck-consumer snapshot recipe
- `e2e/verify-skill-commands.sh` wired into the CI e2e job: walks the CLI subcommand tree so the build fails whenever skill docs drift from the actual command surface (a naive `--help` exit-code check does not work — picocli exits 0 and swallows invalid trailing subcommands)
- README section "Use Jikkou with AI Agents"
