### PR TITLE
perf(provider-aiven): describe only managed schema registry subjects

### DIFF
--- a/providers/jikkou-provider-aiven/src/integration-test/java/io/jikkou/extension/aiven/AbstractAivenIntegrationTest.java
+++ b/providers/jikkou-provider-aiven/src/integration-test/java/io/jikkou/extension/aiven/AbstractAivenIntegrationTest.java
@@ -10,6 +10,7 @@ import io.jikkou.extension.aiven.api.AivenApiClientConfig;
 import java.io.IOException;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -38,5 +39,13 @@ public class AbstractAivenIntegrationTest {
 
     public static void enqueueResponse(MockResponse response) {
         SERVER.enqueue(response);
+    }
+
+    public static int getRequestCount() {
+        return SERVER.getRequestCount();
+    }
+
+    public static RecordedRequest takeRequest() throws InterruptedException {
+        return SERVER.takeRequest();
     }
 }

--- a/providers/jikkou-provider-aiven/src/integration-test/java/io/jikkou/extension/aiven/reconciler/AivenSchemaRegistrySubjectControllerIT.java
+++ b/providers/jikkou-provider-aiven/src/integration-test/java/io/jikkou/extension/aiven/reconciler/AivenSchemaRegistrySubjectControllerIT.java
@@ -31,6 +31,7 @@ import io.jikkou.schema.registry.SchemaRegistryAnnotations;
 import io.jikkou.schema.registry.model.CompatibilityLevels;
 import io.jikkou.schema.registry.models.V1SchemaRegistrySubject;
 import io.jikkou.schema.registry.models.V1SchemaRegistrySubjectSpec;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -70,13 +71,13 @@ public class AivenSchemaRegistrySubjectControllerIT extends BaseExtensionProvide
 
     @Test
     void shouldCreateSchemaRegistrySubject() {
-        // Given
         enqueueResponse(new MockResponse()
             .setHeader("Content-Type", "application/json")
-            .setResponseCode(200)
+            .setResponseCode(404)
             .setBody("""
                 {
-                    "subjects": [ ]
+                    "errors": [ { "message": "Subject 'test' not found.", "status": 404 } ],
+                    "message": "Subject 'test' not found."
                 }
                 """)
         );
@@ -153,16 +154,7 @@ public class AivenSchemaRegistrySubjectControllerIT extends BaseExtensionProvide
 
     @Test
     void shouldUpdateSchemaRegistrySubject() {
-        // Given
-        enqueueResponse(new MockResponse()
-            .setHeader("Content-Type", "application/json")
-            .setResponseCode(200)
-            .setBody("""
-                {
-                    "subjects": [ "test" ]
-                }
-                """)
-        );
+        // Given the expected subject 'test' exists: its latest version + compatibility are described.
         enqueueResponse(new MockResponse()
             .setHeader("Content-Type", "application/json")
             .setResponseCode(200)
@@ -246,5 +238,63 @@ public class AivenSchemaRegistrySubjectControllerIT extends BaseExtensionProvide
             )
             .build();
         Assertions.assertEquals(expected, actual);
+    }
+
+    @Test
+    void shouldOnlyDescribeExpectedSubjectsAndNotTheWholeRegistry() throws InterruptedException {
+        // Given only the latest version + compatibility of the expected subject 'test' are served
+        // (no `list all subjects` response is enqueued: the plan must not scan the whole registry).
+        enqueueResponse(new MockResponse()
+            .setHeader("Content-Type", "application/json")
+            .setResponseCode(200)
+            .setBody("""
+                {
+                	"version": {
+                		"subject": "test",
+                		"id": 1,
+                		"schemaType": "AVRO",
+                		"schema": "{\\"namespace\\": \\"example.avro\\",\\"type\\": \\"record\\",\\"name\\": \\"User\\",\\"fields\\": [{\\"name\\": \\"name\\",\\"type\\": \\"string\\"}]}"
+                	}
+                }
+                """)
+        );
+        enqueueResponse(new MockResponse()
+            .setHeader("Content-Type", "application/json")
+            .setResponseCode(200)
+            .setBody("""
+                {
+                  "compatibilityLevel": "BACKWARD"
+                }
+                """)
+        );
+        V1SchemaRegistrySubject resource = V1SchemaRegistrySubject.builder()
+            .withApiVersion(ApiVersions.KAFKA_AIVEN_V1BETA1)
+            .withMetadata(ObjectMeta.builder().withName(TEST_SUBJECT).build())
+            .withSpec(V1SchemaRegistrySubjectSpec
+                .builder()
+                .withSchemaType(SchemaType.AVRO)
+                .withSchema(new SchemaHandle(AVRO_SCHEMA_V1))
+                .withCompatibilityLevel(CompatibilityLevels.BACKWARD)
+                .build())
+            .build();
+
+        // When
+        api.reconcile(
+            ResourceList.of(List.of(resource)),
+            ReconciliationMode.FULL,
+            ReconciliationContext.builder().dryRun(true).build()
+        );
+
+        // Then only the expected subject 'test' is described (latest version + compatibility) and
+        // the whole registry is never listed: every request targets the managed subject.
+        Assertions.assertEquals(2, getRequestCount());
+        List<String> paths = new ArrayList<>();
+        for (int i = 0; i < 2; i++) {
+            paths.add(takeRequest().getPath());
+        }
+        Assertions.assertTrue(
+            paths.stream().allMatch(path -> path.contains("/" + TEST_SUBJECT)),
+            () -> "Expected only the managed subject to be described (no registry-wide listing), but got: " + paths
+        );
     }
 }

--- a/providers/jikkou-provider-aiven/src/main/java/io/jikkou/extension/aiven/reconciler/AivenSchemaRegistrySubjectCollector.java
+++ b/providers/jikkou-provider-aiven/src/main/java/io/jikkou/extension/aiven/reconciler/AivenSchemaRegistrySubjectCollector.java
@@ -33,8 +33,10 @@ import io.jikkou.schema.registry.V1SchemaRegistrySubjectFactory;
 import io.jikkou.schema.registry.models.V1SchemaRegistrySubject;
 import jakarta.ws.rs.WebApplicationException;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -100,7 +102,6 @@ public class AivenSchemaRegistrySubjectCollector implements Collector<V1SchemaRe
         AivenApiClient api = AivenApiClientFactory.create(apiClientConfig);
         try {
             ListSchemaSubjectsResponse response = api.listSchemaRegistrySubjects();
-
             if (!response.errors().isEmpty()) {
                 throw new JikkouRuntimeException(
                         String.format("failed to list kafka schema registry subjects. %s (%s)",
@@ -109,41 +110,61 @@ public class AivenSchemaRegistrySubjectCollector implements Collector<V1SchemaRe
                         )
                 );
             }
-
-            CompletableFuture<List<V1SchemaRegistrySubject>> result = AsyncUtils
-                    .waitForAll(getAllSchemaRegistrySubjectsAsync(response.subjects(), api));
-
-            Optional<Throwable> exception = AsyncUtils.getException(result);
-            if (exception.isPresent()) {
-                Throwable error = exception.get();
-                if (error instanceof WebApplicationException wae)
-                    throw wae;
-
-                throw new AivenApiClientException("Failed to list schema registry subject versions", error);
-            }
-
-            List<V1SchemaRegistrySubject> items = result.join().stream()
-                    .map(subject -> subject.withApiVersion(ApiVersions.KAFKA_AIVEN_V1BETA1))
-                    .toList();
-            return new V1SchemaRegistrySubjectList.Builder().withItems(items).build();
-
+            return collectSubjects(response.subjects(), api);
         } catch (WebApplicationException e) {
-            String response;
-            try {
-                response = Jackson.JSON_OBJECT_MAPPER
-                        .writerWithDefaultPrettyPrinter()
-                        .writeValueAsString(e.getResponse().readEntity(JsonNode.class));
-            } catch (JsonProcessingException ex) {
-                response = e.getResponse().readEntity(String.class);
-            }
-            throw new AivenApiClientException(String.format(
-                    "failed to list schema registry subject versions. %s:%n%s",
-                    e.getLocalizedMessage(),
-                    response
-            ), e);
+            throw newListException(e);
         } finally {
             api.close(); // make sure api is closed after catching exception
         }
+    }
+
+    public ResourceList<V1SchemaRegistrySubject> listAll(@NotNull Configuration configuration,
+                                                         @NotNull List<String> subjects) {
+        AivenApiClient api = AivenApiClientFactory.create(apiClientConfig);
+        try {
+            return collectSubjects(subjects, api);
+        } catch (WebApplicationException e) {
+            throw newListException(e);
+        } finally {
+            api.close(); // make sure api is closed after catching exception
+        }
+    }
+
+    private ResourceList<V1SchemaRegistrySubject> collectSubjects(@NotNull List<String> subjects,
+                                                                  @NotNull AivenApiClient api) {
+        CompletableFuture<List<V1SchemaRegistrySubject>> result = AsyncUtils
+                .waitForAll(getAllSchemaRegistrySubjectsAsync(subjects, api));
+
+        Optional<Throwable> exception = AsyncUtils.getException(result);
+        if (exception.isPresent()) {
+            Throwable error = exception.get();
+            if (error instanceof WebApplicationException wae)
+                throw wae;
+
+            throw new AivenApiClientException("Failed to list schema registry subject versions", error);
+        }
+
+        List<V1SchemaRegistrySubject> items = result.join().stream()
+                .filter(Objects::nonNull) // subjects that do not exist (404) are skipped
+                .map(subject -> subject.withApiVersion(ApiVersions.KAFKA_AIVEN_V1BETA1))
+                .toList();
+        return new V1SchemaRegistrySubjectList.Builder().withItems(items).build();
+    }
+
+    private AivenApiClientException newListException(@NotNull WebApplicationException e) {
+        String response;
+        try {
+            response = Jackson.JSON_OBJECT_MAPPER
+                    .writerWithDefaultPrettyPrinter()
+                    .writeValueAsString(e.getResponse().readEntity(JsonNode.class));
+        } catch (JsonProcessingException ex) {
+            response = e.getResponse().readEntity(String.class);
+        }
+        return new AivenApiClientException(String.format(
+                "failed to list schema registry subject versions. %s:%n%s",
+                e.getLocalizedMessage(),
+                response
+        ), e);
     }
 
     @NotNull
@@ -168,6 +189,22 @@ public class AivenSchemaRegistrySubjectCollector implements Collector<V1SchemaRe
                 .thenApply(pair ->
                         // Create SchemaRegistrySubject object
                         factory.createSchemaRegistrySubject(pair._1().version(), pair._2().compatibilityLevel(), null)
-                );
+                )
+                // A requested subject may not exist (e.g. it is about to be created): skip it,
+                // mirroring the generic schema-registry collector's emptyOn404 behaviour.
+                .exceptionally(t -> {
+                    if (isNotFound(t)) {
+                        return null;
+                    }
+                    throw (t instanceof CompletionException ce) ? ce : new CompletionException(t);
+                });
+    }
+
+    private static boolean isNotFound(final Throwable throwable) {
+        Throwable cause = (throwable instanceof CompletionException && throwable.getCause() != null)
+                ? throwable.getCause()
+                : throwable;
+        return cause instanceof WebApplicationException wae
+                && wae.getResponse().getStatus() == 404;
     }
 }

--- a/providers/jikkou-provider-aiven/src/main/java/io/jikkou/extension/aiven/reconciler/AivenSchemaRegistrySubjectController.java
+++ b/providers/jikkou-provider-aiven/src/main/java/io/jikkou/extension/aiven/reconciler/AivenSchemaRegistrySubjectController.java
@@ -16,6 +16,7 @@ import io.jikkou.core.annotation.Description;
 import io.jikkou.core.annotation.SupportedResource;
 import io.jikkou.core.annotation.Title;
 import io.jikkou.core.extension.ExtensionContext;
+import io.jikkou.core.models.ObjectMeta;
 import io.jikkou.core.models.change.GenericResourceChange;
 import io.jikkou.core.models.change.GenericResourceChangeSpec;
 import io.jikkou.core.models.change.ResourceChange;
@@ -24,7 +25,6 @@ import io.jikkou.core.reconciler.ChangeHandler;
 import io.jikkou.core.reconciler.ChangeResult;
 import io.jikkou.core.reconciler.Controller;
 import io.jikkou.core.reconciler.annotations.ControllerConfiguration;
-import io.jikkou.core.selector.Selectors;
 import io.jikkou.extension.aiven.AivenExtensionProvider;
 import io.jikkou.extension.aiven.ApiVersions;
 import io.jikkou.extension.aiven.api.AivenApiClient;
@@ -127,11 +127,15 @@ public class AivenSchemaRegistrySubjectController implements Controller<V1Schema
                 .map(this::useGlobalCompatibilityLevelIfUnspecified)
                 .toList();
 
-        // Get existing resources from the environment.
         AivenSchemaRegistrySubjectCollector collector = new AivenSchemaRegistrySubjectCollector(apiClientConfig)
                 .prettyPrintSchema(false);
 
-        List<V1SchemaRegistrySubject> actualSubjects = collector.listAll(context.configuration(), Selectors.NO_SELECTOR).stream()
+        List<String> subjects = expectedSubjects.stream()
+                .map(V1SchemaRegistrySubject::getMetadata)
+                .map(ObjectMeta::getName)
+                .toList();
+
+        List<V1SchemaRegistrySubject> actualSubjects = collector.listAll(context.configuration(), subjects).stream()
                 .filter(context.selector()::apply)
                 .toList();
 


### PR DESCRIPTION
The `AivenSchemaRegistrySubjectController.plan()` describes every subject on the registry — a latest-version + compatibility call each — and only afterwards keeps the ones being managed. 

So `diff/apply` cost scales with the size of the whole registry rather than the number of managed subjects

In our case, `jikkou diff` of 2 subjects against an Aiven schema registry with ~750 subjects took ~44s.

This PR describes only the expected subjects by name (mirroring the generic `SchemaRegistrySubjectController`), cutting that diff to ~1s