### PR TITLE
feat: support custom http headers on all REST-based provider clients

### DIFF
--- a/docs/content/en/docs/Reference/Providers/Aiven/Configuration/_index.md
+++ b/docs/content/en/docs/Reference/Providers/Aiven/Configuration/_index.md
@@ -43,6 +43,13 @@ jikkou {
       nonProxyHosts = "localhost,127.0.0.1"
       # Enable debug logging
       debugLoggingEnabled = false
+
+      # Additional HTTP headers sent on every request to the Aiven REST API.
+      # Applied last, so these override headers Jikkou sets itself, including 'Authorization'.
+      clientHeaders {
+        X-Api-Gateway-Key = "my-gateway-key"
+        X-Tenant = "acme"
+      }
     }
   }
 }
@@ -66,5 +73,28 @@ If `proxyUrl` is not set, Jikkou honors the standard JVM proxy system properties
 {{% alert title="Note" color="info" %}}
 The OS-level `http_proxy` / `https_proxy` environment variables are **not** read by the JVM
 and have no effect. Use `proxyUrl` or the JVM system properties above.
+{{% /alert %}}
+
+## Custom HTTP headers
+
+The `clientHeaders` property attaches arbitrary HTTP headers to every request Jikkou
+sends to the Aiven REST API. It is useful for API gateway keys, tenant identifiers,
+and tracing headers.
+
+```hocon
+clientHeaders {
+  X-Api-Gateway-Key = "my-gateway-key"
+  X-Tenant = "acme"
+}
+```
+
+Custom headers are applied **last**, so a header set here replaces the one Jikkou would
+otherwise send under the same name, including the `Authorization` header built from
+`tokenAuth`. Header names are matched case-insensitively.
+
+{{% alert title="Note" color="info" %}}
+When debug logging is enabled, header values are redacted if the header name is
+`Authorization`, `Proxy-Authorization`, `Cookie`, or `Set-Cookie`, or if it contains
+`token`, `secret`, `key`, or `password`. Header names are always logged in full.
 {{% /alert %}}
 

--- a/docs/content/en/docs/Reference/Providers/Confluent Cloud/Configuration/_index.md
+++ b/docs/content/en/docs/Reference/Providers/Confluent Cloud/Configuration/_index.md
@@ -43,6 +43,13 @@ jikkou {
       nonProxyHosts = "localhost,127.0.0.1"
       # Enable debug logging (default: false)
       debugLoggingEnabled = false
+
+      # Additional HTTP headers sent on every request to the Confluent Cloud REST API.
+      # Applied last, so these override headers Jikkou sets itself, including 'Authorization'.
+      clientHeaders {
+        X-Api-Gateway-Key = "my-gateway-key"
+        X-Tenant = "acme"
+      }
     }
   }
 }
@@ -61,11 +68,33 @@ jikkou {
 | `proxyPassword`      | String  | No       |                                | Password for proxy Basic authentication.                         |
 | `nonProxyHosts`      | String  | No       |                                | Comma-separated hosts that bypass the proxy, e.g. `localhost,*.internal`. |
 | `debugLoggingEnabled`| Boolean | No       | `false`                        | Enable debug logging for REST API calls.                         |
+| `clientHeaders`      | Map     | No       | `{}`                           | Additional HTTP headers sent on every request. Applied last, so they override headers Jikkou sets itself, including `Authorization`. |
 
 > If `proxyUrl` is not set, Jikkou honors the standard JVM proxy system properties
 > (`-Dhttps.proxyHost`, `-Dhttp.proxyHost`, `-Dhttp.proxyUser`, `-Dhttp.proxyPassword`,
 > `-Dhttp.nonProxyHosts`), which can be supplied via `JAVA_TOOL_OPTIONS`. The OS-level
 > `http_proxy` / `https_proxy` environment variables are **not** read by the JVM and have no effect.
+
+### Custom HTTP headers
+
+The `clientHeaders` property attaches arbitrary HTTP headers to every request Jikkou
+sends to the Confluent Cloud REST API. It is useful for API gateway keys, tenant
+identifiers, and tracing headers.
+
+```hocon
+clientHeaders {
+  X-Api-Gateway-Key = "my-gateway-key"
+  X-Tenant = "acme"
+}
+```
+
+Custom headers are applied **last**, so a header set here replaces the one Jikkou would
+otherwise send under the same name, including the `Authorization` header built from
+`apiKey` and `apiSecret`. Header names are matched case-insensitively.
+
+> When debug logging is enabled, header values are redacted if the header name is
+> `Authorization`, `Proxy-Authorization`, `Cookie`, or `Set-Cookie`, or if it contains
+> `token`, `secret`, `key`, or `password`. Header names are always logged in full.
 
 ### Creating a Cloud API Key
 

--- a/docs/content/en/docs/Reference/Providers/Kafka Connect/Configuration/_index.md
+++ b/docs/content/en/docs/Reference/Providers/Kafka Connect/Configuration/_index.md
@@ -69,6 +69,13 @@ jikkou {
           proxyPassword = null
           # Comma-separated hosts that bypass the proxy, e.g. 'localhost,127.0.0.1,*.internal'.
           nonProxyHosts = "localhost,127.0.0.1"
+
+          # Additional HTTP headers sent on every request to this Kafka Connect cluster.
+          # Applied last, so these override headers Jikkou sets itself, including 'Authorization'.
+          clientHeaders {
+            X-Api-Gateway-Key = "my-gateway-key"
+            X-Tenant = "acme"
+          }
         }
       ]
     }
@@ -94,4 +101,29 @@ If `proxyUrl` is not set, Jikkou honors the standard JVM proxy system properties
 {{% alert title="Note" color="info" %}}
 The OS-level `http_proxy` / `https_proxy` environment variables are **not** read by the JVM
 and have no effect. Use `proxyUrl` or the JVM system properties above.
+{{% /alert %}}
+
+## Custom HTTP headers
+
+The `clientHeaders` property attaches arbitrary HTTP headers to every request Jikkou
+sends to a Kafka Connect cluster. It is useful for API gateway keys, tenant identifiers,
+and tracing headers. It is set per cluster, inside a `clusters` entry.
+
+```hocon
+clientHeaders {
+  X-Api-Gateway-Key = "my-gateway-key"
+  X-Tenant = "acme"
+}
+```
+
+Custom headers are applied **last**, so a header set here replaces the one Jikkou would
+otherwise send under the same name, including `Authorization`. Setting `Authorization`
+through `clientHeaders` is the supported way to use a bearer token or another
+authentication scheme that `authMethod` does not cover. Header names are matched
+case-insensitively.
+
+{{% alert title="Note" color="info" %}}
+When debug logging is enabled, header values are redacted if the header name is
+`Authorization`, `Proxy-Authorization`, `Cookie`, or `Set-Cookie`, or if it contains
+`token`, `secret`, `key`, or `password`. Header names are always logged in full.
 {{% /alert %}}

--- a/docs/content/en/docs/Reference/Providers/Schema Registry/Configuration/_index.md
+++ b/docs/content/en/docs/Reference/Providers/Schema Registry/Configuration/_index.md
@@ -65,6 +65,13 @@ jikkou {
       proxyPassword = null
       # Comma-separated hosts that bypass the proxy, e.g. 'localhost,127.0.0.1,*.internal'.
       nonProxyHosts = "localhost,127.0.0.1"
+
+      # Additional HTTP headers sent on every request to the Schema Registry.
+      # Applied last, so these override headers Jikkou sets itself, including 'Authorization'.
+      clientHeaders {
+        X-Api-Gateway-Key = "my-gateway-key"
+        X-Tenant = "acme"
+      }
     }
   }
 }
@@ -88,4 +95,29 @@ If `proxyUrl` is not set, Jikkou honors the standard JVM proxy system properties
 {{% alert title="Note" color="info" %}}
 The OS-level `http_proxy` / `https_proxy` environment variables are **not** read by the JVM
 and have no effect. Use `proxyUrl` or the JVM system properties above.
+{{% /alert %}}
+
+## Custom HTTP headers
+
+The `clientHeaders` property attaches arbitrary HTTP headers to every request Jikkou
+sends to the Schema Registry. It is useful for API gateway keys, tenant identifiers,
+and tracing headers.
+
+```hocon
+clientHeaders {
+  X-Api-Gateway-Key = "my-gateway-key"
+  X-Tenant = "acme"
+}
+```
+
+Custom headers are applied **last**, so a header set here replaces the one Jikkou would
+otherwise send under the same name, including `Authorization`. Setting `Authorization`
+through `clientHeaders` is the supported way to use a bearer token or another
+authentication scheme that `authMethod` does not cover. Header names are matched
+case-insensitively.
+
+{{% alert title="Note" color="info" %}}
+When debug logging is enabled, header values are redacted if the header name is
+`Authorization`, `Proxy-Authorization`, `Cookie`, or `Set-Cookie`, or if it contains
+`token`, `secret`, `key`, or `password`. Header names are always logged in full.
 {{% /alert %}}

--- a/extension-rest-client/src/main/java/io/jikkou/http/client/ClientHeadersConfig.java
+++ b/extension-rest-client/src/main/java/io/jikkou/http/client/ClientHeadersConfig.java
@@ -1,0 +1,53 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.jikkou.http.client;
+
+import io.jikkou.core.config.ConfigProperty;
+import io.jikkou.core.config.Configuration;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Additional HTTP headers sent on every request made by a REST-based provider.
+ */
+public final class ClientHeadersConfig {
+
+    public static final ConfigProperty<Map<String, Object>> CLIENT_HEADERS = ConfigProperty
+        .ofMap("clientHeaders")
+        .displayName("Client Headers")
+        .description("Additional HTTP headers to send on every request to the target API, "
+            + "for example an API gateway key or a tracing header. These headers are applied "
+            + "last and therefore override any header Jikkou sets itself, including 'Authorization'.")
+        .defaultValue(Map.of());
+
+    /**
+     * Reads the custom client headers from the given configuration.
+     * <p>
+     * Header values are coerced to {@link String}. Entries with a blank name or a
+     * {@code null} value are ignored.
+     *
+     * @param configuration the configuration.
+     * @return an unmodifiable map of header name to header value; never {@code null}.
+     */
+    public static Map<String, String> from(final Configuration configuration) {
+        Map<String, Object> headers = CLIENT_HEADERS.get(configuration);
+        if (headers == null || headers.isEmpty()) {
+            return Map.of();
+        }
+        Map<String, String> result = new LinkedHashMap<>(headers.size());
+        headers.forEach((name, value) -> {
+            if (name != null && !name.isBlank() && value != null) {
+                result.put(name.trim(), String.valueOf(value));
+            }
+        });
+        return Collections.unmodifiableMap(result);
+    }
+
+    private ClientHeadersConfig() {
+    }
+}

--- a/extension-rest-client/src/main/java/io/jikkou/http/client/RestClientBuilder.java
+++ b/extension-rest-client/src/main/java/io/jikkou/http/client/RestClientBuilder.java
@@ -30,10 +30,10 @@ import java.security.cert.CertificateException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.KeyManager;
@@ -72,7 +72,7 @@ public class RestClientBuilder {
 
     private URI baseUri;
     private boolean followRedirects;
-    private final Map<String, List<Object>> headers = new HashMap<>();
+    private final Map<String, List<Object>> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
     private boolean enableClientDebugging = false;
     private final ResteasyClientBuilder clientBuilder;
     private ObjectMapper objectMapper = Jackson.JSON_OBJECT_MAPPER;
@@ -208,6 +208,42 @@ public class RestClientBuilder {
      */
     public RestClientBuilder headers(final Map<String, Object> headers) {
         headers.forEach(this::header);
+        return this;
+    }
+
+    /**
+     * Sets an HTTP header on the request, replacing any value previously set for that
+     * header name. Header names are matched case-insensitively.
+     *
+     * @param header the header name.
+     * @param value  the header value.
+     * @return {@code this}.
+     */
+    public RestClientBuilder setHeader(final String header, final Object value) {
+        List<Object> values = new ArrayList<>(1);
+        values.add(value);
+        this.headers.put(header, values);
+        return this;
+    }
+
+    /**
+     * Applies user-supplied custom HTTP headers, overriding any header of the same name
+     * already set on this builder. Call this last so that custom headers take precedence
+     * over the headers Jikkou sets itself.
+     *
+     * @param clientHeaders the custom headers; may be {@code null} or empty.
+     * @return {@code this}.
+     */
+    public RestClientBuilder clientHeaders(final Map<String, String> clientHeaders) {
+        if (clientHeaders == null || clientHeaders.isEmpty()) {
+            return this;
+        }
+        clientHeaders.forEach((name, value) -> {
+            if (this.headers.containsKey(name)) {
+                LOG.warn("Custom client header '{}' overrides the header set by Jikkou.", name);
+            }
+            setHeader(name, value);
+        });
         return this;
     }
 

--- a/extension-rest-client/src/main/java/io/jikkou/http/client/RestClientBuilder.java
+++ b/extension-rest-client/src/main/java/io/jikkou/http/client/RestClientBuilder.java
@@ -31,10 +31,14 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
@@ -69,6 +73,14 @@ public class RestClientBuilder {
     private static final Logger LOG = LoggerFactory.getLogger(RestClientBuilder.class);
 
     public static final AllowAllHostNameVerifier NO_HOST_NAME_VERIFIER = new AllowAllHostNameVerifier();
+
+    private static final Set<String> SENSITIVE_HEADER_NAMES =
+        Set.of("authorization", "proxy-authorization", "cookie", "set-cookie");
+
+    private static final Pattern SENSITIVE_HEADER_PATTERN =
+        Pattern.compile("(?i).*(token|secret|key|password).*");
+
+    private static final String REDACTED = "***";
 
     private URI baseUri;
     private boolean followRedirects;
@@ -458,6 +470,31 @@ public class RestClientBuilder {
     }
 
     /**
+     * @return {@code true} if the given header name is likely to carry a credential.
+     */
+    static boolean isSensitiveHeader(final String name) {
+        if (name == null) {
+            return false;
+        }
+        return SENSITIVE_HEADER_NAMES.contains(name.toLowerCase(Locale.ROOT))
+            || SENSITIVE_HEADER_PATTERN.matcher(name).matches();
+    }
+
+    /**
+     * Renders the given headers for logging, masking the values of any header whose
+     * name is likely to carry a credential.
+     *
+     * @param headers the request headers.
+     * @return a printable representation with sensitive values masked.
+     */
+    static String redactHeaders(final Map<String, List<Object>> headers) {
+        return headers.entrySet().stream()
+            .map(entry -> entry.getKey() + "="
+                + (isSensitiveHeader(entry.getKey()) ? REDACTED : entry.getValue()))
+            .collect(Collectors.joining(", ", "{", "}"));
+    }
+
+    /**
      * ClientRequestFilter that logs HTTP requests.
      */
     private static class LoggingRequestFilter implements ClientRequestFilter {
@@ -465,7 +502,7 @@ public class RestClientBuilder {
         public void filter(ClientRequestContext requestContext) {
             LOG.info("HTTP Request: {} {}", requestContext.getMethod(), requestContext.getUri());
             if (LOG.isDebugEnabled()) {
-                LOG.debug("Headers: {}", requestContext.getHeaders());
+                LOG.debug("Headers: {}", redactHeaders(requestContext.getHeaders()));
             }
         }
     }

--- a/extension-rest-client/src/test/java/io/jikkou/http/client/ClientHeadersConfigTest.java
+++ b/extension-rest-client/src/test/java/io/jikkou/http/client/ClientHeadersConfigTest.java
@@ -1,0 +1,104 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.jikkou.http.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.jikkou.core.config.Configuration;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ClientHeadersConfigTest {
+
+    @Test
+    @DisplayName("Should return an empty map when no clientHeaders is configured")
+    void shouldReturnEmptyMapWhenNotConfigured() {
+        assertTrue(ClientHeadersConfig.from(Configuration.empty()).isEmpty());
+    }
+
+    @Test
+    @DisplayName("Should read configured headers as strings")
+    void shouldReadConfiguredHeaders() {
+        // Given
+        Map<String, Object> headers = new LinkedHashMap<>();
+        headers.put("X-Api-Key", "secret");
+        headers.put("X-Tenant", "acme");
+        Configuration configuration = Configuration.from(Map.of("clientHeaders", headers));
+
+        // When
+        Map<String, String> result = ClientHeadersConfig.from(configuration);
+
+        // Then
+        assertEquals(Map.of("X-Api-Key", "secret", "X-Tenant", "acme"), result);
+    }
+
+    @Test
+    @DisplayName("Should coerce non-string header values to string")
+    void shouldCoerceNonStringValues() {
+        // Given
+        Map<String, Object> headers = new LinkedHashMap<>();
+        headers.put("X-Retry-Count", 3);
+        headers.put("X-Enabled", true);
+        Configuration configuration = Configuration.from(Map.of("clientHeaders", headers));
+
+        // When
+        Map<String, String> result = ClientHeadersConfig.from(configuration);
+
+        // Then
+        assertEquals("3", result.get("X-Retry-Count"));
+        assertEquals("true", result.get("X-Enabled"));
+    }
+
+    @Test
+    @DisplayName("Should skip entries with a null value")
+    void shouldSkipNullValues() {
+        // Given
+        Map<String, Object> headers = new HashMap<>();
+        headers.put("X-Null", null);
+        headers.put("X-Kept", "kept");
+        Configuration configuration = Configuration.from(Map.of("clientHeaders", headers));
+
+        // When
+        Map<String, String> result = ClientHeadersConfig.from(configuration);
+
+        // Then
+        assertEquals(Map.of("X-Kept", "kept"), result);
+    }
+
+    @Test
+    @DisplayName("Should trim surrounding whitespace from header names")
+    void shouldTrimHeaderNames() {
+        // Given
+        Configuration configuration = Configuration.from(
+                Map.of("clientHeaders", Map.of("  X-Padded  ", "value")));
+
+        // When
+        Map<String, String> result = ClientHeadersConfig.from(configuration);
+
+        // Then
+        assertEquals(Map.of("X-Padded", "value"), result);
+    }
+
+    @Test
+    @DisplayName("Should return an unmodifiable map")
+    void shouldReturnUnmodifiableMap() {
+        // Given
+        Configuration configuration = Configuration.from(
+                Map.of("clientHeaders", Map.of("X-Kept", "kept")));
+
+        // When
+        Map<String, String> result = ClientHeadersConfig.from(configuration);
+
+        // Then
+        assertThrows(UnsupportedOperationException.class, () -> result.put("X-New", "nope"));
+    }
+}

--- a/extension-rest-client/src/test/java/io/jikkou/http/client/RestClientBuilderTest.java
+++ b/extension-rest-client/src/test/java/io/jikkou/http/client/RestClientBuilderTest.java
@@ -30,6 +30,7 @@ import java.io.OutputStream;
 import java.nio.file.Files;
 import java.security.KeyStore;
 import java.util.List;
+import java.util.Map;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
@@ -182,6 +183,113 @@ class RestClientBuilderTest {
         RecordedRequest request = server.takeRequest();
         assertEquals("Bearer test-token", request.getHeader("Authorization"));
         assertEquals("custom-value", request.getHeader("X-Custom-Header"));
+    }
+
+    @Test
+    void shouldReplaceHeaderValueWhenUsingSetHeader() throws InterruptedException {
+        // Given
+        server.enqueue(new MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setResponseCode(200)
+                .setBody("pong"));
+
+        // When
+        TestResource resource = RestClientBuilder.newBuilder()
+                .baseUri(server.url("/").toString())
+                .header("Authorization", "Basic first")
+                .setHeader("Authorization", "Bearer second")
+                .build(TestResource.class);
+        resource.ping();
+
+        // Then
+        RecordedRequest request = server.takeRequest();
+        assertEquals("Bearer second", request.getHeader("Authorization"));
+        assertEquals(1, request.getHeaders().values("Authorization").size());
+    }
+
+    @Test
+    void shouldTreatHeaderNamesAsCaseInsensitive() throws InterruptedException {
+        // Given
+        server.enqueue(new MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setResponseCode(200)
+                .setBody("pong"));
+
+        // When
+        TestResource resource = RestClientBuilder.newBuilder()
+                .baseUri(server.url("/").toString())
+                .header("Authorization", "Basic first")
+                .setHeader("authorization", "Bearer second")
+                .build(TestResource.class);
+        resource.ping();
+
+        // Then
+        RecordedRequest request = server.takeRequest();
+        assertEquals(1, request.getHeaders().values("Authorization").size());
+        assertEquals("Bearer second", request.getHeader("Authorization"));
+    }
+
+    @Test
+    void shouldLetClientHeadersOverrideBuiltInAuthorizationHeader() throws InterruptedException {
+        // Given
+        server.enqueue(new MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setResponseCode(200)
+                .setBody("pong"));
+
+        // When
+        TestResource resource = RestClientBuilder.newBuilder()
+                .baseUri(server.url("/").toString())
+                .header("Authorization", "Basic built-in")
+                .clientHeaders(Map.of("Authorization", "Bearer custom", "X-Tenant", "acme"))
+                .build(TestResource.class);
+        resource.ping();
+
+        // Then
+        RecordedRequest request = server.takeRequest();
+        assertEquals(1, request.getHeaders().values("Authorization").size());
+        assertEquals("Bearer custom", request.getHeader("Authorization"));
+        assertEquals("acme", request.getHeader("X-Tenant"));
+    }
+
+    @Test
+    void shouldIgnoreNullAndEmptyClientHeaders() {
+        // Given
+        server.enqueue(new MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setResponseCode(200)
+                .setBody("pong"));
+
+        // When
+        TestResource resource = RestClientBuilder.newBuilder()
+                .baseUri(server.url("/").toString())
+                .clientHeaders(null)
+                .clientHeaders(Map.of())
+                .build(TestResource.class);
+
+        // Then
+        assertEquals("pong", resource.ping());
+    }
+
+    @Test
+    void shouldKeepAppendSemanticsForHeaderMethod() throws InterruptedException {
+        // Given
+        server.enqueue(new MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setResponseCode(200)
+                .setBody("pong"));
+
+        // When
+        TestResource resource = RestClientBuilder.newBuilder()
+                .baseUri(server.url("/").toString())
+                .header("X-Multi", "one")
+                .header("X-Multi", "two")
+                .build(TestResource.class);
+        resource.ping();
+
+        // Then
+        RecordedRequest request = server.takeRequest();
+        assertEquals(2, request.getHeaders().values("X-Multi").size());
     }
 
     @Test

--- a/extension-rest-client/src/test/java/io/jikkou/http/client/RestClientBuilderTest.java
+++ b/extension-rest-client/src/test/java/io/jikkou/http/client/RestClientBuilderTest.java
@@ -7,8 +7,10 @@
 package io.jikkou.http.client;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.jikkou.core.config.Configuration;
@@ -29,6 +31,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.security.KeyStore;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import okhttp3.mockwebserver.MockResponse;
@@ -290,6 +293,49 @@ class RestClientBuilderTest {
         // Then
         RecordedRequest request = server.takeRequest();
         assertEquals(2, request.getHeaders().values("X-Multi").size());
+    }
+
+    @Test
+    void shouldFlagWellKnownSensitiveHeaderNames() {
+        assertTrue(RestClientBuilder.isSensitiveHeader("Authorization"));
+        assertTrue(RestClientBuilder.isSensitiveHeader("authorization"));
+        assertTrue(RestClientBuilder.isSensitiveHeader("Proxy-Authorization"));
+        assertTrue(RestClientBuilder.isSensitiveHeader("Cookie"));
+        assertTrue(RestClientBuilder.isSensitiveHeader("Set-Cookie"));
+    }
+
+    @Test
+    void shouldFlagHeaderNamesMatchingSecretPatterns() {
+        assertTrue(RestClientBuilder.isSensitiveHeader("X-API-Key"));
+        assertTrue(RestClientBuilder.isSensitiveHeader("X-Auth-Token"));
+        assertTrue(RestClientBuilder.isSensitiveHeader("X-Client-Secret"));
+        assertTrue(RestClientBuilder.isSensitiveHeader("X-Password"));
+    }
+
+    @Test
+    void shouldNotFlagOrdinaryHeaderNames() {
+        assertFalse(RestClientBuilder.isSensitiveHeader("Content-Type"));
+        assertFalse(RestClientBuilder.isSensitiveHeader("Accept"));
+        assertFalse(RestClientBuilder.isSensitiveHeader("X-Tenant"));
+        assertFalse(RestClientBuilder.isSensitiveHeader(null));
+    }
+
+    @Test
+    void shouldMaskSensitiveHeaderValuesAndKeepOthersReadable() {
+        // Given
+        Map<String, List<Object>> headers = new LinkedHashMap<>();
+        headers.put("Content-Type", List.of("application/json"));
+        headers.put("Authorization", List.of("Basic dXNlcjpwYXNz"));
+        headers.put("X-Api-Key", List.of("super-secret"));
+        headers.put("X-Tenant", List.of("acme"));
+
+        // When
+        String redacted = RestClientBuilder.redactHeaders(headers);
+
+        // Then
+        assertEquals(
+                "{Content-Type=[application/json], Authorization=***, X-Api-Key=***, X-Tenant=[acme]}",
+                redacted);
     }
 
     @Test

--- a/providers/jikkou-provider-aiven/src/main/java/io/jikkou/extension/aiven/AivenExtensionProvider.java
+++ b/providers/jikkou-provider-aiven/src/main/java/io/jikkou/extension/aiven/AivenExtensionProvider.java
@@ -40,6 +40,7 @@ import io.jikkou.extension.aiven.reconciler.AivenSchemaRegistrySubjectCollector;
 import io.jikkou.extension.aiven.reconciler.AivenSchemaRegistrySubjectController;
 import io.jikkou.extension.aiven.validation.AivenSchemaCompatibilityValidation;
 import io.jikkou.extension.aiven.validation.SchemaRegistryAclEntryValidation;
+import io.jikkou.http.client.ClientHeadersConfig;
 import io.jikkou.http.client.proxy.ProxyConfig;
 import io.jikkou.kafka.models.V1KafkaTopic;
 import io.jikkou.schema.registry.models.V1SchemaRegistrySubject;
@@ -113,7 +114,8 @@ public final class AivenExtensionProvider extends BaseExtensionProvider {
             Config.PROJECT.get(configuration),
             Config.SERVICE.get(configuration),
             ProxyConfig.from(configuration),
-            Config.DEBUG_LOGGING_ENABLED.get(configuration)
+            Config.DEBUG_LOGGING_ENABLED.get(configuration),
+            ClientHeadersConfig.from(configuration)
         );
     }
 
@@ -135,6 +137,7 @@ public final class AivenExtensionProvider extends BaseExtensionProvider {
             ProxyConfig.PROXY_USERNAME,
             ProxyConfig.PROXY_PASSWORD,
             ProxyConfig.NON_PROXY_HOSTS,
+            ClientHeadersConfig.CLIENT_HEADERS,
             Config.DEBUG_LOGGING_ENABLED,
             Config.TOPIC_DELETE_EXCLUDE_PATTERNS
         );

--- a/providers/jikkou-provider-aiven/src/main/java/io/jikkou/extension/aiven/api/AivenApiClientConfig.java
+++ b/providers/jikkou-provider-aiven/src/main/java/io/jikkou/extension/aiven/api/AivenApiClientConfig.java
@@ -7,6 +7,7 @@
 package io.jikkou.extension.aiven.api;
 
 import io.jikkou.http.client.proxy.ProxyConfig;
+import java.util.Map;
 
 public record AivenApiClientConfig(
     String apiUrl,
@@ -14,6 +15,7 @@ public record AivenApiClientConfig(
     String project,
     String service,
     ProxyConfig proxyConfig,
-    boolean debugLoggingEnabled
+    boolean debugLoggingEnabled,
+    Map<String, String> clientHeaders
 ) {
 }

--- a/providers/jikkou-provider-aiven/src/main/java/io/jikkou/extension/aiven/api/AivenApiClientFactory.java
+++ b/providers/jikkou-provider-aiven/src/main/java/io/jikkou/extension/aiven/api/AivenApiClientFactory.java
@@ -35,6 +35,10 @@ public class AivenApiClientFactory {
 
         builder.header("Authorization", "Bearer " + config.tokenAuth());
         builder.proxyConfig(config.proxyConfig());
+
+        // Applied last so that user-supplied headers override the ones set above.
+        builder.clientHeaders(config.clientHeaders());
+
         return new AivenApiClient(
                 builder.build(AivenApi.class),
                 config.project(),

--- a/providers/jikkou-provider-aiven/src/test/java/io/jikkou/extension/aiven/api/AivenApiClientFactoryTest.java
+++ b/providers/jikkou-provider-aiven/src/test/java/io/jikkou/extension/aiven/api/AivenApiClientFactoryTest.java
@@ -1,0 +1,91 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.jikkou.extension.aiven.api;
+
+import io.jikkou.core.config.Configuration;
+import io.jikkou.http.client.proxy.ProxyConfig;
+import java.io.IOException;
+import java.util.Map;
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class AivenApiClientFactoryTest {
+
+    private MockWebServer mockServer;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        mockServer = new MockWebServer();
+        mockServer.start();
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        mockServer.close();
+    }
+
+    @Test
+    @DisplayName("Should send the Bearer token when no custom headers are configured")
+    void shouldSendBearerTokenByDefault() throws InterruptedException {
+        // Given
+        mockServer.enqueue(new MockResponse.Builder()
+                .code(200)
+                .addHeader("Content-Type", "application/json")
+                .body("{\"acl\":[]}")
+                .build());
+        AivenApiClientConfig config = newConfig(Map.of());
+
+        // When
+        try (AivenApiClient client = AivenApiClientFactory.create(config)) {
+            client.listKafkaAclEntries();
+        }
+
+        // Then
+        Assertions.assertEquals("Bearer token", mockServer.takeRequest().getHeaders().get("Authorization"));
+    }
+
+    @Test
+    @DisplayName("Should let custom headers override the built-in Authorization header")
+    void shouldLetCustomHeadersOverrideAuthorization() throws InterruptedException {
+        // Given
+        mockServer.enqueue(new MockResponse.Builder()
+                .code(200)
+                .addHeader("Content-Type", "application/json")
+                .body("{\"acl\":[]}")
+                .build());
+        AivenApiClientConfig config = newConfig(
+                Map.of("Authorization", "Bearer custom-token", "X-Tenant", "acme"));
+
+        // When
+        try (AivenApiClient client = AivenApiClientFactory.create(config)) {
+            client.listKafkaAclEntries();
+        }
+
+        // Then
+        var actualHeaders = mockServer.takeRequest().getHeaders();
+        Assertions.assertEquals("Bearer custom-token", actualHeaders.get("Authorization"));
+        Assertions.assertEquals(1, actualHeaders.values("Authorization").size());
+        Assertions.assertEquals("acme", actualHeaders.get("X-Tenant"));
+    }
+
+    private AivenApiClientConfig newConfig(Map<String, String> clientHeaders) {
+        return new AivenApiClientConfig(
+                String.format("http://%s:%s", mockServer.getHostName(), mockServer.getPort()),
+                "token",
+                "my-project",
+                "my-service",
+                ProxyConfig.from(Configuration.empty()),
+                false,
+                clientHeaders
+        );
+    }
+}

--- a/providers/jikkou-provider-confluent/src/main/java/io/jikkou/extension/confluent/ConfluentCloudExtensionProvider.java
+++ b/providers/jikkou-provider-confluent/src/main/java/io/jikkou/extension/confluent/ConfluentCloudExtensionProvider.java
@@ -18,6 +18,7 @@ import io.jikkou.extension.confluent.collections.V1RoleBindingList;
 import io.jikkou.extension.confluent.models.V1RoleBinding;
 import io.jikkou.extension.confluent.reconciler.ConfluentCloudRoleBindingCollector;
 import io.jikkou.extension.confluent.reconciler.ConfluentCloudRoleBindingController;
+import io.jikkou.http.client.ClientHeadersConfig;
 import io.jikkou.http.client.proxy.ProxyConfig;
 import io.jikkou.spi.BaseExtensionProvider;
 import java.util.List;
@@ -72,7 +73,8 @@ public final class ConfluentCloudExtensionProvider extends BaseExtensionProvider
             Config.API_SECRET.get(configuration),
             Config.CRN_PATTERN.get(configuration),
             ProxyConfig.from(configuration),
-            Config.DEBUG_LOGGING_ENABLED.get(configuration)
+            Config.DEBUG_LOGGING_ENABLED.get(configuration),
+            ClientHeadersConfig.from(configuration)
         );
     }
 
@@ -90,6 +92,7 @@ public final class ConfluentCloudExtensionProvider extends BaseExtensionProvider
             ProxyConfig.PROXY_USERNAME,
             ProxyConfig.PROXY_PASSWORD,
             ProxyConfig.NON_PROXY_HOSTS,
+            ClientHeadersConfig.CLIENT_HEADERS,
             Config.DEBUG_LOGGING_ENABLED
         );
     }

--- a/providers/jikkou-provider-confluent/src/main/java/io/jikkou/extension/confluent/api/ConfluentCloudApiClientConfig.java
+++ b/providers/jikkou-provider-confluent/src/main/java/io/jikkou/extension/confluent/api/ConfluentCloudApiClientConfig.java
@@ -7,6 +7,7 @@
 package io.jikkou.extension.confluent.api;
 
 import io.jikkou.http.client.proxy.ProxyConfig;
+import java.util.Map;
 
 /**
  * Configuration for the Confluent Cloud API client.
@@ -17,6 +18,7 @@ import io.jikkou.http.client.proxy.ProxyConfig;
  * @param crnPattern           CRN pattern used to scope role binding list operations.
  * @param proxyConfig          HTTP proxy configuration.
  * @param debugLoggingEnabled  Whether to enable debug logging.
+ * @param clientHeaders        Additional HTTP headers to send on every request.
  */
 public record ConfluentCloudApiClientConfig(
     String apiUrl,
@@ -24,6 +26,7 @@ public record ConfluentCloudApiClientConfig(
     String apiSecret,
     String crnPattern,
     ProxyConfig proxyConfig,
-    boolean debugLoggingEnabled
+    boolean debugLoggingEnabled,
+    Map<String, String> clientHeaders
 ) {
 }

--- a/providers/jikkou-provider-confluent/src/main/java/io/jikkou/extension/confluent/api/ConfluentCloudApiClientFactory.java
+++ b/providers/jikkou-provider-confluent/src/main/java/io/jikkou/extension/confluent/api/ConfluentCloudApiClientFactory.java
@@ -42,6 +42,10 @@ public class ConfluentCloudApiClientFactory {
 
         builder.header("Authorization", "Basic " + credentials);
         builder.proxyConfig(config.proxyConfig());
+
+        // Applied last so that user-supplied headers override the ones set above.
+        builder.clientHeaders(config.clientHeaders());
+
         return new ConfluentCloudApiClient(
             builder.build(ConfluentCloudApi.class),
             config.crnPattern()

--- a/providers/jikkou-provider-confluent/src/test/java/io/jikkou/extension/confluent/api/ConfluentCloudApiClientFactoryTest.java
+++ b/providers/jikkou-provider-confluent/src/test/java/io/jikkou/extension/confluent/api/ConfluentCloudApiClientFactoryTest.java
@@ -1,0 +1,93 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.jikkou.extension.confluent.api;
+
+import io.jikkou.core.config.Configuration;
+import io.jikkou.http.client.proxy.ProxyConfig;
+import java.io.IOException;
+import java.util.Map;
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ConfluentCloudApiClientFactoryTest {
+
+    private MockWebServer mockServer;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        mockServer = new MockWebServer();
+        mockServer.start();
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        mockServer.close();
+    }
+
+    @Test
+    @DisplayName("Should send the basic Authorization header when no custom headers are configured")
+    void shouldSendBasicAuthorizationByDefault() throws InterruptedException {
+        // Given
+        mockServer.enqueue(new MockResponse.Builder()
+                .code(200)
+                .addHeader("Content-Type", "application/json")
+                .body("{}")
+                .build());
+        ConfluentCloudApiClientConfig config = newConfig(Map.of());
+
+        // When
+        try (ConfluentCloudApiClient client = ConfluentCloudApiClientFactory.create(config)) {
+            client.getRoleBinding("rb-123");
+        }
+
+        // Then
+        String authorization = mockServer.takeRequest().getHeaders().get("Authorization");
+        Assertions.assertNotNull(authorization);
+        Assertions.assertTrue(authorization.startsWith("Basic "));
+    }
+
+    @Test
+    @DisplayName("Should let custom headers override the built-in Authorization header")
+    void shouldLetCustomHeadersOverrideAuthorization() throws InterruptedException {
+        // Given
+        mockServer.enqueue(new MockResponse.Builder()
+                .code(200)
+                .addHeader("Content-Type", "application/json")
+                .body("{}")
+                .build());
+        ConfluentCloudApiClientConfig config = newConfig(
+                Map.of("Authorization", "Bearer custom-token", "X-Tenant", "acme"));
+
+        // When
+        try (ConfluentCloudApiClient client = ConfluentCloudApiClientFactory.create(config)) {
+            client.getRoleBinding("rb-123");
+        }
+
+        // Then
+        var actualHeaders = mockServer.takeRequest().getHeaders();
+        Assertions.assertEquals("Bearer custom-token", actualHeaders.get("Authorization"));
+        Assertions.assertEquals(1, actualHeaders.values("Authorization").size());
+        Assertions.assertEquals("acme", actualHeaders.get("X-Tenant"));
+    }
+
+    private ConfluentCloudApiClientConfig newConfig(Map<String, String> clientHeaders) {
+        return new ConfluentCloudApiClientConfig(
+                String.format("http://%s:%s", mockServer.getHostName(), mockServer.getPort()),
+                "api-key",
+                "api-secret",
+                "crn://confluent.cloud/kafka=lkc-000000",
+                ProxyConfig.from(Configuration.empty()),
+                false,
+                clientHeaders
+        );
+    }
+}

--- a/providers/jikkou-provider-kafka-connect/src/main/java/io/jikkou/kafka/connect/api/KafkaConnectApiFactory.java
+++ b/providers/jikkou-provider-kafka-connect/src/main/java/io/jikkou/kafka/connect/api/KafkaConnectApiFactory.java
@@ -69,6 +69,10 @@ public final class KafkaConnectApiFactory {
 
             case INVALID -> throw new IllegalStateException("Unexpected value: " + config.authMethod());
         };
+
+        // Applied last so that user-supplied headers override the ones set above.
+        builder.clientHeaders(config.clientHeaders());
+
         return builder.build(KafkaConnectApi.class);
     }
 

--- a/providers/jikkou-provider-kafka-connect/src/main/java/io/jikkou/kafka/connect/api/KafkaConnectClientConfig.java
+++ b/providers/jikkou-provider-kafka-connect/src/main/java/io/jikkou/kafka/connect/api/KafkaConnectClientConfig.java
@@ -9,8 +9,10 @@ package io.jikkou.kafka.connect.api;
 import io.jikkou.common.utils.Enums;
 import io.jikkou.core.config.ConfigProperty;
 import io.jikkou.core.config.Configuration;
+import io.jikkou.http.client.ClientHeadersConfig;
 import io.jikkou.http.client.proxy.ProxyConfig;
 import io.jikkou.http.client.ssl.SSLConfig;
+import java.util.Map;
 import java.util.function.Supplier;
 
 public record KafkaConnectClientConfig(
@@ -21,7 +23,8 @@ public record KafkaConnectClientConfig(
     Supplier<String> basicAuthPassword,
     Supplier<SSLConfig> sslConfig,
     Supplier<ProxyConfig> proxyConfig,
-    Boolean debugLoggingEnabled
+    Boolean debugLoggingEnabled,
+    Map<String, String> clientHeaders
 ) {
 
     public static final ConfigProperty<String> KAFKA_CONNECT_NAME = ConfigProperty
@@ -65,7 +68,8 @@ public record KafkaConnectClientConfig(
             () -> KAFKA_CONNECT_BASIC_AUTH_PASSWORD.get(configuration),
             () -> SSLConfig.from(configuration),
             () -> ProxyConfig.from(configuration),
-            KAFKA_CONNECT_DEBUG_LOGGING_ENABLED.get(configuration)
+            KAFKA_CONNECT_DEBUG_LOGGING_ENABLED.get(configuration),
+            ClientHeadersConfig.from(configuration)
         );
     }
 }

--- a/providers/jikkou-provider-kafka-connect/src/test/java/io/jikkou/kafka/connect/api/KafkaConnectApiFactoryTest.java
+++ b/providers/jikkou-provider-kafka-connect/src/test/java/io/jikkou/kafka/connect/api/KafkaConnectApiFactoryTest.java
@@ -12,6 +12,7 @@ import io.jikkou.http.client.ssl.SSLConfig;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.Map;
 import mockwebserver3.MockResponse;
 import mockwebserver3.MockWebServer;
 import org.junit.jupiter.api.AfterAll;
@@ -52,7 +53,8 @@ class KafkaConnectApiFactoryTest {
                 () -> "secret",
                 () -> SSLConfig.from(Configuration.empty()),
                 () -> ProxyConfig.from(Configuration.empty()),
-                false
+                false,
+                Map.of()
         );
 
         // When
@@ -67,5 +69,55 @@ class KafkaConnectApiFactoryTest {
         // result should correspond to base64 encoded string "alice:secret" prefixed with "Basic"
         Assertions.assertEquals("Basic " + expectedCredentials, authorization,
                 "Authorization header must contain the base64-encoded credentials");
+    }
+
+    @Test
+    @DisplayName("Should let a custom Authorization header override basicauth")
+    void shouldLetCustomAuthorizationHeaderOverrideBasicAuth() throws InterruptedException {
+        // Given
+        mockServer.enqueue(new MockResponse.Builder()
+                .code(200)
+                .addHeader("Content-Type", "application/json")
+                .body("[]")
+                .build());
+        KafkaConnectClientConfig config = new KafkaConnectClientConfig(
+                "test-cluster",
+                String.format("http://%s:%s", mockServer.getHostName(), mockServer.getPort()),
+                AuthMethod.BASICAUTH,
+                () -> "alice",
+                () -> "secret",
+                () -> SSLConfig.from(Configuration.empty()),
+                () -> ProxyConfig.from(Configuration.empty()),
+                false,
+                Map.of("Authorization", "Bearer custom-token", "X-Tenant", "acme")
+        );
+
+        // When
+        try (KafkaConnectApi api = KafkaConnectApiFactory.create(config)) {
+            api.listConnectors();
+        }
+
+        // Then
+        var actualHeaders = mockServer.takeRequest().getHeaders();
+        Assertions.assertEquals("Bearer custom-token", actualHeaders.get("Authorization"));
+        Assertions.assertEquals(1, actualHeaders.values("Authorization").size());
+        Assertions.assertEquals("acme", actualHeaders.get("X-Tenant"));
+    }
+
+    @Test
+    @DisplayName("Should read clientHeaders from configuration")
+    void shouldReadClientHeadersFromConfiguration() {
+        // Given
+        Configuration configuration = Configuration.from(Map.of(
+                "name", "test-cluster",
+                "url", "http://localhost:8083",
+                "clientHeaders", Map.of("X-Tenant", "acme")
+        ));
+
+        // When
+        KafkaConnectClientConfig config = KafkaConnectClientConfig.from(configuration);
+
+        // Then
+        Assertions.assertEquals(Map.of("X-Tenant", "acme"), config.clientHeaders());
     }
 }

--- a/providers/jikkou-provider-schema-registry/src/main/java/io/jikkou/schema/registry/SchemaRegistryExtensionProvider.java
+++ b/providers/jikkou-provider-schema-registry/src/main/java/io/jikkou/schema/registry/SchemaRegistryExtensionProvider.java
@@ -15,6 +15,7 @@ import io.jikkou.core.extension.ExtensionRegistry;
 import io.jikkou.core.models.change.GenericResourceChange;
 import io.jikkou.core.models.change.ResourceChange;
 import io.jikkou.core.resource.ResourceRegistry;
+import io.jikkou.http.client.ClientHeadersConfig;
 import io.jikkou.http.client.proxy.ProxyConfig;
 import io.jikkou.http.client.ssl.SSLConfig;
 import io.jikkou.schema.registry.api.AuthMethod;
@@ -32,7 +33,6 @@ import io.jikkou.schema.registry.validation.SubjectNameRegexValidation;
 import io.jikkou.spi.BaseExtensionProvider;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -86,13 +86,6 @@ public final class SchemaRegistryExtensionProvider extends BaseExtensionProvider
             .displayName("Normalize Schemas")
             .description("Specify whether to normalize schemas (default: true).")
             .defaultValue(true);
-
-        ConfigProperty<Map<String, Object>> SCHEMA_REGISTRY_CLIENT_HEADERS = ConfigProperty
-                .ofMap("clientHeaders")
-                .displayName("Client Headers")
-                .description("Passthrough properties for Schema Registry Client Headers."
-                    + " Covers arbitrary client headers to pass on http connections.")
-                .defaultValue(Map.of());
     }
 
     private SchemaRegistryClientConfig clientConfig;
@@ -108,7 +101,7 @@ public final class SchemaRegistryExtensionProvider extends BaseExtensionProvider
             Config.SCHEMA_REGISTRY_BASIC_AUTH_PASSWORD,
             Config.SCHEMA_REGISTRY_DEBUG_LOGGING_ENABLED,
             Config.NORMALIZE_SCHEMAS_ENABLED,
-            Config.SCHEMA_REGISTRY_CLIENT_HEADERS
+            ClientHeadersConfig.CLIENT_HEADERS
         );
     }
 
@@ -120,8 +113,6 @@ public final class SchemaRegistryExtensionProvider extends BaseExtensionProvider
             .map(String::trim)
             .filter(s -> !s.isEmpty())
             .toList();
-        Map<String, Object> schemaRegistryClientHeaders = Config.SCHEMA_REGISTRY_CLIENT_HEADERS.get(configuration);
-
         this.clientConfig = new SchemaRegistryClientConfig(
             urls,
             Config.SCHEMA_REGISTRY_VENDOR.get(configuration),
@@ -131,7 +122,7 @@ public final class SchemaRegistryExtensionProvider extends BaseExtensionProvider
             () -> SSLConfig.from(configuration),
             () -> ProxyConfig.from(configuration),
             Config.SCHEMA_REGISTRY_DEBUG_LOGGING_ENABLED.get(configuration),
-            schemaRegistryClientHeaders
+            ClientHeadersConfig.from(configuration)
         );
     }
 

--- a/providers/jikkou-provider-schema-registry/src/main/java/io/jikkou/schema/registry/api/SchemaRegistryApiFactory.java
+++ b/providers/jikkou-provider-schema-registry/src/main/java/io/jikkou/schema/registry/api/SchemaRegistryApiFactory.java
@@ -11,7 +11,6 @@ import io.jikkou.http.client.RestClientBuilder;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import java.util.Optional;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,9 +53,6 @@ public final class SchemaRegistryApiFactory {
         builder.sslConfig(config.sslConfig().get());
         builder.proxyConfig(config.proxyConfig().get());
 
-        Optional.ofNullable(config.schemaRegistryClientHeaders())
-                .ifPresent(builder::headers);
-
         builder = switch (config.authMethod()) {
             case BASICAUTH -> {
                 String buildAuthorizationHeader = getAuthorizationHeader(config);
@@ -67,6 +63,10 @@ public final class SchemaRegistryApiFactory {
 
             case INVALID -> throw new IllegalStateException("Unexpected value: " + config.authMethod());
         };
+
+        // Applied last so that user-supplied headers override the ones set above.
+        builder.clientHeaders(config.clientHeaders());
+
         return builder.build(SchemaRegistryApi.class);
     }
 

--- a/providers/jikkou-provider-schema-registry/src/main/java/io/jikkou/schema/registry/api/SchemaRegistryClientConfig.java
+++ b/providers/jikkou-provider-schema-registry/src/main/java/io/jikkou/schema/registry/api/SchemaRegistryClientConfig.java
@@ -21,7 +21,7 @@ public record SchemaRegistryClientConfig(
     Supplier<SSLConfig> sslConfig,
     Supplier<ProxyConfig> proxyConfig,
     Boolean debugLoggingEnabled,
-    Map<String, Object> schemaRegistryClientHeaders
+    Map<String, String> clientHeaders
 ) {
 
     /**

--- a/providers/jikkou-provider-schema-registry/src/test/java/io/jikkou/schema/registry/api/SchemaRegistryApiFactoryTest.java
+++ b/providers/jikkou-provider-schema-registry/src/test/java/io/jikkou/schema/registry/api/SchemaRegistryApiFactoryTest.java
@@ -60,7 +60,7 @@ class SchemaRegistryApiFactoryTest {
                 () -> SSLConfig.from(Configuration.empty()),
                 () -> ProxyConfig.from(Configuration.empty()),
                 false,
-                null
+                Map.of()
         );
 
         // When
@@ -108,7 +108,7 @@ class SchemaRegistryApiFactoryTest {
                 () -> SSLConfig.from(Configuration.empty()),
                 () -> ProxyConfig.from(Configuration.empty()),
                 false,
-                null
+                Map.of()
         );
 
         // When
@@ -137,7 +137,7 @@ class SchemaRegistryApiFactoryTest {
                 () -> SSLConfig.from(Configuration.empty()),
                 () -> ProxyConfig.from(Configuration.empty()),
                 false,
-                null
+                Map.of()
         );
 
         // When
@@ -160,7 +160,7 @@ class SchemaRegistryApiFactoryTest {
                 () -> SSLConfig.from(Configuration.empty()),
                 () -> ProxyConfig.from(Configuration.empty()),
                 false,
-                null
+                Map.of()
         );
 
         // When
@@ -218,7 +218,7 @@ class SchemaRegistryApiFactoryTest {
                     ))),
                     () -> ProxyConfig.from(Configuration.empty()),
                     false,
-                    null
+                    Map.of()
             );
 
             // When
@@ -248,7 +248,7 @@ class SchemaRegistryApiFactoryTest {
                 .build();
         schemaRegistryMockServer.setDispatcher(schemaRegistryHTTPDispatcher);
 
-        HashMap<String, Object> clientHeaders = new HashMap<>();
+        HashMap<String, String> clientHeaders = new HashMap<>();
         clientHeaders.put("custom-header-1", "custom-value-1");
         clientHeaders.put("custom-header-2", "custom-value-2");
 
@@ -275,10 +275,46 @@ class SchemaRegistryApiFactoryTest {
 
         var actualHeaders = schemaRegistryMockServer.takeRequest().getHeaders();
 
-        for (Map.Entry<String, Object> header : clientHeaders.entrySet()) {
+        for (Map.Entry<String, String> header : clientHeaders.entrySet()) {
             String actualValue = actualHeaders.get(header.getKey());
             Assertions.assertEquals(header.getValue(), actualValue);
         }
+    }
+
+    @Test
+    @DisplayName("Should let a custom Authorization header override basicauth")
+    public void shouldLetCustomAuthorizationHeaderOverrideBasicAuth() throws InterruptedException {
+        // Given
+        HttpPathBasedDispatcher dispatcher = HttpPathBasedDispatcher.builder()
+                .forPath("/subjects/subject-value/versions", new MockResponse.Builder()
+                        .code(200)
+                        .addHeader("Content-Type", "application/vnd.schemaregistry.v1+json")
+                        .body("[]")
+                        .build())
+                .build();
+        schemaRegistryMockServer.setDispatcher(dispatcher);
+
+        SchemaRegistryClientConfig config = new SchemaRegistryClientConfig(
+                List.of(String.format("http://%s:%s", schemaRegistryMockServer.getHostName(), schemaRegistryMockServer.getPort())),
+                "generic",
+                AuthMethod.BASICAUTH,
+                () -> "username",
+                () -> "password",
+                () -> SSLConfig.from(Configuration.empty()),
+                () -> ProxyConfig.from(Configuration.empty()),
+                false,
+                Map.of("Authorization", "Bearer custom-token")
+        );
+
+        // When
+        try (SchemaRegistryApi schemaRegistryApi = SchemaRegistryApiFactory.create(config)) {
+            schemaRegistryApi.getAllSubjectVersions("subject-value");
+        }
+
+        // Then
+        var actualHeaders = schemaRegistryMockServer.takeRequest().getHeaders();
+        Assertions.assertEquals("Bearer custom-token", actualHeaders.get("Authorization"));
+        Assertions.assertEquals(1, actualHeaders.values("Authorization").size());
     }
 
     @AfterAll


### PR DESCRIPTION
Follow-up to a2cbb7586, which added a `clientHeaders` option to the Schema Registry provider.

This PR:

- moves the `clientHeaders` property into a shared `ClientHeadersConfig` in `extension-rest-client` and extends it to the Kafka Connect, Aiven, and Confluent Cloud providers;
- makes custom headers override the headers Jikkou sets itself. Previously a user-supplied `Authorization` was appended alongside the built-in basicauth header, producing two `Authorization` values on the wire. Header names are now matched case-insensitively;
- redacts credential-looking header values from debug logs. `LoggingRequestFilter` previously printed the full header map, leaking basicauth credentials and custom tokens;
- documents the option on all four provider reference pages.

Setting `Authorization` through `clientHeaders` is now the supported way to use a bearer token or another scheme that `authMethod` does not cover.

### Compatibility

`SchemaRegistryClientConfig.schemaRegistryClientHeaders` is renamed to `clientHeaders` and retyped from `Map<String, Object>` to `Map<String, String>`. That component has never appeared in a tagged release, so this is not a public API break.

### Testing

`./mvnw clean verify -DskipITs` passes. New coverage: `ClientHeadersConfigTest`, header override and redaction cases in `RestClientBuilderTest`, an `Authorization`-override case in `SchemaRegistryApiFactoryTest` and `KafkaConnectApiFactoryTest`, and new `AivenApiClientFactoryTest` / `ConfluentCloudApiClientFactoryTest` (neither provider had a factory test before).
