### PR TITLE
perf(provider-aiven): describe only managed Kafka topics when planning

### DIFF
--- a/providers/jikkou-provider-aiven/src/integration-test/java/io/jikkou/extension/aiven/reconciler/AivenKafkaTopicControllerIT.java
+++ b/providers/jikkou-provider-aiven/src/integration-test/java/io/jikkou/extension/aiven/reconciler/AivenKafkaTopicControllerIT.java
@@ -1,0 +1,166 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) The original authors
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.jikkou.extension.aiven.reconciler;
+
+import io.jikkou.core.ReconciliationContext;
+import io.jikkou.core.ReconciliationMode;
+import io.jikkou.core.config.Configuration;
+import io.jikkou.core.models.ObjectMeta;
+import io.jikkou.core.models.ResourceList;
+import io.jikkou.core.models.change.ResourceChange;
+import io.jikkou.core.reconciler.Operation;
+import io.jikkou.extension.aiven.ApiVersions;
+import io.jikkou.extension.aiven.BaseExtensionProviderIT;
+import io.jikkou.kafka.models.V1KafkaTopic;
+import io.jikkou.kafka.models.V1KafkaTopicSpec;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import okhttp3.mockwebserver.MockResponse;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("integration")
+public class AivenKafkaTopicControllerIT extends BaseExtensionProviderIT {
+
+    public static final String TEST_TOPIC = "test";
+    public static final String UNMANAGED_TOPIC = "unmanaged";
+
+    private static MockResponse topicInfoResponse(final String topicName) {
+        return new MockResponse()
+            .setHeader("Content-Type", "application/json")
+            .setResponseCode(200)
+            .setBody("""
+                {
+                  "topic": {
+                    "topic_name": "%s",
+                    "partitions": [ { "partition": 0 } ],
+                    "replication": 3,
+                    "config": {
+                      "retention_ms": { "source": "topic_config", "value": 60000 }
+                    }
+                  }
+                }
+                """.formatted(topicName));
+    }
+
+    private static MockResponse topicListResponse(final String... topicNames) {
+        String topics = String.join(",", List.of(topicNames).stream()
+            .map(name -> """
+                { "topic_name": "%s", "partitions": 1, "replication": 3 }
+                """.formatted(name))
+            .toList());
+        return new MockResponse()
+            .setHeader("Content-Type", "application/json")
+            .setResponseCode(200)
+            .setBody("""
+                {
+                  "topics": [ %s ]
+                }
+                """.formatted(topics));
+    }
+
+    private static MockResponse topicNotFoundResponse() {
+        return new MockResponse()
+            .setHeader("Content-Type", "application/json")
+            .setResponseCode(404)
+            .setBody("""
+                {
+                    "errors": [ { "message": "Topic 'test' does not exist", "status": 404 } ],
+                    "message": "Topic 'test' does not exist"
+                }
+                """);
+    }
+
+    private static V1KafkaTopic testTopic() {
+        return V1KafkaTopic.builder()
+            .withApiVersion(ApiVersions.KAFKA_AIVEN_V1BETA2)
+            .withMetadata(ObjectMeta.builder().withName(TEST_TOPIC).build())
+            .withSpec(V1KafkaTopicSpec
+                .builder()
+                .withPartitions(1)
+                .withReplicas((short) 3)
+                .build())
+            .build();
+    }
+
+    @Test
+    void shouldOnlyDescribeExpectedTopicsAndNotTheWholeService() throws InterruptedException {
+        // Given only the expected topic 'test' is served. No `list all topics` response is enqueued:
+        // the plan must not enumerate the service.
+        enqueueResponse(topicInfoResponse(TEST_TOPIC));
+
+        // When
+        api.reconcile(
+            ResourceList.of(List.of(testTopic())),
+            ReconciliationMode.FULL,
+            ReconciliationContext.builder().dryRun(true).build()
+        );
+
+        // Then the managed topic is described directly, and the service is never enumerated.
+        Assertions.assertEquals(1, getRequestCount());
+        String path = takeRequest().getPath();
+        Assertions.assertTrue(
+            path.endsWith("/topic/" + TEST_TOPIC),
+            () -> "Expected only the managed topic to be described, but got: " + path
+        );
+    }
+
+    @Test
+    void shouldDescribeWholeServiceWhenDeleteOrphansIsEnabled() throws InterruptedException {
+        // Given delete-orphans needs every topic of the service to spot orphans.
+        enqueueResponse(topicListResponse(TEST_TOPIC, UNMANAGED_TOPIC));
+        enqueueResponse(topicInfoResponse(TEST_TOPIC));
+        enqueueResponse(topicInfoResponse(UNMANAGED_TOPIC));
+
+        // When
+        api.reconcile(
+            ResourceList.of(List.of(testTopic())),
+            ReconciliationMode.FULL,
+            ReconciliationContext.builder()
+                .dryRun(true)
+                .configuration(Configuration.from(Map.of(
+                    AivenKafkaTopicController.Config.IS_DELETE_ORPHANS_ENABLED.key(), true
+                )))
+                .build()
+        );
+
+        // Then the service is enumerated and every topic on it is described, including the
+        // unmanaged one — otherwise orphans could never be detected.
+        Assertions.assertEquals(3, getRequestCount());
+        List<String> paths = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            paths.add(takeRequest().getPath());
+        }
+        Assertions.assertTrue(
+            paths.stream().anyMatch(path -> path.endsWith("/topic")),
+            () -> "Expected the service to be enumerated, but got: " + paths
+        );
+        Assertions.assertTrue(
+            paths.stream().anyMatch(path -> path.endsWith("/topic/" + UNMANAGED_TOPIC)),
+            () -> "Expected the unmanaged topic to be described, but got: " + paths
+        );
+    }
+
+    @Test
+    void shouldPlanCreateWhenExpectedTopicDoesNotExist() {
+        // Given the expected topic does not exist yet: describing it returns 404, which is not an
+        // error — it is simply absent from the actual state.
+        enqueueResponse(topicNotFoundResponse());
+
+        // When
+        List<ResourceChange> changes = api.getDiff(
+            ResourceList.of(List.of(testTopic())),
+            ReconciliationContext.builder().dryRun(true).build()
+        ).getItems();
+
+        // Then
+        Assertions.assertEquals(1, changes.size());
+        Assertions.assertEquals(Operation.CREATE, changes.getFirst().getSpec().getOp());
+    }
+}

--- a/providers/jikkou-provider-aiven/src/main/java/io/jikkou/extension/aiven/reconciler/AivenKafkaTopicCollector.java
+++ b/providers/jikkou-provider-aiven/src/main/java/io/jikkou/extension/aiven/reconciler/AivenKafkaTopicCollector.java
@@ -23,6 +23,7 @@ import io.jikkou.core.models.ResourceList;
 import io.jikkou.core.models.generics.GenericResourceList;
 import io.jikkou.core.reconciler.Collector;
 import io.jikkou.core.selector.Selector;
+import io.jikkou.core.selector.Selectors;
 import io.jikkou.extension.aiven.AivenExtensionProvider;
 import io.jikkou.extension.aiven.ApiVersions;
 import io.jikkou.extension.aiven.adapter.KafkaTopicAdapter;
@@ -31,7 +32,7 @@ import io.jikkou.extension.aiven.api.AivenApiClientConfig;
 import io.jikkou.extension.aiven.api.AivenApiClientException;
 import io.jikkou.extension.aiven.api.AivenApiClientFactory;
 import io.jikkou.extension.aiven.api.data.KafkaTopicConfigInfo;
-import io.jikkou.extension.aiven.api.data.KafkaTopicInfoResponse;
+import io.jikkou.extension.aiven.api.data.KafkaTopicInfo;
 import io.jikkou.extension.aiven.api.data.KafkaTopicListResponse;
 import io.jikkou.kafka.models.V1KafkaTopic;
 import io.jikkou.kafka.reconciler.KafkaConfigsConfig;
@@ -94,33 +95,92 @@ public class AivenKafkaTopicCollector extends ContextualExtension implements Col
                     )
                 );
             }
-            List<V1KafkaTopic> items = response.topics()
+            List<String> topics = response.topics()
                 .stream()
-                .map(topicInfo -> api.getKafkaTopicInfo(topicInfo.topicName()))
-                .map(KafkaTopicInfoResponse::topic)
-                .filter(Objects::nonNull)
-                .map(topicInfo -> KafkaTopicAdapter.map(topicInfo, getConfigPredicate(configuration)))
-                .filter(selector::apply)
+                .map(KafkaTopicListResponse.KafkaTopicInfoGet::topicName)
                 .toList();
-            
-            return new GenericResourceList.Builder<V1KafkaTopic>().withItems(items).build();
+
+            return listAll(configuration, topics, selector, api);
 
         } catch (WebApplicationException e) {
-            String response;
-            try {
-                response = Jackson.JSON_OBJECT_MAPPER.writerWithDefaultPrettyPrinter()
-                    .writeValueAsString(e.getResponse().readEntity(JsonNode.class));
-            } catch (JsonProcessingException ex) {
-                response = e.getResponse().readEntity(String.class);
-            }
-            throw new AivenApiClientException(String.format(
-                "Failed to list kafka topics. %s:%n%s",
-                e.getLocalizedMessage(),
-                response
-            ), e);
+            throw newListException(e);
         } finally {
             api.close(); // make sure api is closed after catching exception
         }
+    }
+
+    /**
+     * Lists only the given Kafka topics, by name.
+     *
+     * <p>In contrast to {@link #listAll(Configuration, Selector)}, this does not list every topic
+     * of the service first: it describes the given topics directly, so the number of API calls
+     * scales with the number of topics asked for and not with the size of the service. Topics that
+     * do not exist are skipped.
+     *
+     * @param configuration the configuration.
+     * @param topics        the names of the topics to describe.
+     * @return the list of described topics that exist.
+     */
+    public ResourceList<V1KafkaTopic> listAll(@NotNull Configuration configuration,
+                                              @NotNull List<String> topics) {
+        final AivenApiClient api = AivenApiClientFactory.create(apiClientConfig);
+        try {
+            return listAll(configuration, topics, Selectors.NO_SELECTOR, api);
+        } catch (WebApplicationException e) {
+            throw newListException(e);
+        } finally {
+            api.close(); // make sure api is closed after catching exception
+        }
+    }
+
+    private ResourceList<V1KafkaTopic> listAll(@NotNull Configuration configuration,
+                                               @NotNull List<String> topics,
+                                               @NotNull Selector selector,
+                                               @NotNull AivenApiClient api) {
+        List<V1KafkaTopic> items = topics
+            .stream()
+            .map(topic -> describeTopicOrEmptyOn404(api, topic))
+            .filter(Objects::nonNull)
+            .map(topicInfo -> KafkaTopicAdapter.map(topicInfo, getConfigPredicate(configuration)))
+            .filter(selector::apply)
+            .toList();
+
+        return new GenericResourceList.Builder<V1KafkaTopic>().withItems(items).build();
+    }
+
+    /**
+     * Describes a single topic, returning {@code null} if it does not exist. A requested topic may
+     * legitimately be missing (e.g. it is about to be created), which is not an error.
+     */
+    private KafkaTopicInfo describeTopicOrEmptyOn404(@NotNull AivenApiClient api,
+                                                     @NotNull String topic) {
+        try {
+            return api.getKafkaTopicInfo(topic).topic();
+        } catch (WebApplicationException e) {
+            if (isNotFound(e)) {
+                return null;
+            }
+            throw e;
+        }
+    }
+
+    private static boolean isNotFound(final WebApplicationException exception) {
+        return exception.getResponse().getStatus() == 404;
+    }
+
+    private AivenApiClientException newListException(@NotNull WebApplicationException e) {
+        String response;
+        try {
+            response = Jackson.JSON_OBJECT_MAPPER.writerWithDefaultPrettyPrinter()
+                .writeValueAsString(e.getResponse().readEntity(JsonNode.class));
+        } catch (JsonProcessingException ex) {
+            response = e.getResponse().readEntity(String.class);
+        }
+        return new AivenApiClientException(String.format(
+            "Failed to list kafka topics. %s:%n%s",
+            e.getLocalizedMessage(),
+            response
+        ), e);
     }
 
     /**

--- a/providers/jikkou-provider-aiven/src/main/java/io/jikkou/extension/aiven/reconciler/AivenKafkaTopicController.java
+++ b/providers/jikkou-provider-aiven/src/main/java/io/jikkou/extension/aiven/reconciler/AivenKafkaTopicController.java
@@ -21,6 +21,8 @@ import io.jikkou.core.config.Configuration;
 import io.jikkou.core.extension.ContextualExtension;
 import io.jikkou.core.extension.ExtensionContext;
 import io.jikkou.core.models.Configs;
+import io.jikkou.core.models.ObjectMeta;
+import io.jikkou.core.models.ResourceList;
 import io.jikkou.core.models.change.ResourceChange;
 import io.jikkou.core.reconciler.ChangeExecutor;
 import io.jikkou.core.reconciler.ChangeHandler;
@@ -160,14 +162,26 @@ public final class AivenKafkaTopicController
         // Get the list of remote resources that are candidates for this reconciliation
         collector.init(extensionContext().contextForExtension(AivenKafkaTopicCollector.class));
 
-        List<V1KafkaTopic> actualKafkaTopics = collector.listAll(configuration, Selectors.NO_SELECTOR)
+        boolean deleteOrphans = Config.IS_DELETE_ORPHANS_ENABLED.get(context.configuration());
+
+        // Deleting orphans requires knowing every topic of the service, so the whole service must be
+        // described. Otherwise only the expected topics are described: the Aiven API has no bulk
+        // describe endpoint, so describing the whole service costs one round-trip per topic on it.
+        ResourceList<V1KafkaTopic> describedKafkaTopics = deleteOrphans
+            ? collector.listAll(configuration, Selectors.NO_SELECTOR)
+            : collector.listAll(configuration, expectedKafkaTopics.stream()
+                .map(V1KafkaTopic::getMetadata)
+                .map(ObjectMeta::getName)
+                .toList());
+
+        List<V1KafkaTopic> actualKafkaTopics = describedKafkaTopics
             .stream()
             .filter(context.selector()::apply)
             .toList();
 
         TopicChangeComputer changeComputer = new TopicChangeComputer(
             topicDeleteExcludePatterns,
-            Config.IS_DELETE_ORPHANS_ENABLED.get(context.configuration()),
+            deleteOrphans,
             Config.IS_CONFIG_DELETE_ORPHANS_ENABLED.get(context.configuration())
         );
 


### PR DESCRIPTION
`AivenKafkaTopicController.plan()` describes every topic on the service — a list call plus one describe call each — and only afterwards keeps the ones being managed.

So `diff`/`apply` cost scales with the size of the whole service rather than the number of managed topics. 

The Aiven API has no bulk describe endpoint, so each topic is its own round-trip.

In our case, `jikkou diff` of 2 topics against an Aiven service with ~354 topics took ~76s.

This PR describes only the expected topics by name (mirroring #791 for schema registry subjects, and the generic `SchemaRegistrySubjectController`), cutting that diff to ~2s.

Detecting orphans still needs every topic, so when `delete-orphans` is enabled the whole service is described as before. 

`AivenKafkaTopicControllerIT` is new, since the Aiven topic controller and collector had no test coverage.