### PR TITLE
feat(provider-schema-registry): Support http headers on the Schema Registry Client

### DIFF
--- a/providers/jikkou-provider-schema-registry/src/main/java/io/jikkou/schema/registry/SchemaRegistryExtensionProvider.java
+++ b/providers/jikkou-provider-schema-registry/src/main/java/io/jikkou/schema/registry/SchemaRegistryExtensionProvider.java
@@ -32,6 +32,7 @@ import io.jikkou.schema.registry.validation.SubjectNameRegexValidation;
 import io.jikkou.spi.BaseExtensionProvider;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -85,6 +86,13 @@ public final class SchemaRegistryExtensionProvider extends BaseExtensionProvider
             .displayName("Normalize Schemas")
             .description("Specify whether to normalize schemas (default: true).")
             .defaultValue(true);
+
+        ConfigProperty<Map<String, Object>> SCHEMA_REGISTRY_CLIENT_HEADERS = ConfigProperty
+                .ofMap("clientHeaders")
+                .displayName("Client Headers")
+                .description("Passthrough properties for Schema Registry Client Headers."
+                    + " Covers arbitrary client headers to pass on http connections.")
+                .defaultValue(Map.of());
     }
 
     private SchemaRegistryClientConfig clientConfig;
@@ -99,7 +107,8 @@ public final class SchemaRegistryExtensionProvider extends BaseExtensionProvider
             Config.SCHEMA_REGISTRY_BASIC_AUTH_USER,
             Config.SCHEMA_REGISTRY_BASIC_AUTH_PASSWORD,
             Config.SCHEMA_REGISTRY_DEBUG_LOGGING_ENABLED,
-            Config.NORMALIZE_SCHEMAS_ENABLED
+            Config.NORMALIZE_SCHEMAS_ENABLED,
+            Config.SCHEMA_REGISTRY_CLIENT_HEADERS
         );
     }
 
@@ -111,6 +120,8 @@ public final class SchemaRegistryExtensionProvider extends BaseExtensionProvider
             .map(String::trim)
             .filter(s -> !s.isEmpty())
             .toList();
+        Map<String, Object> schemaRegistryClientHeaders = Config.SCHEMA_REGISTRY_CLIENT_HEADERS.get(configuration);
+
         this.clientConfig = new SchemaRegistryClientConfig(
             urls,
             Config.SCHEMA_REGISTRY_VENDOR.get(configuration),
@@ -119,7 +130,8 @@ public final class SchemaRegistryExtensionProvider extends BaseExtensionProvider
             () -> Config.SCHEMA_REGISTRY_BASIC_AUTH_PASSWORD.get(configuration),
             () -> SSLConfig.from(configuration),
             () -> ProxyConfig.from(configuration),
-            Config.SCHEMA_REGISTRY_DEBUG_LOGGING_ENABLED.get(configuration)
+            Config.SCHEMA_REGISTRY_DEBUG_LOGGING_ENABLED.get(configuration),
+            schemaRegistryClientHeaders
         );
     }
 

--- a/providers/jikkou-provider-schema-registry/src/main/java/io/jikkou/schema/registry/api/SchemaRegistryApiFactory.java
+++ b/providers/jikkou-provider-schema-registry/src/main/java/io/jikkou/schema/registry/api/SchemaRegistryApiFactory.java
@@ -11,6 +11,7 @@ import io.jikkou.http.client.RestClientBuilder;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Optional;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,6 +53,9 @@ public final class SchemaRegistryApiFactory {
         // auth method, so HTTPS endpoints with private CAs work for basicAuth/none too.
         builder.sslConfig(config.sslConfig().get());
         builder.proxyConfig(config.proxyConfig().get());
+
+        Optional.ofNullable(config.schemaRegistryClientHeaders())
+                .ifPresent(builder::headers);
 
         builder = switch (config.authMethod()) {
             case BASICAUTH -> {

--- a/providers/jikkou-provider-schema-registry/src/main/java/io/jikkou/schema/registry/api/SchemaRegistryClientConfig.java
+++ b/providers/jikkou-provider-schema-registry/src/main/java/io/jikkou/schema/registry/api/SchemaRegistryClientConfig.java
@@ -9,6 +9,7 @@ package io.jikkou.schema.registry.api;
 import io.jikkou.http.client.proxy.ProxyConfig;
 import io.jikkou.http.client.ssl.SSLConfig;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Supplier;
 
 public record SchemaRegistryClientConfig(
@@ -19,7 +20,8 @@ public record SchemaRegistryClientConfig(
     Supplier<String> basicAuthPassword,
     Supplier<SSLConfig> sslConfig,
     Supplier<ProxyConfig> proxyConfig,
-    Boolean debugLoggingEnabled
+    Boolean debugLoggingEnabled,
+    Map<String, Object> schemaRegistryClientHeaders
 ) {
 
     /**

--- a/providers/jikkou-provider-schema-registry/src/test/java/io/jikkou/schema/registry/api/SchemaRegistryApiFactoryTest.java
+++ b/providers/jikkou-provider-schema-registry/src/test/java/io/jikkou/schema/registry/api/SchemaRegistryApiFactoryTest.java
@@ -15,7 +15,9 @@ import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.KeyStore;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import mockwebserver3.MockResponse;
 import mockwebserver3.MockWebServer;
 import okhttp3.tls.HandshakeCertificates;
@@ -57,7 +59,8 @@ class SchemaRegistryApiFactoryTest {
                 () -> "password",
                 () -> SSLConfig.from(Configuration.empty()),
                 () -> ProxyConfig.from(Configuration.empty()),
-                false
+                false,
+                null
         );
 
         // When
@@ -104,7 +107,8 @@ class SchemaRegistryApiFactoryTest {
                 () -> null,
                 () -> SSLConfig.from(Configuration.empty()),
                 () -> ProxyConfig.from(Configuration.empty()),
-                false
+                false,
+                null
         );
 
         // When
@@ -132,7 +136,8 @@ class SchemaRegistryApiFactoryTest {
                 () -> null,
                 () -> SSLConfig.from(Configuration.empty()),
                 () -> ProxyConfig.from(Configuration.empty()),
-                false
+                false,
+                null
         );
 
         // When
@@ -154,7 +159,8 @@ class SchemaRegistryApiFactoryTest {
                 () -> null,
                 () -> SSLConfig.from(Configuration.empty()),
                 () -> ProxyConfig.from(Configuration.empty()),
-                false
+                false,
+                null
         );
 
         // When
@@ -211,7 +217,8 @@ class SchemaRegistryApiFactoryTest {
                             SSLConfig.SSL_TRUST_STORE_TYPE.key(), "JKS"
                     ))),
                     () -> ProxyConfig.from(Configuration.empty()),
-                    false
+                    false,
+                    null
             );
 
             // When
@@ -225,6 +232,52 @@ class SchemaRegistryApiFactoryTest {
             Assertions.assertEquals(List.of("subject-1"), subjects);
         } finally {
             httpsServer.close();
+        }
+    }
+
+    @Test
+    @DisplayName("Should send custom headers in http request")
+    public void getCustomHeader() throws InterruptedException {
+        // Given
+        HttpPathBasedDispatcher schemaRegistryHTTPDispatcher = HttpPathBasedDispatcher.builder()
+                .forPath("/subjects/subject-value/versions", new MockResponse.Builder()
+                        .code(200)
+                        .addHeader("Content-Type", "application/vnd.schemaregistry.v1+json")
+                        .body("[]")
+                        .build())
+                .build();
+        schemaRegistryMockServer.setDispatcher(schemaRegistryHTTPDispatcher);
+
+        HashMap<String, Object> clientHeaders = new HashMap<>();
+        clientHeaders.put("custom-header-1", "custom-value-1");
+        clientHeaders.put("custom-header-2", "custom-value-2");
+
+        SchemaRegistryClientConfig config = new SchemaRegistryClientConfig(
+                List.of(String.format("http://%s:%s", schemaRegistryMockServer.getHostName(), schemaRegistryMockServer.getPort())),
+                "generic",
+                AuthMethod.BASICAUTH,
+                () -> "username",
+                () -> "password",
+                () -> SSLConfig.from(Configuration.empty()),
+                () -> ProxyConfig.from(Configuration.empty()),
+                false,
+                clientHeaders
+        );
+
+        // When
+        List<Integer> versions;
+        try (SchemaRegistryApi schemaRegistryApi = SchemaRegistryApiFactory.create(config)) {
+            versions = schemaRegistryApi.getAllSubjectVersions("subject-value");
+        }
+
+        // Then
+        Assertions.assertNotNull(versions);
+
+        var actualHeaders = schemaRegistryMockServer.takeRequest().getHeaders();
+
+        for (Map.Entry<String, Object> header : clientHeaders.entrySet()) {
+            String actualValue = actualHeaders.get(header.getKey());
+            Assertions.assertEquals(header.getValue(), actualValue);
         }
     }
 


### PR DESCRIPTION
feat(provider-schema-registry): Support http headers on the Schema Registry Client- #795


Change SchemaRegistryApiFactory to accept a configurable list of optional headers to be included on the Rest client requests to schema registry.
Use of OAuth to Confluent Schema Registry requires additional custom headers to be provided.

https://github.com/streamthoughts/jikkou/issues/793