### PR TITLE
fix(deps): bump jackson, netty, pgjdbc and logback to patch CVEs

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -47,15 +47,31 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- Netty BOM must be imported BEFORE Micronaut so its 4.2.11 pins win
-                 (Maven first-declaration-wins). Micronaut platform 4.10.10 otherwise
-                 pulls in netty-codec-http* 4.2.9 (CVE-2026-33870, CVE-2026-33871). -->
+            <!-- Netty BOM must be imported BEFORE Micronaut so its pins win
+                 (Maven first-declaration-wins). Micronaut platform otherwise
+                 pulls in an older netty-codec-http* release. -->
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
                 <version>${netty.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <!-- Jackson BOM must also be imported BEFORE Micronaut, which otherwise
+                 pulls in an older jackson patch release. -->
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- Likewise BEFORE Micronaut, which otherwise downgrades the pgjdbc
+                 driver pulled in by jikkou-provider-iceberg. -->
+            <dependency>
+                <groupId>org.postgresql</groupId>
+                <artifactId>postgresql</artifactId>
+                <version>${postgresql.version}</version>
             </dependency>
             <!-- Micronaut -->
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
         <!-- Dependencies -->
         <kafka.version>4.3.0</kafka.version>
         <picocli.version>4.7.7</picocli.version>
-        <jackson.version>2.18.6</jackson.version>
+        <jackson.version>2.21.4</jackson.version>
         <jinjava.version>2.8.3</jinjava.version>
         <lombok.version>1.18.42</lombok.version>
         <config.version>1.4.3</config.version>
@@ -127,11 +127,12 @@
         <cel.version>0.9.1</cel.version>
         <avro.version>1.12.1</avro.version>
         <lz4.version>1.8.1</lz4.version>
-        <netty.version>4.2.13.Final</netty.version>
+        <netty.version>4.2.16.Final</netty.version>
         <bouncycastle.version>1.84</bouncycastle.version>
+        <postgresql.version>42.7.12</postgresql.version>
         <!-- Logging -->
         <slf4j-api.version>2.0.17</slf4j-api.version>
-        <logback.version>1.5.32</logback.version>
+        <logback.version>1.5.34</logback.version>
         <jul-to-slf4j.version>2.0.17</jul-to-slf4j.version>
         <!-- Build -->
         <graal-sdk.version>25.0.2</graal-sdk.version>
@@ -181,6 +182,12 @@
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bcprov-jdk18on</artifactId>
                 <version>${bouncycastle.version}</version>
+            </dependency>
+            <!-- Centralized so the Iceberg JDBC catalog driver is managed in one place -->
+            <dependency>
+                <groupId>org.postgresql</groupId>
+                <artifactId>postgresql</artifactId>
+                <version>${postgresql.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.graalvm.sdk</groupId>

--- a/providers/jikkou-provider-iceberg/pom.xml
+++ b/providers/jikkou-provider-iceberg/pom.xml
@@ -139,7 +139,6 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.7.11</version>
             <scope>runtime</scope>
         </dependency>
         <!-- Lombok (annotation processing + compile) -->

--- a/server/jikkou-api-server/pom.xml
+++ b/server/jikkou-api-server/pom.xml
@@ -171,15 +171,31 @@
     </dependencies>
     <dependencyManagement>
         <dependencies>
-            <!-- Netty BOM must be imported BEFORE Micronaut so its 4.2.11 pins win
-                 (Maven first-declaration-wins). Micronaut platform 4.10.10 otherwise
-                 pulls in netty-codec-http* 4.2.9 (CVE-2026-33870, CVE-2026-33871). -->
+            <!-- Netty BOM must be imported BEFORE Micronaut so its pins win
+                 (Maven first-declaration-wins). Micronaut platform otherwise
+                 pulls in an older netty-codec-http* release. -->
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
                 <version>${netty.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <!-- Jackson BOM must also be imported BEFORE Micronaut, which otherwise
+                 pulls in an older jackson patch release. -->
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- Likewise BEFORE Micronaut, which otherwise downgrades the pgjdbc
+                 driver pulled in by jikkou-provider-iceberg. -->
+            <dependency>
+                <groupId>org.postgresql</groupId>
+                <artifactId>postgresql</artifactId>
+                <version>${postgresql.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.micronaut.platform</groupId>


### PR DESCRIPTION
Resolves the HIGH findings reported by the Trivy scan that runs on pull request builds (seen on #796).

## Bumps

| Library | From | To |
|---|---|---|
| `com.fasterxml.jackson` | 2.18.6 (and 2.21.2 via Micronaut) | 2.21.4 |
| `io.netty` | 4.2.13.Final | 4.2.16.Final |
| `org.postgresql` | 42.7.11 (42.7.8 as actually resolved) | 42.7.12 |
| `ch.qos.logback` | 1.5.32 | 1.5.34 |

Together these clear every HIGH the scan reported across `pom.xml`, `cli`, `core`, `extension-rest-client`, `template-jinja`, `resource-generator`, `server/jikkou-api-server` and all `providers/*` modules.

## Why more than a property bump was needed

`cli` and `server/jikkou-api-server` import the Micronaut BOMs in their **own** `dependencyManagement`, which takes precedence over the inherited parent one. Bumping `jackson.version` in the parent alone had no effect there: those two modules kept resolving Micronaut's Jackson 2.21.2. That is why the scan reported two different Jackson versions.

Chasing this surfaced a related issue the report understated: the same precedence rule meant `cli` and `api-server` were resolving pgjdbc to **42.7.8**, i.e. older than the 42.7.11 declared in the Iceberg module.

Both the Jackson BOM and pgjdbc are now imported ahead of the Micronaut BOMs, mirroring what was already in place for Netty. The pgjdbc version moves to a `postgresql.version` property in the parent so the Iceberg JDBC catalog driver no longer carries its own literal.

## Verification

- `dependency:tree` across all 18 modules: every `jackson` / `netty` / `postgresql` / `logback` artifact resolves to a patched version, no stragglers.
- Full unit test suite passes, 18/18 modules.
- Integration tests were not run locally (they need Docker/testcontainers) - worth watching CI here given the Jackson 2.18 to 2.21 minor jump.

## Not addressed

- `org.lz4:lz4-java` (CVE-2025-66566, CVE-2026-59949): Dependabot reports no patched version available upstream, so there is nothing to bump to.
- npm advisories in `docs/package-lock.json` (postcss, braces, decompress, picomatch): real open alerts, but they affect the docs site rather than the shipped artifacts. Better handled separately.